### PR TITLE
fix(autoscale): reap disconnected (unhealthy) runners, not just exited

### DIFF
--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -161,24 +161,38 @@ scale_down_idle() {
   done
 }
 
-# Remove managed runners that have died (crash, OOM, inner-dockerd failure, or a
-# host/Docker restart not yet reconciled). With --restart=no the plugin owns
-# recovery; a dead container would otherwise linger and — because its last log
-# line isn't "Running job" — count as phantom *idle* capacity in busy_count/idle,
-# suppressing growth so the live fleet silently shrinks while current_count still
-# looks full. Reaping lets the grow step below refill the floor with a freshly
-# registered runner. Only exited/dead containers are reaped (never a container
-# still starting), and the caches/DinD root persist as bind mounts.
+# Remove managed runners that can no longer service jobs, so the grow step below
+# refills the floor with a freshly registered one. Two failure modes qualify:
+#
+#   1. exited/dead — crash, OOM, inner-dockerd failure, or a host/Docker restart
+#      not yet reconciled. With --restart=no the plugin owns recovery.
+#   2. running + Docker health=unhealthy — the runner's GitHub registration was
+#      removed out from under it, so its listener loops forever on "Registration
+#      was not found / Retrying until reconnected". It never exits, so mode (1)
+#      misses it. The runner image's HEALTHCHECK flags exactly this state.
+#
+# Either way the zombie lingers and — because its last log line isn't "Running
+# job" — counts as phantom *idle* capacity in busy_count/idle, suppressing growth
+# so the live fleet silently shrinks to zero usable runners while current_count
+# still looks full (jobs then queue forever behind zombies). Never reaped: a
+# container still starting (state != running, or health=starting within the
+# HEALTHCHECK start-period) or one on an image without a healthcheck (health
+# empty => treated as fine, so this is a safe no-op until the new image ships).
+# Caches/DinD roots persist as bind mounts across the recycle.
 reap_dead_runners() {
-  local c st
+  local c st health
   for c in $(managed_names); do
     [ -n "$c" ] || continue
     st="$(docker inspect -f '{{.State.Status}}' "$c" 2>/dev/null)"
+    health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$c" 2>/dev/null)"
     case "$st" in
-      exited|dead) ;;
+      exited|dead)
+        log "autoscale: reaping dead runner $c (state=$st)" ;;
+      running)
+        [ "$health" = "unhealthy" ] || continue
+        log "autoscale: reaping unhealthy runner $c (disconnected; health=$health)" ;;
       *) continue ;;
     esac
-    log "autoscale: reaping dead runner $c (state=$st)"
     deregister_runner_api "$c"
     docker rm -f "$c" >/dev/null 2>&1
   done


### PR DESCRIPTION
## Problem

When a runner's GitHub registration is removed out from under it, the container **does not exit** — its listener loops forever on `Registration was not found / Retrying until reconnected`. `reap_dead_runners` only reaped `state=exited|dead`, so the zombie stayed `running`.

Because a zombie's last log line isn't `Running job`, `busy_count`/idle counted it as **phantom idle capacity**. Autoscale then saw spare headroom → never grew → the live fleet could silently drain toward **0 usable runners while `current_count` still looked full**, with jobs queued behind zombies. A full `restart` recovers it (fresh registrations), but the fleet should self-heal.

## Fix

Extend `reap_dead_runners` to also recycle `running` containers Docker marks `health=unhealthy`:
- Pairs with the ci-runner-image `HEALTHCHECK` (unraid/ci-runner-image#7), which flags **exactly** the stuck-disconnected state and **never** a busy or still-starting runner.
- A runner on an image **without** a healthcheck reports empty health → untouched, so this is a **safe no-op until the new image ships**.
- Reaping already runs first in `autoscale_tick`, so post-reap idle accounting is real and the grow step refills the floor with a freshly registered runner.

## Rollout
Merge with unraid/ci-runner-image#7, rebuild the runner image, and recreate the fleet so containers pick up the healthcheck.

## Test
- `bash -n` clean.
- `docker inspect` health template renders empty (not an error) for containers without a healthcheck → backward-compatible.
- Manual: remove a runner's registration via the API while it's idle → within an autoscale tick it flips `unhealthy` and is recycled; a busy runner stays healthy and is never touched.