### PR TITLE
docs(ca): make GitHub Issues the definitive Support link

### DIFF
--- a/community-applications/ci-runner-farm.xml
+++ b/community-applications/ci-runner-farm.xml
@@ -22,7 +22,6 @@ CI Runner Farm executes GitHub Actions jobs in [b]privileged Docker-in-Docker[/b
 [br][br]
 By installing you acknowledge these risks and accept responsibility for what runs on your fleet.
 </Requires>
-<!-- TODO(before submission): replace with the dedicated Unraid forum support-thread URL (CA requires it). -->
 <Support>https://github.com/unraid/ci-runner-farm/issues</Support>
 <Project>https://github.com/unraid/ci-runner-farm</Project>
 <Icon>https://raw.githubusercontent.com/unraid/ci-runner-farm/main/community-applications/ci-runner-farm.png</Icon>


### PR DESCRIPTION
Drops the `TODO(before submission)` comment above `<Support>` in the CA template. GitHub Issues (https://github.com/unraid/ci-runner-farm/issues) is the intended support channel — no separate Unraid forum thread. Keeps this source-of-truth in sync with the live CA listing template in unraid/docker-templates#92.