### PR TITLE
fix(release): restore author attribution

### DIFF
--- a/.github/scripts/credit_release_authors.py
+++ b/.github/scripts/credit_release_authors.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Restore commit-author credits that Release Please drops while parsing."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+
+COMMIT_LINK = re.compile(
+    r"\(\[[0-9a-f]{7,40}\]\(https://github\.com/[^/]+/[^/]+/commit/([0-9a-f]{40})\)\)"
+)
+NOREPLY_EMAIL = re.compile(
+    r"^(?:[0-9]+\+)?([^@]+)@users\.noreply\.github\.com$", re.IGNORECASE
+)
+RELEASE_HEADING = re.compile(r"^## \[")
+
+
+def commit_author(commit: str) -> str:
+    result = subprocess.run(
+        ["git", "show", "-s", "--format=%an%n%ae", commit],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    name, email = result.stdout.rstrip("\n").split("\n", 1)
+    match = NOREPLY_EMAIL.match(email)
+    return f"@{match.group(1)}" if match else name
+
+
+def credit_line(line: str) -> str:
+    match = COMMIT_LINK.search(line)
+    if not match or not line.startswith("* "):
+        return line
+
+    author = commit_author(match.group(1))
+    first_reference = line.find(" ([")
+    if first_reference < 0:
+        return line
+    if line[:first_reference].endswith(f" ({author})"):
+        return line
+    return f"{line[:first_reference]} ({author}){line[first_reference:]}"
+
+
+def credit_release_section(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    headings = [i for i, line in enumerate(lines) if RELEASE_HEADING.match(line)]
+    if not headings:
+        return text
+
+    start = headings[0]
+    end = headings[1] if len(headings) > 1 else len(lines)
+    for index in range(start, end):
+        newline = "\n" if lines[index].endswith("\n") else ""
+        lines[index] = credit_line(lines[index].rstrip("\n")) + newline
+    return "".join(lines)
+
+
+def credit_all_release_lines(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        newline = "\n" if line.endswith("\n") else ""
+        lines[index] = credit_line(line.rstrip("\n")) + newline
+    return "".join(lines)
+
+
+def update(path: Path, transform) -> None:
+    original = path.read_text()
+    updated = transform(original)
+    if updated != original:
+        path.write_text(updated)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("changelog", type=Path)
+    parser.add_argument("--pr-body", type=Path)
+    args = parser.parse_args()
+
+    update(args.changelog, credit_release_section)
+    if args.pr_body:
+        update(args.pr_body, credit_all_release_lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_credit_release_authors.py
+++ b/.github/scripts/test_credit_release_authors.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).with_name("credit_release_authors.py")
+SPEC = importlib.util.spec_from_file_location("credit_release_authors", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class CreditReleaseAuthorsTest(unittest.TestCase):
+    @patch.object(MODULE, "commit_author", return_value="@jmagar")
+    def test_credits_only_the_latest_changelog_section(self, _author) -> None:
+        text = """# Changelog
+
+## [1.6.0](compare)
+
+* **ui:** facelift ([#33](issue)) ([fc95b61](https://github.com/unraid/ci-runner-farm/commit/fc95b614c61dc8dca99c68358e67ea428c4a0297))
+
+## [1.5.1](compare)
+
+* old fix ([#30](issue)) ([a605b80](https://github.com/unraid/ci-runner-farm/commit/a605b80193cd93ba37ee9849c8ea52ba3110cd45))
+"""
+        updated = MODULE.credit_release_section(text)
+        self.assertIn("facelift (@jmagar) ([#33]", updated)
+        self.assertIn("* old fix ([#30]", updated)
+
+    @patch.object(MODULE, "commit_author", return_value="@jmagar")
+    def test_is_idempotent(self, _author) -> None:
+        line = "* fix (@jmagar) ([#1](issue)) ([abc1234](https://github.com/unraid/ci-runner-farm/commit/abcdefabcdefabcdefabcdefabcdefabcdefabcd))"
+        self.assertEqual(MODULE.credit_line(line), line)
+
+    @patch.object(MODULE.subprocess, "run")
+    def test_uses_github_login_from_noreply_email(self, run) -> None:
+        run.return_value.stdout = "jmagar\n38927646+jmagar@users.noreply.github.com\n"
+        self.assertEqual(MODULE.commit_author("a" * 40), "@jmagar")
+
+    @patch.object(MODULE.subprocess, "run")
+    def test_falls_back_to_git_author_name(self, run) -> None:
+        run.return_value.stdout = "Jane Contributor\njane@example.com\n"
+        self.assertEqual(MODULE.commit_author("a" * 40), "Jane Contributor")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,9 +29,9 @@ jobs:
         with:
           token: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN || github.token }}
 
-  # On the open release PR, regenerate the self-contained .plg so its version
-  # entities and embedded payload match the version release-please just bumped,
-  # then commit it back onto the PR branch.
+  # On the open release PR, restore author credits dropped by release-please's
+  # conventional-commit parser and regenerate the self-contained .plg, then
+  # commit both updates back onto the PR branch.
   prepare-plugin-release-pr:
     needs: release-please
     if: ${{ needs.release-please.outputs.pr != '' }}
@@ -56,19 +56,45 @@ jobs:
           chmod +x build-plg.sh
           INTERNAL_VERSION="$version" ./build-plg.sh
 
-      - name: Commit plugin release metadata
+      - name: Credit release authors
+        env:
+          GH_TOKEN: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN || github.token }}
+          PYTHONDONTWRITEBYTECODE: "1"
+          PR_NUMBER: ${{ fromJSON(needs.release-please.outputs.pr).number }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/test_credit_release_authors.py
+          body="$RUNNER_TEMP/release-pr-body.md"
+          gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .body > "$body"
+          python3 .github/scripts/credit_release_authors.py CHANGELOG.md --pr-body "$body"
+
+      - name: Commit prepared release files
         shell: bash
         run: |
           set -euo pipefail
           if [[ -z "$(git status --porcelain)" ]]; then
-            echo "Plugin release metadata is already current"
+            echo "Prepared release files are already current"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add VERSION ci-runner-farm.plg
-          git commit -m "chore(release): prepare plugin metadata"
+          git add CHANGELOG.md VERSION ci-runner-farm.plg
+          git commit -m "chore(release): prepare release files"
           git push origin HEAD:${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+
+      - name: Update release PR body
+        env:
+          GH_TOKEN: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN || github.token }}
+          PR_NUMBER: ${{ fromJSON(needs.release-please.outputs.pr).number }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          body="$RUNNER_TEMP/release-pr-body.md"
+          jq -n --rawfile body "$body" '{body: $body}' |
+            gh api --method PATCH "repos/$REPO/pulls/$PR_NUMBER" --input - >/dev/null
 
   validate-plugin-release:
     needs: release-please


### PR DESCRIPTION
## Summary

Release Please drops commit-author metadata during conventional-commit parsing; this restores the author credits in both the generated changelog and release PR before publication.

## Why This Exists

PR #35 enabled `include-commit-authors`, and PR #38 upgraded the action to a supporting Release Please version, but regenerated release PR #34 still omitted every author. A live dry run confirmed the option is enabled and GitHub returns the correct identities; Release Please then loses the `author` field while converting raw commits into parsed conventional commits.

Without a repository-side correction, community work such as PR #33 remains unattributed in the changelog and GitHub Release notes.

## Resolution

Post-process the current generated release section during the existing release-PR preparation job. The helper resolves GitHub noreply addresses to `@username`, falls back to the Git author name, updates the matching release PR body, and commits the corrected changelog alongside the plugin metadata.

This keeps Release Please responsible for versioning, grouping, and note generation while narrowly repairing the metadata it loses.

## Reviewer Considerations

- Only the newest changelog release section is modified; historical entries remain untouched.
- The helper is idempotent, so repeated Release Please force-pushes do not duplicate credits.
- PR-body text is fetched and patched in place, preserving Release Please headers, footers, and formatting.
- The workflow continues to use the existing admin token and current write permissions; no new secret or permission is introduced.

## Behavior Changes

Generated entries now include authors before their PR and commit references, for example: `native theming (@jmagar) ([#33]...)`. The same credited text appears in `CHANGELOG.md`, the release PR body, and the eventual GitHub Release.

## Implementation Summary

- Add a Python helper that credits commit-linked release lines from local Git metadata.
- Add unit coverage for current-section scoping, idempotency, GitHub noreply handles, and author-name fallback.
- Run the helper in the release PR preparation job, commit `CHANGELOG.md`, and update the PR body through the GitHub REST API.

## Verification

- `python3 .github/scripts/test_credit_release_authors.py` — 4 tests passed.
- `actionlint .github/workflows/release-please.yml` — passed.
- Ruby YAML parsing — passed.
- `git diff --check` — passed.
- Exercised the helper against live release PR #34 content: PR #33 resolves to `@jmagar`; PRs #35 and #38 resolve to `@elibosley`; older 1.5.1 notes remain unchanged.

## Risk

Low. The postprocessor only touches bullet lines containing a full GitHub commit link in the newest release section, and repeated runs are covered by an idempotency test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes now retain commit-author credits, including GitHub usernames when available.
  * Release pull requests automatically update the changelog, version metadata, packaged plugin, and PR description.

* **Bug Fixes**
  * Prevented author attribution from being lost during release preparation.
  * Avoided unnecessary commits when release files have no changes.

* **Tests**
  * Added coverage for author resolution, fallback names, section handling, and repeat-safe updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->