### PR TITLE
fix: recreate runners with a fresh token instead of resurrecting stale ones

### DIFF
--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -134,9 +134,33 @@ scale_down_idle() {
   done
 }
 
+# Remove managed runners that have died (crash, OOM, inner-dockerd failure, or a
+# host/Docker restart not yet reconciled). With --restart=no the plugin owns
+# recovery; a dead container would otherwise linger and — because its last log
+# line isn't "Running job" — count as phantom *idle* capacity in busy_count/idle,
+# suppressing growth so the live fleet silently shrinks while current_count still
+# looks full. Reaping lets the grow step below refill the floor with a freshly
+# registered runner. Only exited/dead containers are reaped (never a container
+# still starting), and the caches/DinD root persist as bind mounts.
+reap_dead_runners() {
+  local c st
+  for c in $(managed_names); do
+    [ -n "$c" ] || continue
+    st="$(docker inspect -f '{{.State.Status}}' "$c" 2>/dev/null)"
+    case "$st" in
+      exited|dead) ;;
+      *) continue ;;
+    esac
+    log "autoscale: reaping dead runner $c (state=$st)"
+    deregister_runner_api "$c"
+    docker rm -f "$c" >/dev/null 2>&1
+  done
+}
+
 # one autoscaling evaluation: keep AUTOSCALE_MIN_IDLE warm runners, within [MIN,MAX]
 autoscale_tick() {
   [ "$AUTOSCALE" = "true" ] || return 0
+  reap_dead_runners        # drop dead containers first so idle accounting is real
   local cur busy idle statef over target
   cur=$(current_count); busy=$(busy_count); idle=$((cur - busy))
   statef="${CFGDIR}/autoscale.state"; over=0
@@ -635,7 +659,14 @@ effective_image() {
 build_args() {
   local idx="$1"; local name="${2:-${NAME_PREFIX}-${idx}}"
   ARGS=(
-    -d --restart=unless-stopped
+    # --restart=no (NOT unless-stopped): the registration token baked in below is
+    # short-lived (~1h) and the runner re-runs config on start, so letting Docker
+    # auto-restart a crashed/exited runner makes it re-register with an expired
+    # token — GitHub returns 404 ("Not configured") and the container crash-loops.
+    # The plugin is the sole supervisor: start_stopped_managed (boot) and
+    # reap_dead_runners (autoscale) recreate a dead runner with a freshly minted
+    # token instead of resurrecting it with the stale one.
+    -d --restart=no
     --name "$name" --hostname "$name"
     --pids-limit=4096
     --label "${MANAGED_LABEL%=*}=true"
@@ -723,20 +754,36 @@ start_one() {
   docker run "${ARGS[@]}" >/dev/null
 }
 
-# (Re)start any managed runner containers that exist but are stopped — e.g. after
-# Unraid stopped Docker for an array stop, which leaves them "exited". Docker's
-# unless-stopped policy does NOT resurrect explicitly-stopped containers, so the
-# docker_started event hook reconciles here. Starting in place (vs recreate) keeps
-# each runner's caches, GitHub registration and DinD data root intact, and
-# preserves a fleet the autoscaler had grown above the floor.
+# Recreate a stopped managed runner with a FRESH registration token. We cannot
+# `docker start` it in place: the baked-in RUNNER_TOKEN is short-lived (~1h) and
+# the runner re-runs config on start, so a stale token yields a GitHub 404
+# ("Not configured") and a crash loop. Only the container is removed — the warm
+# caches and the DinD data root are bind mounts on the pool (see build_args), so
+# they survive under the same name and the replacement starts warm. The stale
+# GitHub registration is dropped host-side first (the PAT never touches the
+# container) so the fresh runner re-registers cleanly.
+recreate_stopped_runner() {
+  local c="$1" idx
+  idx="$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.index" }}' "$c" 2>/dev/null)"
+  [ -z "$idx" ] && idx="${c##*-}"
+  deregister_runner_api "$c"
+  docker rm -f "$c" >/dev/null 2>&1
+  start_one "$idx"
+}
+
+# Bring back managed runner containers that exist but are stopped — e.g. after
+# Unraid stopped Docker for an array stop, which leaves them "exited", reconciled
+# by the docker_started event hook. Each is recreated with a fresh registration
+# token (see recreate_stopped_runner) rather than started in place, because the
+# original token has almost certainly expired by the time Docker comes back.
 start_stopped_managed() {
   local c st
   for c in $(managed_names); do
     [ -n "$c" ] || continue
     st="$(docker inspect -f '{{.State.Running}}' "$c" 2>/dev/null)"
     [ "$st" = "true" ] && continue
-    log "restarting stopped runner $c"
-    docker start "$c" >/dev/null 2>&1 || err "could not restart $c"
+    log "recreating stopped runner $c with a fresh registration token"
+    recreate_stopped_runner "$c"
   done
 }
 


### PR DESCRIPTION
## Summary

Self-hosted runners crash-loop once their GitHub registration token expires, silently draining the fleet. This makes the plugin the sole supervisor of the runner lifecycle, always (re)provisioning with a freshly minted token.

## Root cause

Each runner container is created with a **short-lived (~1h) registration token baked into its env** (`RUNNER_TOKEN`), and the container re-runs `config` on start. But runners ran under `--restart=unless-stopped`, and `start_stopped_managed` brought exited runners back with `docker start`. So when a runner exits and is (re)started more than ~1h later — a crash, an array/Docker restart, a reboot — it re-registers with the **now-expired token**:

```
POST https://api.github.com/actions/runner-registration → 404 Not Found
An error occurred: Not configured. Run config.(sh/cmd) to configure the runner.
```

Docker then restart-loops it forever. And because a dead container's last log line isn't `Running job`, `busy_count`/`idle` counted it as **phantom idle capacity**, so `autoscale_tick` never grew to replace it — the live fleet shrank while `current_count` still looked full, and queued jobs sat with no runner.

Observed live on the `titan` farm: `ci-runner-1`/`ci-runner-2` stuck in this exact loop with **restart counts 59 and 83**, blocking a CI deploy that sat queued for ~15 minutes.

## Fix

The PAT still never enters a container; deregistration and token minting stay host-side.

- **`--restart=no`** for runner containers — Docker never resurrects a crashed runner with a stale token.
- **`recreate_stopped_runner`** — `start_stopped_managed` now recreates each stopped runner with a fresh token (host-side deregister → `docker rm` → `start_one`) instead of `docker start`. Only the container is removed; warm caches and the DinD data root are pool bind mounts, so the replacement starts warm under the same name.
- **`reap_dead_runners`** — run at the top of every `autoscale_tick`, removes exited/dead runners (only `exited`/`dead`, never a still-starting container) so idle accounting is real and the grow step refills the floor with a freshly registered runner.

## Reviewer considerations

- **`--restart=no` vs the `docker_started` hook:** on an array/Docker restart, runners are no longer auto-started by Docker; the existing `docker_started` → `cmd_start` → `start_stopped_managed` path recreates them with fresh tokens, which is now the *only* bring-up path (previously `unless-stopped` raced it with a stale token). Please confirm this matches the intended boot flow.
- **Caches preserved:** `recreate_stopped_runner` uses `docker rm` (not `remove_runner`, which nukes `$CACHE_ROOT/docker/$c`), so the DinD data root and warm caches survive — same rationale the old in-place comment cited, now achieved via recreate.
- **Ephemeral mode** (`EPHEMERAL=true`) was affected by the same stale-token-on-restart bug and is likewise fixed: an exited ephemeral runner is reaped and refilled with a fresh token rather than looping.
- `reap_dead_runners` calls `deregister_runner_api` once per dead runner (it removes the container in the same pass), so no repeated API churn.

## Behavior changes

Crashed/stopped/rebooted runners now recover automatically with a fresh registration token instead of crash-looping on an expired one; the autoscaler no longer miscounts dead containers as idle. No config/UI changes.

## Verification

- `bash -n` clean; `shellcheck -S warning` clean on the changed code (only pre-existing SC1090/SC2206 warnings elsewhere remain).
- Confirmed against the live farm: the two crash-looping runners recovered after a controlled `runner-farm.sh restart` re-minted their tokens (`√ Connected to GitHub … Listening for Jobs`, restart count 0). This change makes that recovery automatic rather than a manual restart.

## Risk

Low. Scoped to runner lifecycle in `runner-farm.sh`; the token/PAT security boundary is unchanged; worst case a still-crashing runner is recreated (fresh token) each autoscale tick instead of Docker-looping it — strictly better observability and no stale-token wedging.