### PR TITLE
Plugins page: proper name + icon link to settings

### DIFF
--- a/ci-runner-farm.plg
+++ b/ci-runner-farm.plg
@@ -14,6 +14,7 @@
         version="&version;"
         pluginURL="&pluginURL;"
         min="6.12.0"
+        launch="Settings/RunnerFarm"
         support="https://github.com/unraid/ci-runner-farm/issues"
         icon="docker">
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,7 +13,7 @@ cd "$(dirname "$0")"
 
 echo "[deploy] syncing $SRC -> $HOST:$DEST"
 ssh "$HOST" "mkdir -p '$DEST/include'"
-scp -q "$SRC/RunnerFarm.page" "$SRC/default.cfg" "$SRC/default.Dockerfile" "$HOST:$DEST/"
+scp -q "$SRC/RunnerFarm.page" "$SRC/default.cfg" "$SRC/default.Dockerfile" "$SRC/README.md" "$HOST:$DEST/"
 scp -q "$SRC"/include/* "$HOST:$DEST/include/"
 
 echo "[deploy] enforcing root:root + perms on $HOST"

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/README.md
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/README.md
@@ -1,0 +1,4 @@
+**CI Runner Farm**
+
+Self-hosted GitHub Actions runners for Unraid &mdash; an autoscaling fleet of
+docker-in-docker runners with a shared image cache and warm package caches.


### PR DESCRIPTION
Small UX fix so the farm matches other Unraid plugins on the Plugins page.

- **Name:** ships an installed `README.md` (`ShowPlugins.php` renders it as the plugin's name/description) so it shows **CI Runner Farm** with a one-line summary instead of the bare `ci-runner-farm` slug.
- **Icon link:** adds `launch="Settings/RunnerFarm"` to the `.plg` so the icon hyperlinks to the settings page (`ShowPlugins.php` wraps the icon in `<a href='/$launch'>`).

Verified live on titan (README deployed, installed .plg patched with `launch`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the plugin’s Unraid menu placement so it launches from the settings area.
  * Expanded deployment to publish all required plugin files together.
  * Added a clearer README describing the plugin and its runner setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->