### PR TITLE
fix: honor EPHEMERAL=false, enforce autoscale MIN floor, runner-owned cache dirs

### DIFF
--- a/build-plg.sh
+++ b/build-plg.sh
@@ -145,6 +145,36 @@ chmod 0755 "\$PLGDIR/include/runner-farm.sh"
 # Config defaults are NOT seeded to flash — the settings page and runner-farm.sh
 # both fall back to built-in defaults, so flash only ever holds what the user set.
 [ -f "\$CFGDIR/Dockerfile" ] || cp "\$PLGDIR/default.Dockerfile" "\$CFGDIR/Dockerfile"
+# Migrate saved Dockerfiles seeded before the cache-ownership fix: without
+# runner-owned CACHE_MOUNTS destinations baked into the image, Docker's
+# bind-mount auto-creation leaves root-owned parents and a non-root runner
+# fails writing beside them (rustup: "could not create bin directory
+# '/home/runner/.cargo/bin'"). Patch only files that still carry the stock
+# packages marker and lack the fix; customized files without the marker get a
+# notice instead.
+DF="\$CFGDIR/Dockerfile"
+if [ -f "\$DF" ] && ! grep -q 'mkdir -p /home/runner/.cargo/registry' "\$DF"; then
+  if grep -q '^#  && rm -rf /var/lib/apt/lists/\\*' "\$DF"; then
+    BLK=\$(mktemp)
+    cat > "\$BLK" <<'EOF_CACHEDIRS'
+
+# Pre-create the default CACHE_MOUNTS destinations as runner-owned. When these
+# paths are absent from the image, Docker's bind-mount auto-creation makes the
+# missing parent directories root-owned, and a non-root runner (RUN_AS_ROOT=false)
+# can then no longer write beside them — e.g. rustup fails with "could not
+# create bin directory '/home/runner/.cargo/bin': Permission denied".
+RUN mkdir -p /home/runner/.cargo/registry /home/runner/.cargo/git \\
+      /home/runner/.cache/sccache /home/runner/.cache/yarn /home/runner/.cache/ms-playwright \\
+      /home/runner/.npm /home/runner/.local/share/pnpm/store \\
+ && chown -R runner:runner /home/runner/.cargo /home/runner/.cache /home/runner/.npm /home/runner/.local
+EOF_CACHEDIRS
+    sed -i "\\@^#  && rm -rf /var/lib/apt/lists/\\*@r \$BLK" "\$DF"
+    rm -f "\$BLK"
+    echo "ci-runner-farm: patched saved Dockerfile to pre-create runner-owned cache dirs (press Build to rebuild the runner image)."
+  else
+    echo "ci-runner-farm: NOTE - saved \$DF lacks the runner-owned cache-dir block from default.Dockerfile; merge it manually so non-root runners can write beside the cache mounts."
+  fi
+fi
 ( docker pull myoung34/github-runner:latest >/dev/null 2>&1 & ) || true
 # Bring the fleet + autoscaler up. Runs on manual install AND on every boot
 # (rc.local reinstalls plugins), detached so it waits for dockerd+array without

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/default.Dockerfile
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/default.Dockerfile
@@ -14,6 +14,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 # RUN apt-get update && apt-get install -y --no-install-recommends <your-packages> \
 #  && rm -rf /var/lib/apt/lists/*
 
