### PR TITLE
fix(release): credit commit authors in notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
     }
   },
   "include-component-in-tag": false,
+  "include-commit-authors": true,
   "changelog-path": "CHANGELOG.md",
   "draft": false
 }


### PR DESCRIPTION
## Summary

Future Release Please entries will identify the commit author, so community contributions receive visible attribution in generated changelog and GitHub Release notes.

## Why This Exists

The current generated entry links to its pull request and commit but does not name the contributor. That makes community work easy to miss in the release announcement.

## Resolution

Enable Release Please’s built-in `include-commit-authors` option. This is the smallest supported change because it preserves the existing release workflow and adds attribution to all generated entries.

## Reviewer Considerations

- Attribution applies to every commit author, including maintainers and bots when GitHub can resolve their identity.
- This does not create a separate “Community contributions” section; that would require custom notes generation and a contributor classification policy.

## Behavior Changes

Future generated changelog and GitHub Release entries append the recognized commit author, such as `(@jmagar)`.

## Implementation Summary

- Set `include-commit-authors` to `true` in `release-please-config.json`.

## Verification

- `jq empty release-please-config.json`
- Confirmed `include-commit-authors` is a boolean in Release Please’s current JSON schema.
- `git diff --check`

## Risk

Low. This is a supported Release Please presentation setting and does not alter version calculation, tags, artifacts, or publication.