### PR TITLE
fix(ui): keep the fleet log panel visible when empty

### DIFF
--- a/src/usr/local/emhttp/plugins/ci-runner-farm/RunnerFarm.page
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/RunnerFarm.page
@@ -272,7 +272,7 @@ Status: <strong id="crf-tok"><?= $has_token ? 'configured &#10004;' : 'not set' 
   <thead><tr><th>Runner</th><th>State</th><th>Phase</th><th>CPU</th><th>Mem</th></tr></thead>
   <tbody><tr><td colspan="5">loading...</td></tr></tbody>
 </table>
-<div id="crf-log" style="white-space:pre-wrap;font-family:monospace;font-size:12px;max-height:220px;overflow:auto;background:#1e1e1e;color:#ddd;padding:8px;border-radius:4px;margin-top:8px"></div>
+<div id="crf-log" style="white-space:pre-wrap;font-family:monospace;font-size:12px;min-height:120px;max-height:220px;overflow:auto;background:#1e1e1e;color:#ddd;padding:8px;border-radius:4px;margin-top:8px"><span style="color:#888">Output from fleet actions and image builds appears here.</span></div>
 
 <hr>
 <p><strong>Runner image builder</strong> &mdash; edit the Dockerfile for the built-in runner image (add apt packages, tools, browsers), Save, then Build. It's tagged <code>ci-runner-farm-runner:latest</code>; set <em>Image source</em> to <strong>Built-in</strong> and restart the fleet to use a new build. Build output streams to the log above.</p>


### PR DESCRIPTION
## Problem

The dark output box under the fleet controls (`#crf-log`) only receives content after a fleet action (Start/Stop/Restart/Validate/Scale) or during an image build. On a fresh page load it's empty — and because it had `max-height` but **no `min-height`**, an empty box collapsed to ~16px (just its padding), so it looked like the panel had vanished.

## Fix

- Add `min-height:120px` so the panel stays a stable, visible size even when empty.
- Add a muted empty-state hint ("Output from fleet actions and image builds appears here.") so it's clear what the panel is for. It's replaced the moment real output is written.

Single-line markup change in `RunnerFarm.page`; no behavior change to logging itself.

## Not included (possible follow-up)

This panel is an action/build output pane, not a live runner terminal — nothing tails per-runner logs into it continuously. The `logs i` action exists in `runner-farm.sh` but isn't wired to the UI. Happy to add real log tailing as a separate change if we want a true live terminal.