+# Pre-create the default CACHE_MOUNTS destinations as runner-owned. When these
+# paths are absent from the image, Docker's bind-mount auto-creation makes the
+# missing parent directories root-owned, and a non-root runner (RUN_AS_ROOT=false)
+# can then no longer write beside them — e.g. rustup fails with "could not
+# create bin directory '/home/runner/.cargo/bin': Permission denied".
+RUN mkdir -p /home/runner/.cargo/registry /home/runner/.cargo/git \
+      /home/runner/.cache/sccache /home/runner/.cache/yarn /home/runner/.cache/ms-playwright \
+      /home/runner/.npm /home/runner/.local/share/pnpm/store \
+ && chown -R runner:runner /home/runner/.cargo /home/runner/.cache /home/runner/.npm /home/runner/.local
+
 # DinD: the base entrypoint starts dockerd (START_DOCKER_SERVICE=true) but does
 # NOT wait for it to be ready. Wrap the runner CMD so it waits for docker before
 # the runner accepts jobs — otherwise 'Checking docker version'/services: race a

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -209,10 +209,15 @@ autoscale_tick() {
 
   # runner churn (crash, reap, or ephemeral exit) can drop the fleet below the
   # floor between ticks; the grow branch below only ever adds STEP to the
-  # current count, so enforce AUTOSCALE_MIN unconditionally first.
-  if [ "$cur" -lt "$AUTOSCALE_MIN" ]; then
-    log "autoscale: count $cur < min $AUTOSCALE_MIN -> grow to $AUTOSCALE_MIN"
-    cmd_scale "$AUTOSCALE_MIN" >/dev/null; echo 0 > "$statef"
+  # current count, so enforce AUTOSCALE_MIN unconditionally first. Clamp the
+  # floor to AUTOSCALE_MAX so a floor misconfigured above the ceiling can
+  # never bypass the resource cap.
+  local floor
+  floor=$AUTOSCALE_MIN
+  [ "$floor" -gt "$AUTOSCALE_MAX" ] && floor=$AUTOSCALE_MAX
+  if [ "$cur" -lt "$floor" ]; then
+    log "autoscale: count $cur < floor $floor -> grow to $floor"
+    cmd_scale "$floor" >/dev/null; echo 0 > "$statef"
     return 0
   fi
 

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -147,12 +147,15 @@ busy_count() {
   echo "$b"
 }
 
-# remove up to $1 IDLE runners (highest index first), never below MIN, never busy ones
+# remove up to $1 IDLE runners (highest index first), never below the effective
+# floor (MIN clamped to MAX), never busy ones
 scale_down_idle() {
-  local want="$1" removed=0 c
+  local want="$1" removed=0 c floor
+  floor=$AUTOSCALE_MIN
+  [ "$floor" -gt "$AUTOSCALE_MAX" ] && floor=$AUTOSCALE_MAX
   for c in $(managed_names | sort -rV); do
     [ "$removed" -ge "$want" ] && break
-    [ "$(current_count)" -le "$AUTOSCALE_MIN" ] && break
+    [ "$(current_count)" -le "$floor" ] && break
     if ! runner_busy "$c"; then
       log "autoscale: removing idle $c"
       remove_runner "$c"
@@ -225,7 +228,7 @@ autoscale_tick() {
     target=$(( cur + AUTOSCALE_STEP )); [ "$target" -gt "$AUTOSCALE_MAX" ] && target=$AUTOSCALE_MAX
     log "autoscale: idle=$idle/$cur < buffer $AUTOSCALE_MIN_IDLE -> grow to $target"
     cmd_scale "$target" >/dev/null; echo 0 > "$statef"
-  elif [ "$idle" -gt $(( AUTOSCALE_MIN_IDLE + AUTOSCALE_STEP )) ] && [ "$cur" -gt "$AUTOSCALE_MIN" ]; then
+  elif [ "$idle" -gt $(( AUTOSCALE_MIN_IDLE + AUTOSCALE_STEP )) ] && [ "$cur" -gt "$floor" ]; then
     over=$(( over + 1 )); echo "$over" > "$statef"
     if [ "$over" -ge "$AUTOSCALE_IDLE_GRACE" ]; then
       log "autoscale: idle=$idle/$cur high for $over checks -> shrink by $AUTOSCALE_STEP"

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -207,6 +207,15 @@ autoscale_tick() {
   statef="${CFGDIR}/autoscale.state"; over=0
   [ -f "$statef" ] && over=$(cat "$statef" 2>/dev/null || echo 0)
 
+  # runner churn (crash, reap, or ephemeral exit) can drop the fleet below the
+  # floor between ticks; the grow branch below only ever adds STEP to the
+  # current count, so enforce AUTOSCALE_MIN unconditionally first.
+  if [ "$cur" -lt "$AUTOSCALE_MIN" ]; then
+    log "autoscale: count $cur < min $AUTOSCALE_MIN -> grow to $AUTOSCALE_MIN"
+    cmd_scale "$AUTOSCALE_MIN" >/dev/null; echo 0 > "$statef"
+    return 0
+  fi
+
   if [ "$idle" -lt "$AUTOSCALE_MIN_IDLE" ] && [ "$cur" -lt "$AUTOSCALE_MAX" ]; then
     target=$(( cur + AUTOSCALE_STEP )); [ "$target" -gt "$AUTOSCALE_MAX" ] && target=$AUTOSCALE_MAX
     log "autoscale: idle=$idle/$cur < buffer $AUTOSCALE_MIN_IDLE -> grow to $target"
@@ -714,7 +723,6 @@ build_args() {
     --label "net.unraid.ci-runner-farm.index=${idx}"
     -e RUNNER_NAME="$(host)-${name}"
     -e LABELS="$RUNNER_LABELS"
-    -e EPHEMERAL="$EPHEMERAL"
     -e DISABLE_AUTO_UPDATE="true"
     -e DISABLE_AUTOMATIC_DEREGISTRATION="true"   # we deregister host-side (deregister_runner_api)
     -e RUN_AS_ROOT="$RUN_AS_ROOT"
@@ -722,6 +730,10 @@ build_args() {
     -e RUNNER_WORKDIR="/_work"
     -e npm_config_cache="/home/runner/.npm"
   )
+  # myoung34 entrypoints enable ephemeral mode when the EPHEMERAL env var is
+  # PRESENT (any value, including "false") — so only pass it when it is true,
+  # otherwise EPHEMERAL="false" silently produces one-job-then-exit runners.
+  [ "$EPHEMERAL" = "true" ] && ARGS+=( -e EPHEMERAL="true" )
   # warm caches mounted into the runner, configurable via CACHE_MOUNTS
   local m
   for m in $CACHE_MOUNTS; do


### PR DESCRIPTION
Three production-found bugs from running a farm (2–6 runners, DinD, non-root, persistent-runner config) against a Rust monorepo's CI on a 24-core Unraid host. Each was diagnosed live on 2026-07-21; the same patches have been running hot on that host since.

## 1. `EPHEMERAL="false"` still produces ephemeral runners

`build_args()` always passes `-e EPHEMERAL="$EPHEMERAL"` to `docker run`. The myoung34-based entrypoint enables ephemeral mode when the variable is **present**, regardless of value:

- config: `EPHEMERAL="false"` → container env `EPHEMERAL=false` → runner log: **"Ephemeral option is enabled"**
- every runner takes exactly one job, deregisters, and exits; the farm's intended persistent mode is unreachable, and each job pays ~30–60s of re-registration overhead.

**Fix:** append the env var only when `EPHEMERAL = "true"`.

## 2. Autoscaler can hold the fleet below `AUTOSCALE_MIN`

`autoscale_tick()` reaps dead runners first, then grows relative to the shrunken count (`target = cur + STEP`); `AUTOSCALE_MIN` is only consulted as a shrink guard. Under runner churn (bug 1, or any crash/reap), the loop converges to `busy + MIN_IDLE` regardless of the floor. Observed: `AUTOSCALE_MIN=2`, a 40-job queue, and the daemon logging `grow to 1` every tick — the queue drained essentially serially.

**Fix:** enforce the floor unconditionally before the idle-buffer heuristics.

## 3. Cache bind-mounts leave root-owned parents; non-root runner can't write its own home

The default `CACHE_MOUNTS` bind e.g. `cargo-registry:/home/runner/.cargo/registry`. The starter image doesn't contain those destination paths, so Docker's mount auto-creation makes the missing parents (`/home/runner/.cargo`, `.cache`, …) **root-owned**. With `RUN_AS_ROOT="false"`, toolchains then fail on first write beside a mount:

```
error: could not create bin directory: '/home/runner/.cargo/bin'
Caused by: Permission denied (os error 13)
```

**Fix:** pre-create the default destinations in `default.Dockerfile`, owned `runner:runner`.

## Validation

With all three applied (plus a rebuilt image): runners register once and stay resident across many jobs, the daemon respawns to the floor and scales 2→4 under queue load and back down after idle-grace, and rustup/sccache/npm write through the cache mounts without permission errors. `bash -n` clean; no behavior change for anyone running `EPHEMERAL="true"` (the env var is still passed) or root runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured runner containers can write to required cache and toolchain directories when running without root privileges.
  - Enforced the configured minimum runner count during autoscaling, including safe handling when the minimum exceeds the maximum.
  - Prevented non-ephemeral runners from being unintentionally configured as ephemeral.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->