### PR TITLE
fix(release): update release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - id: release
         name: Release Please
-        uses: googleapis/release-please-action@8b8fd2cc23b2e18957157a9d923d75aa0c6f6ad5
+        uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062
         with:
           token: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN || github.token }}
 


### PR DESCRIPTION
## Summary

Update the pinned Release Please action so the configured commit-author attribution is actually supported during release-note generation.

## Why This Exists

The workflow used Release Please 17.3.0 through the pinned action revision. That version predates `include-commit-authors`, so it silently omitted contributors despite the repository configuration enabling attribution.

## Resolution

Pin Release Please Action v5.0.0, whose bundled Release Please 17.6.0 supports `include-commit-authors`. This retains the existing workflow, permissions, and release process while making the already-configured setting effective.

## Reviewer Considerations

- The upgrade moves the action runtime to Node 24, as provided by the upstream v5 action. GitHub-hosted runners support this runtime.
- No release configuration semantics change beyond enabling the previously ignored author-attribution option.
- Existing release PR #34 will need its notes regenerated after this PR merges.

## Behavior Changes

Generated changelog entries and GitHub Release notes will append resolvable commit authors, such as `(@jmagar)`.

## Implementation Summary

- Replace the immutable Release Please Action v4 revision with the immutable v5.0.0 revision in the release workflow.

## Verification

- `git diff --check` passed.
- Inspected the pinned action package lock: it bundles Release Please 17.6.0.

## Risk

Low; this is a one-line upstream action upgrade to a version that supports the existing configuration.