### PR TITLE
feat(dind): bind per-runner diagnostics dir for DinD post-mortem

### DIFF
--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -440,6 +440,14 @@ build_args() {
     ARGS+=( -v "$CACHE_ROOT/docker/$name:/var/lib/docker" )
     # inner daemon.json: storage-driver + optional pull-through mirror
     ARGS+=( -v "$CACHE_ROOT/dind-daemon.json:/etc/docker/daemon.json:ro" )
+    # Persisted DinD diagnostics dir (kept by remove_runner, unlike the data root):
+    # the runner image's wait-docker.sh snapshots inner-daemon state (storage driver,
+    # Native Overlay Diff, backing fs, userxattr, uid_map) here and mirrors the inner
+    # dockerd log, so a layer-extraction failure (e.g. the whiteout "operation not
+    # permitted" mknod seen on ZFS-backed overlay2 under the services: workload) leaves
+    # a post-mortem trail off the ephemeral container. Inspect $CACHE_ROOT/dind-logs/<runner>.
+    mkdir -p "$CACHE_ROOT/dind-logs/$name"
+    ARGS+=( -v "$CACHE_ROOT/dind-logs/$name:/var/log/dind" )
     [ "$SHARED_IMAGE_CACHE" = "true" ] && ARGS+=( --add-host "host.docker.internal:host-gateway" )
   elif [ "$SHARE_DOCKER_SOCK" = "true" ]; then
     ARGS+=( -v /var/run/docker.sock:/var/run/docker.sock )


### PR DESCRIPTION
## Why

A farm runner's inner (DinD) dockerd intermittently failed `docker pull postgres:18` on the ZFS-backed overlay2 data root with `failed to convert whiteout file ...: operation not permitted`. The failure isn't reproducible and the inner dockerd logs live inside the ephemeral runner, so the daemon-side detail is lost on teardown.

## What

Bind-mount a persisted per-runner dir `$CACHE_ROOT/dind-logs/<runner>` at `/var/log/dind`. The runner image's `wait-docker.sh` (see companion ci-runner-image PR) writes a startup snapshot (`Storage Driver`, **`Native Overlay Diff`**, `Backing Filesystem`, `userxattr`, `uid_map`) and mirrors the inner `dockerd` log there. The dir is **not** removed by `remove_runner` (unlike the per-runner data root), so a failure leaves a post-mortem trail on the pool.

Storage driver stays `overlay2` (proven working in testing; avoids fuse-overlayfs's I/O cost). If the captured snapshot ever shows `Native Overlay Diff: false` or a non-identity `uid_map` at the time of a failure, that pins the mechanism and justifies switching that path to fuse-overlayfs.

## Inspect after a failure

`$CACHE_ROOT/dind-logs/<runner>/startup.log` and `dockerd.log`.