### PR TITLE
feat: add GitLab runner provider

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+/tmp/
+ci-runner-farm.tgz
+docs/sessions
+*.err

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
 name: Lint
 
-# Fast static gate for the plugin: shell syntax, PHP syntax, and the config-parity
-# guard (engine / default.cfg / UI $defaults must agree — see tests/config-parity.sh).
-# No build or runtime; complements package-plugins.yml.
+# Linux gate for syntax, config/provider contracts, fork release safety, safe
+# paths, and a temporary package build. The same entry point is available to
+# local developers through tests/run-linux-checks.sh.
 
 on:
   pull_request:
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Shell + PHP syntax and config parity
+    name: Repository checks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,30 +28,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Shell syntax (bash -n)
-        run: |
-          set -e
-          # *.sh always; plus the extension-less shell scripts Unraid runs from nchan/
-          # and event/ (lint the ones with a shell shebang, skip any non-shell helper).
-          for f in $(git ls-files '*.sh'); do echo "bash -n $f"; bash -n "$f"; done
-          for f in $(git ls-files 'src/usr/local/emhttp/plugins/*/nchan/*' 'src/usr/local/emhttp/plugins/*/event/*'); do
-            case "$(head -1 "$f" 2>/dev/null)" in '#!'*sh*) echo "bash -n $f"; bash -n "$f" ;; esac
-          done
+      - name: Run repository checks
+        run: bash tests/check.sh
 
-      - name: PHP syntax (php -l)
-        run: |
-          set -e
-          # *.php plus the .page files, which are PHP under a small "key=val ... ---" header
-          # (php -l treats the header as literal text). RunnerFarmSettings.page holds the
-          # $defaults array, so a syntax error there must not slip past this gate.
-          for f in $(git ls-files '*.php' 'src/usr/local/emhttp/plugins/*/*.page'); do
-            grep -q '<?php' "$f" || continue
-            echo "php -l $f"
-            php -l "$f"
-          done
-
-      - name: Config parity
-        run: bash tests/config-parity.sh
-
-      - name: Path guards
-        run: bash tests/safe-paths.sh
+      - name: Lint generated GitLab Runner configuration
+        run: bash tests/gitlab-runner-lint.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,9 @@ concurrency:
 
 jobs:
   release-please:
+    # Forks keep this workflow for upstream parity, but must never create a
+    # release PR, tag, release, or asset from their own main branch.
+    if: ${{ github.repository == 'unraid/ci-runner-farm' }}
     runs-on: ubuntu-latest
     outputs:
       pr: ${{ steps.release.outputs.pr || '' }}
@@ -34,7 +37,7 @@ jobs:
   # then commit it back onto the PR branch.
   prepare-plugin-release-pr:
     needs: release-please
-    if: ${{ needs.release-please.outputs.pr != '' }}
+    if: ${{ github.repository == 'unraid/ci-runner-farm' && needs.release-please.outputs.pr != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout release PR
@@ -72,7 +75,7 @@ jobs:
 
   validate-plugin-release:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ github.repository == 'unraid/ci-runner-farm' && needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
@@ -83,7 +86,7 @@ jobs:
     needs:
       - release-please
       - validate-plugin-release
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ github.repository == 'unraid/ci-runner-farm' && needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout release tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ permissions:
 
 jobs:
   release:
+    # A fork may push a v* tag or dispatch this workflow while developing. Keep
+    # upstream's release validation intact without treating fork tags as releases.
+    if: ${{ github.repository == 'unraid/ci-runner-farm' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,282 +1,432 @@
 # CI Runner Farm for Unraid
 
-Turn your Unraid server into a fleet of **GitHub Actions self-hosted runners** —
-multiple concurrent, resource-capped runners running as Docker containers, with
-warm shared caches, queue-aware autoscaling, and Docker-in-Docker. No VM
-required.
+Turn an Unraid server into a resource-capped fleet of self-hosted runners for
+**GitHub Actions or GitLab CI/CD**. The farm keeps package and image caches warm,
+supports Docker-in-Docker, and can scale several single-job runner slots without
+requiring a VM.
 
-Hosted CI minutes are slow and metered. Meanwhile, the Unraid server in your
-rack has spare cores and a fast cache pool sitting idle between media tasks.
-Point CI Runner Farm at a repo or organization, paste a token, and your builds
-run on your own hardware — as many in parallel as your box can handle, with
-dependency caches that stay hot between runs, at zero cost per minute.
-
----
-
-## Why run your own CI?
-
-- **Cost.** Hosted CI bills by the minute. A server you already own runs builds
-  for the price of the electricity.
-- **Speed.** Run many jobs in parallel and keep pnpm/npm/yarn/Playwright caches
-  warm on a local NVMe pool — no re-downloading the world on every run.
-- **It's the Unraid thing to do.** Self-hosted runners are just Docker
-  containers, and Docker is what your server is already great at. This is "do
-  more with the hardware you have," turned up to a build farm.
-- **A couple of clicks to install.** It's a normal plugin from Community
-  Applications, configured entirely from the webGUI.
-
----
+GitHub remains the default provider, so an existing installation upgrades
+without changing its runner behavior. A farm runs one provider at a time;
+switching provider drains and recreates the managed slots with the selected
+provider's credentials and runtime.
 
 ## What you get
 
 | Capability | What it means |
-|---|---|
-| **N concurrent runners** | Each runner is its own container, optionally capped with `--cpus` / `--memory` so CI never starves the rest of the host. |
-| **Queue-aware autoscaling** | An optional daemon floats the fleet between a min and max based on how many jobs are waiting — capacity when you need it, idle when you don't. |
-| **Warm shared caches** | npm, yarn, pnpm, and Playwright caches by default (fully configurable — add cargo, sccache, and more) live on a fast pool and are reused across every run. This is the biggest hidden speed win over hosted CI. |
-| **Docker-in-Docker per runner** | Jobs that use `services:` or `docker compose` just work, with an optional shared pull-through registry mirror so images are pulled once for the whole fleet. |
-| **Bring your own image** | Point at any image you publish to a registry, or build one in-plugin — toggle **Rust / Python / Node·TS / Android** toolchains into the Dockerfile with one click, then Build. |
-| **Live fleet dashboard** | Watch each runner's phase, the repo and **PR # it's building right now**, and live CPU/memory against its cap — plus queue depth, cache usage (one-click clear), recent-run pass rates, per-runner log drawers, and a colorized activity log. |
-| **One webGUI page** | Three tabs — configure, build your image, run and watch the fleet — with your token stored securely on the host. No shell required. |
+| --- | --- |
+| Concurrent runner slots | Each slot accepts one job at a time and can have CPU and memory limits, keeping CI from starving the rest of the host. |
+| GitHub and GitLab providers | Keep the existing GitHub Actions integration or select GitLab.com/self-managed GitLab. |
+| Warm shared caches | Reuse npm, yarn, pnpm, Playwright, Cargo, sccache, or custom cache directories across jobs. |
+| Slot-scoped Docker-in-Docker | Give each runner slot a private privileged Docker daemon without exposing Unraid's existing Docker socket by default; privileged DinD is still capable of host compromise. |
+| Bring your own job image | Pull a remote image or edit and build a provider-specific starter image in the plugin. |
+| Fleet controls and telemetry | Validate, start, stop, scale, recycle, and inspect runner/job state from the Unraid webGUI. |
+| Optional autoscaling | Keep a warm idle buffer between configured minimum and maximum runner counts. |
 
----
+## Architecture
 
-## How it works
+GitHub mode preserves the original container model: each `ci-runner-N`
+container is a GitHub Actions runner based on the configured runner image. The
+host keeps the GitHub PAT and gives containers only short-lived registration
+tokens.
 
-The plugin provisions a set of Docker containers from a runner image — built
-in-plugin or pulled from a registry. Each container registers itself with GitHub
-as a self-hosted runner, either at **repo** scope or **org** scope (org scope
-gives you one shared pool that any of your private repos can pull from).
+GitLab mode uses the official
+[`gitlab/gitlab-runner`](https://docs.gitlab.com/runner/install/docker/) image;
+it does not modify or fork GitLab Runner itself. Each slot contains:
 
-Persistent package caches and the build workspace are bind-mounted from a fast
-pool so they survive across jobs. An optional companion container runs a
-**pull-through registry mirror**, so Docker-in-Docker jobs across the whole fleet
-pull each image only once. And an optional autoscaler watches the GitHub job
-queue, scaling the fleet up toward your max when work is waiting and back down to
-your min when things go quiet.
+- `ci-runner-N`, a persistent GitLab Runner manager with `concurrent = 1`, a
+  per-runner `limit = 1`, and a persisted `config.toml` plus
+  `.runner_system_id`;
+- `ci-runner-N-dind`, by default, a private privileged Docker daemon shared
+  with that manager through a Unix socket; and
+- one temporary Docker-executor job container for each accepted pipeline job,
+  created from the configured default job image or the job's `.gitlab-ci.yml`
+  `image:` override.
 
----
+The reusable GitLab `glrt-` token identifies the runner configuration. Each
+manager retains its own system ID, so recycling a slot does not create a new
+shared runner configuration in GitLab.
 
 ## Install
 
-### Community Applications (recommended)
+### Community Applications
 
-Search for **CI Runner Farm** in [Community Applications](https://unraid.net/community/apps)
-and click **Install**.
+Search for **CI Runner Farm** in
+[Community Applications](https://unraid.net/community/apps) and click
+**Install**.
 
 ### Install by URL
 
-In the Unraid webGUI go to **Plugins → Install Plugin** and paste:
+In **Plugins → Install Plugin**, paste:
 
-```
+```text
 https://github.com/unraid/ci-runner-farm/releases/latest/download/ci-runner-farm.plg
 ```
 
-Unraid always resolves this to the newest published release, and its built-in
-"check for updates" keeps the plugin current.
+Everything is managed from **Settings → Utilities → CI Runner Farm**. The page
+has **Fleet**, **Runner image**, and **Settings** tabs.
 
----
+## GitHub setup
 
-## Setup, step by step
+1. Leave **Active provider** set to **GitHub Actions**.
+2. Select repository or organization scope, then configure the owner, target
+   repositories, optional runner group, labels, and resource limits.
+3. Create and save a classic GitHub Personal Access Token.
+4. Configure Docker, caches, job image, and optional autoscaling; then
+   **Validate** and **Start** on the Fleet tab.
 
-Everything lives on one page — **Settings → Utilities → CI Runner Farm** — split
-into three tabs: **Fleet** (run and watch, the default view), **Runner image**
-(build), and **Settings** (configure). The steps below follow setup order, so
-they start on the **Settings** tab (rightmost). You'll need a GitHub Personal
-Access Token and a fast pool/share for caches.
-
-### 1. Configure the fleet — the *Settings* tab
-
-The Settings tab holds the whole configuration on one screen:
-
-- **GitHub** — pick your **scope** (`repo` or `org`), the **owner** and **target
-  repos**, and an optional **runner group**.
-- **Runners** — how many **concurrent runners**, their **labels** (so workflows
-  target this fleet with `runs-on:`), and optional **CPU / memory caps per
-  runner** so CI can't starve the rest of the box.
-- **Runner image** — the **Image source**: **Built-in** (build locally, below),
-  or **Remote** to pull a named image, e.g. `ghcr.io/org/ci-runner-image:latest`
-  (for a private image, set the registry server/username and save a registry
-  token; for `ghcr.io`, a blank registry token reuses your GitHub token).
-- **Storage & caches** — the **warm caches** (host-subdir → container-path
-  mounts; defaults cover pnpm/npm/yarn/Playwright) and the **workspace tmpfs
-  size**.
-- **Docker** — **Docker-in-Docker** mode, host-socket sharing, and network
-  isolation.
-- **Autoscaling** and **image auto-update** — optional; see steps below.
-
-Save a **classic Personal Access Token** from the band at the top. The selector
-opens GitHub with the appropriate least-privilege scope preset. Here, “least
-privilege” means the minimum **classic PAT scopes** for the job; it does not
-make the credential repository- or organization-scoped. A classic PAT applies
-across the token owner's accessible repositories, so use a dedicated service
-account/token with only the access this farm needs.
-
-| Use case | PAT scopes |
+| Use case | Classic PAT scopes |
 | --- | --- |
 | Repository runners | `repo` |
 | Organization runners | `repo`, `admin:org` |
 | Either runner type with a private GHCR image | Add `read:packages` |
-| Separate registry token for pulling a private GHCR image | `read:packages` |
+| Separate registry token for a private GHCR image | `read:packages` |
 
-The runner token is stored at `/boot/config/plugins/ci-runner-farm/token` with
-`chmod 600` and is **never** written into the plugin config. A separate
-package-only token can be saved in the registry-token field when you do not want
-the runner-management token to have package access. If the GitHub organization
-uses SSO, authorize each token for that organization.
+The GitHub PAT is stored at
+`/boot/config/plugins/ci-runner-farm/token` with mode `0600`; it is not written
+to the main config or passed into job containers. Existing GitHub settings,
+container names, and the legacy editable `Dockerfile` remain compatible.
 
-![The Settings tab — GitHub scope and targets, per-runner CPU/memory caps, runner image source, warm caches, Docker-in-Docker, autoscaling, and secure token storage, all on one screen](docs/images/settings.png)
+## GitLab setup
 
-### 2. Build a runner image — the *Runner image* tab
+### 1. Create the runner in GitLab
 
-Point CI at any registry image, or build one right here. The Runner image tab is
-a syntax-highlighted, in-page Dockerfile editor over a generic
-[starter image](src/usr/local/emhttp/plugins/ci-runner-farm/default.Dockerfile)
-(stock self-hosted runner base + a Docker-in-Docker readiness wrapper). Click the
-**toolchain** pills — **Rust**, **Python**, **Node / TS**, **Android** — to
-splice matching install blocks in or out, then **Save + Build** and watch the
-live build log. Restart the fleet to roll onto the new image. No registry needed.
+Create a project, group, or instance runner using GitLab's
+[new runner creation workflow](https://docs.gitlab.com/ci/runners/new_creation_workflow/).
+Set its tags, protected status, project/group scope, and whether it may run
+untagged jobs in GitLab. Copy the runner authentication token shown after
+creation; the token must begin exactly with `glrt-`.
 
-![The Runner image tab — a syntax-highlighted Dockerfile editor, one-click Rust / Python / Node·TS / Android toolchain blocks, and a live build log](docs/images/runner-image.png)
+The same token is intentionally reused by the farm's manager slots. Avoid
+automatic authentication-token rotation for this shared multi-manager setup:
+one manager can rotate first and leave the other persisted managers with the
+old token. Rotate manually by stopping the farm, replacing the saved token, and
+starting it again. Slot retirement uses the token plus that slot's persisted
+system ID to delete only its runner-manager record; it never deletes the shared
+runner entity. The plugin rejects `glrtr-` tokens created through the deprecated
+registration-token workflow because their unregister semantics can delete that
+shared runner. It also rejects instance-prefixed variants: current official
+GitLab Runner releases recognize the safe manager-only unregister path only when
+the token itself starts with `glrt-`.
 
-### 3. Run and watch — the *Fleet* tab
+### 2. Configure the provider
 
-The Fleet tab is mission control. **Validate** (no token needed) confirms the
-host can provision, then **Start / Stop / Restart / Scale** the fleet and watch
-live per-runner status: phase, the **repo and PR # each runner is building right
-now** (linked to the GitHub run), and live **CPU / memory** against each runner's
-cap. Click the ↻ on a runner to **recycle** it — deregister, remove, and bring
-back a fresh replacement in place, so the fleet keeps its size.
+On the Settings tab:
 
-The stat tiles track runners up / busy / idle, GitHub **queue** depth, autoscaler
-state, image-update state, and total **cache** usage — with a one-click **Clear
-caches**. A **Recent runs** strip summarizes pass/fail/cancel rates across your
-repos, and the colorized **Fleet log** streams autoscaler and action output.
+1. Set **Active provider** to **GitLab CI/CD**.
+2. Set **GitLab URL** to `https://gitlab.com` or the HTTPS base URL of a
+   self-managed instance.
+3. Keep the official manager image or pin a version appropriate for the
+   self-managed instance, for example `gitlab/gitlab-runner:v18.5.0`. Explicit
+   host-socket mode requires Runner 18.5.0 or newer; Start and Validate reject an
+   older or unparseable version because safe host cleanup depends on the exact
+   build/helper/service labels fixed in that release. Every mode requires
+   Runner 16.0.0 or newer because that release added manager-only unregister
+   with a persisted system ID. Older images are rejected rather than risk
+   deleting the shared runner entity. Use GitLab 16.0 or newer for a self-managed
+   server so its runner-authentication-token and manager-system-ID APIs match
+   this lifecycle contract.
+4. Save the required `glrt-` runner token.
+5. Set the graceful manager shutdown timeout. The default is 7200 seconds.
+6. Optionally enter monitored project paths and save a separate access token
+   with `read_api`. A project access token covers only its project; for several
+   monitored projects use a group token scoped to their common group or a
+   dedicated PAT that can read every listed project.
+7. Configure resource limits, caches, the default job image, Docker mode, and
+   optional image/service execution policy; save, **Validate**, and **Start**.
 
-![The Fleet tab — live runner bays showing each runner's current repo/PR and per-runner CPU/memory, stat tiles for queue depth, autoscaler, and cache usage, a recent-runs summary, and a colorized fleet log](docs/images/fleet.png)
+The runner token is stored separately as
+`/boot/config/plugins/ci-runner-farm/gitlab-runner-token`. The optional API
+token is stored as `gitlab-api-token`. Core job execution needs only the runner
+token; the API token is used exclusively for advisory queue and recent-job
+telemetry. GitLab Runner also requires the reusable runner token in each
+mode-`0600` per-slot `gitlab-runners/ci-runner-N/config.toml`. Token validation
+uses a mode-`0600` `gitlab-token-probe/config.toml`: GitLab verification creates
+a temporary manager row, so the plugin immediately unregisters it and retains
+that file only when exact cleanup must be retried. After a manager is
+successfully unregistered and all of its local containers are removed, ordinary
+Stop, scale-down, recycle, and provider switching scrub that slot's TOML, Docker
+auth, CA snapshot, and unregister marker while preserving `.runner_system_id`.
+Any failed retirement preserves the complete material needed for a safe retry.
+Clearing the runner token applies the same rule across the active fleet. Stop,
+Restart, manager replacement, and active-token removal send `SIGQUIT`, stop
+accepting new jobs, and wait up to
+`GITLAB_SHUTDOWN_TIMEOUT` for an in-flight job to finish before Docker forces the
+manager to stop. The Unraid `stopping_docker` hook quiesces all GitLab managers
+in parallel before Docker stops their DinD sidecars, preserving the same graceful
+behavior for array stops and Docker-service restarts. The plugin registers no
+diagnostics collector for the
+bootstrap/API/registry token files, per-slot/probe `config.toml` files, or Docker auth
+files. Current Unraid system diagnostics list the plugin configuration directory
+but do not copy those file contents. Do not add those paths to a support bundle
+or attach them manually; they contain live credentials even though their modes
+are restricted.
 
-Click any runner to drop down a live **log drawer** streaming that container's
-job output inline:
+If GitLab is permanently unreachable or the saved manager token has been
+revoked, normal Stop/Recycle intentionally fails closed and preserves the local
+manager identity for retry. The Fleet row's warning action provides a separately
+confirmed **force local forget** escape hatch: it interrupts that slot, deletes
+its local manager/sidecar/token-bearing config and slot Docker/cache roots
+without contacting GitLab, and
+leaves any offline remote manager record for you to remove in GitLab manually.
 
-![A runner's log drawer expanded below its row, streaming the live job log](docs/images/fleet-log-drawer.png)
+### Self-managed GitLab and custom CAs
 
-### 4. (Optional) Queue-aware autoscaling
+Use the complete HTTPS base URL, including a non-default port if required. If
+the instance's certificate chain is not already trusted, upload its PEM CA
+chain in the GitLab credential band. It is stored as
+`/boot/config/plugins/ci-runner-farm/gitlab-ca.crt`. Each manager snapshots the
+CA used to create it alongside that slot's `config.toml`, so a CA rotation does
+not prevent the old manager identity from unregistering. The manager uses its
+snapshot for the GitLab API, and the Docker executor mounts it at the official
+`/etc/gitlab-runner/certs/ca.crt` helper path so clone, artifact, and cache
+helpers trust it. Runner also exposes the GitLab chain to jobs through
+`CI_SERVER_TLS_CA_FILE`, but an arbitrary job image does not automatically add
+it to that image's system trust store. Job scripts that call the self-managed
+service directly must use that file (for example, `curl --cacert
+"$CI_SERVER_TLS_CA_FILE" ...`) or install it using the image's own CA tooling.
 
-On the Settings tab, set a **min** and **max** runner count, a **warm idle
-buffer**, an **autoscale step**, a **demand check interval**, and a **scale-down
-grace** period. The daemon adds runners when jobs are queued and removes idle
-ones once the grace window passes — so you keep capacity ready without leaving
-the whole fleet running around the clock. Its decisions stream into the Fleet
-log.
+In DinD mode the uploaded CA is also installed for the exact authority in
+**Registry server**, allowing that per-slot daemon to pull from a registry using
+the same private CA. GitLab registry endpoints must use HTTPS (the scheme may be
+omitted); plain HTTP is rejected so credentials are never sent to an insecure
+registry. GitLab keeps the configured registry credentials available
+to each manager even when its default job image is built locally, so an
+`image:` or `services:` override can authenticate to that one registry. The
+strict-network exception for the configured authority follows the same rule.
+This does not discover other registry hostnames from job configuration. If the
+GitLab registry uses a different hostname or CA, configure that authority and
+chain explicitly. Host-socket mode cannot modify Unraid's Docker trust store;
+install the registry CA on the host and restart its Docker service before using
+that mode. The built-in shared Docker Hub mirror is local HTTP and is explicitly
+scoped as an insecure registry inside each DinD daemon; the uploaded CA is
+unrelated to it.
 
-Once started, the runners also show up as ordinary Docker containers
-(`ci-runner-1…N`), plus the optional `ci-runner-mirror` registry mirror — each
-with the warm-cache bind mounts you configured — register with GitHub, and start
-picking up jobs.
+Strict network isolation normally blocks the host and LAN. GitLab mode adds a
+narrow exception for the configured GitLab endpoint so a self-managed instance
+remains reachable; do not use a broad LAN allow rule. Configure private job
+image registries explicitly rather than weakening the runner network.
 
----
+Each private DinD daemon also allocates per-build job and service networks from
+Docker's default address pools. If a self-managed GitLab or registry lives in a
+private CIDR that overlaps those pools (commonly `172.16.0.0/12`), an inner
+Docker route can shadow the real endpoint even though the farm firewall allows
+it. Keep CI/registry endpoints on non-overlapping subnets, or configure suitable
+Docker default address pools before relying on that topology.
 
-## Security
+### Queue telemetry limitation
 
-Self-hosted runners execute arbitrary workflow code on your hardware. Read this
-before exposing the fleet:
+GitLab does not expose one public API endpoint containing every pending job
+eligible for a particular runner. With a `read_api` token, the plugin can count
+pending/recent jobs only for **Monitored projects** that the token can read.
+That number is advisory: it can omit other eligible projects and jobs excluded
+by tags or protection rules. Runner execution and busy/idle scaling do not rely
+on it.
 
-- DinD runners run `--privileged`, and the shared-socket mode gives runners
-  root-equivalent access to the host. Use self-hosted runners **only for
-  trusted/private repositories**. Fork-PR code from public repos must **never**
-  run on a privileged or socket-mounted self-hosted runner.
-- **The plugin actively warns you.** When you Start the fleet (and live on the
-  settings page), it checks each repo-scope target's visibility via your token
-  and shows a prominent warning if any is **public** while runners are
-  privileged. It warns rather than blocks — the call stays yours.
-- **`Share host docker.sock` now defaults to off.** Turn it on only for trusted
-  private repos; DinD (the default) already covers `services:` without it.
-- **Your GitHub token never enters a runner container.** The PAT stays on the
-  host; each runner is handed only a short-lived registration token, and runners
-  are deregistered host-side. So a workflow step can't read your token out of its
-  own environment.
-- **Network isolation** (Docker section) confines runners at the network layer:
-  - `isolate` puts them on a dedicated bridge so they can't reach your **other
-    Unraid containers**;
-  - `strict` adds firewall rules (Docker's `DOCKER-USER` chain) that also block
-    the runners from the **Unraid host and your LAN**, while still allowing the
-    internet and the shared image cache. Recommended if runners might touch
-    less-trusted code. Applies on the next Start; needs `iptables` on the host.
-- For stronger isolation, set `EPHEMERAL=true` so each job gets a clean runner.
-- At org scope, create a **runner group restricted to your private repos** so a
-  public repo can never schedule onto these runners.
+## Job images
 
-See GitHub's [self-hosted runner security guidance](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
-for the full picture.
+The Runner image tab maintains provider-specific editable files on flash:
 
----
+- `Dockerfile.github` for the GitHub runner container;
+- `Dockerfile.gitlab` for GitLab Docker-executor job containers; and
+- legacy `Dockerfile`, used as the GitHub fallback so existing customized
+  installs keep working.
+
+The packaged starter files are `default.github.Dockerfile` and
+`default.gitlab.Dockerfile`; the original `default.Dockerfile` remains
+byte-identical to the GitHub default for compatibility. The GitLab starter is a
+general Ubuntu job image with common build tools and a Docker client. It is
+deliberately not the GitLab Runner manager image. A GitLab job may override the
+default with:
+
+```yaml
+build:
+  image: node:24
+  script:
+    - npm ci
+    - npm test
+```
+
+GitHub-only image controls such as `EPHEMERAL`, `RUN_AS_ROOT`, and the workspace
+tmpfs do not change GitLab Docker-executor semantics. GitLab jobs are **always
+ephemeral at the job-container layer**: the manager and configured caches
+persist, but every accepted job receives a fresh Docker container.
+
+### GitLab execution policy
+
+Pipeline write access implies job-image selection and code execution on this
+host. The GitLab settings therefore expose the Docker executor's
+`allowed_images`, `allowed_services`, `pull_policy`, and `shm_size` controls:
+
+- `GITLAB_ALLOWED_IMAGES` and `GITLAB_ALLOWED_SERVICES` are space-separated
+  wildcard patterns. Empty values deliberately preserve the upgrade-compatible
+  GitLab Runner default of allowing every image; configure explicit trusted
+  registries or image families to narrow that exposure.
+- `GITLAB_PULL_POLICY=auto` preserves existing behavior (`if-not-present` for
+  the locally built image, `always` for a remote default). An explicit
+  `always` or `if-not-present` value is also written as
+  `allowed_pull_policies`, so jobs cannot select a different pull policy.
+  Explicit `always` requires a remote default image; it is rejected for the
+  locally built tag because Runner would try to pull a tag with no registry.
+  Runner's `never` policy is rejected because a fresh per-slot daemon cannot
+  obtain the helper and service images required to execute its first job.
+- `GITLAB_SHM_SIZE` is an integer byte count for Docker-executor containers.
+  The default `0` preserves Docker's default; browser/test workloads commonly
+  need a larger value such as `1073741824` (1 GiB).
+
+These controls follow GitLab Runner's
+[Docker executor configuration](https://docs.gitlab.com/runner/configuration/advanced-configuration/#the-runnersdocker-section).
+They govern images and services admitted by GitLab Runner; they are useful
+guardrails against accidental or declarative `.gitlab-ci.yml` overrides, not a
+security boundary. Every job, helper, and service container receives the
+selected Docker socket, so its code can invoke the Docker API directly to
+pull/run an otherwise disallowed image;
+against privileged DinD it can also request privileged nested containers. Route
+only trusted code to this farm even when allowlists are configured.
+Maximum job duration is server-owned runner metadata rather than a local
+`config.toml` key; set it on the runner in GitLab or with the
+[Runners API](https://docs.gitlab.com/ci/runners/configure_runners/#set-the-maximum-job-timeout).
+
+![The runner image editor and build log](docs/images/runner-image.png)
+
+## Cache scope and concurrency
+
+GitLab's native `/cache` bind is deliberately **per slot**
+(`gitlab-cache/ci-runner-N`), so managers do not race on the same Runner cache
+files; the tradeoff is that a cache warmed on one slot is not automatically
+available on another. The configurable `CACHE_MOUNTS` directories are different:
+they are shared across every slot for package-manager reuse. Use them only for
+cache formats whose tools support concurrent writers, or assign disjoint
+directories yourself. The plugin does not currently emit GitLab's distributed
+S3 cache configuration, so an external MinIO/S3 backend is not yet a supported
+configuration key.
+
+## Docker and security
+
+Self-hosted runners execute repository-controlled code on your hardware. Use
+privileged or socket-mounted runners only for trusted private projects.
+
+- **DinD is slot-scoped, not host-secure.** Each GitLab slot gets a private
+  privileged daemon, and `concurrent = 1` limits its normal cross-job blast
+  radius to that slot. The daemon creates the job, helper, and service
+  containers, and its socket is mounted into job, helper, and service containers;
+  any of them can therefore inspect or remove those siblings, pull/run images that
+  bypass Runner's image/service allowlists, and request privileged containers
+  inside the nested daemon. More importantly,
+  the DinD sidecar itself is privileged and must be treated as capable of host
+  compromise. It avoids handing jobs Unraid's existing Docker control socket,
+  but it is not a security boundary against the NAS. GitLab validation rejects
+  configurations with neither DinD nor host-socket sharing because the Docker
+  executor would have no endpoint.
+- **Host socket sharing is root-equivalent host access.** Enable it only as an
+  explicit alternative for trusted jobs. A job that controls
+  `/var/run/docker.sock` can control Unraid's containers and host filesystem.
+  GitLab host-socket mode requires `NETWORK_ISOLATION=off`: per-build networks
+  are created by Unraid's daemon and cannot be confined by attaching only the
+  manager to the farm's dedicated bridge.
+- **Public/fork pipelines are dangerous.** Do not route untrusted merge-request
+  or pull-request code to privileged DinD or host-socket runners. Enforce
+  protected runners, tags, runner groups, and private project scope at the CI
+  provider.
+- **Credentials are separated.** Runner-management credentials live in
+  mode-`0600` host files, not `ci-runner-farm.cfg`. Registry credentials use the
+  separate `registry-token` file. Clearing it unlinks every per-slot auth file
+  and the plugin-owned tmpfs Docker client config immediately; the plugin never
+  logs registry credentials into root's global Docker config. Managers mount the
+  containing per-slot directory and observe removal. An image pull that already
+  authenticated may still finish.
+- **Network isolation matters.** `isolate` separates runner containers from
+  other Unraid containers. `strict` also blocks the Unraid host and LAN, apart
+  from narrowly configured service endpoints.
+
+See [GitHub's self-hosted runner security guidance](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
+and [GitLab's self-managed runner security guidance](https://docs.gitlab.com/runner/security/).
+
+## Fleet and autoscaling
+
+The Fleet tab shows provider-neutral runner, project, job, ref, CPU, and memory
+state while retaining GitHub run/PR links for compatibility. Runner-manager logs
+are available from each slot; job links open in the provider UI. The autoscaler
+maintains the configured minimum, maximum, and warm-idle buffer and drains busy
+slots before recycling or switching provider. Autoscaling is off by default and
+must be explicitly enabled for GitLab; when enabled, it uses observed manager
+metrics and job containers, never the incomplete advisory project queue. A
+provider switch is an idle-drained rolling transition: a busy old-provider slot
+finishes first, its old adapter deregisters it, and only then is that slot
+recreated for the new provider.
+The Fleet tab may therefore briefly show both providers during the transition;
+ordinary steady state still has one active provider.
+
+![Fleet state and controls](docs/images/fleet.png)
 
 ## CLI
 
-Everything in the UI maps to the control script:
-
+```text
+include/runner-farm.sh {start|boot-autostart|docker-stopping|stop|restart|scale N|status|status-json|logs i|validate|build-image|prune-cache|autoscale-*}
 ```
-include/runner-farm.sh {start|boot-autostart|stop|restart|scale N|status|status-json|logs i|validate|build-image|prune-cache|autoscale-*}
-```
-
----
-
-## Releases & versioning
-
-Releases are automated with
-[release-please](https://github.com/googleapis/release-please) and published as
-**GitHub Release assets** — the same flow used by Unraid's other plugins.
-
-- `.release-please-manifest.json` is the SemVer source of truth; `VERSION`
-  mirrors it for tooling.
-- Merging [Conventional Commits](https://www.conventionalcommits.org) to `main`
-  opens a release PR. That PR regenerates the self-contained
-  `ci-runner-farm.plg` (version entities + embedded payload) and updates
-  `CHANGELOG.md`.
-- Merging the release PR tags `vX.Y.Z`, cuts a GitHub Release, validates the
-  tagged `.plg`, and uploads it as the `ci-runner-farm.plg` release asset that
-  the install URL above resolves to.
-
-The Unraid plugin-manager `<version>` is written as
-`YYYY.MM.DD.HHMM.BUILD-INTERNAL` (e.g. `2026.06.24.1530.42-0.1.0`) so it sorts
-chronologically in the plugin manager while still pinning the SemVer release.
-
----
 
 ## Development
 
+Fork the repository on GitHub, then keep the canonical project as `upstream`:
+
 ```sh
-./build-plg.sh                 # build ci-runner-farm.plg from src/ (date-stamped dev build)
-./deploy.sh root@tower         # rsync src/ to a dev Unraid host (fast iteration; not for installs)
+git clone git@github.com:YOUR-ACCOUNT/ci-runner-farm.git
+cd ci-runner-farm
+git remote add upstream https://github.com/unraid/ci-runner-farm.git
+git switch -c feat/gitlab-provider
 ```
 
-The `.plg` is fully self-contained: the plugin file tree is tarred,
-base64-encoded, and embedded inline, so installing only ever fetches the single
-`.plg` — no external file hosting.
+Run all checks in the bundled Linux environment. This is the preferred command
+on macOS because the host commonly has Bash 3, BSD tar/realpath, and no PHP CLI:
+
+```sh
+./tests/run-linux-checks.sh
+```
+
+With compatible Linux tools installed, run `bash tests/check.sh` directly.
+Checks cover Bash/PHP syntax, config parity, safe cache paths, the provider and
+credential contract, fork release guards, generated XML, and exact package
+contents.
+
+Build and deploy to a disposable Unraid development host:
+
+```sh
+./build-plg.sh
+./deploy.sh root@tower
+```
+
+`deploy.sh` uploads the complete runtime into a staging directory, validates
+its sentinels and permissions, then performs a rollback-protected replacement
+of the development copy.
+Stop the fleet before deploying; the script refuses an active fleet/daemon so
+long-running processes cannot keep executing an unlinked older engine while
+new web actions use the replacement.
+The generated `.plg` downloads a version-pinned reproducible `.tgz`; it is not
+an inline/base64 package.
 
 ### Layout
 
-```
-ci-runner-farm.plg                 self-contained installer (built artifact, committed)
-build-plg.sh                       packages src/ -> versioned .plg
-deploy.sh                          dev-only raw deploy to an Unraid host
-release-please-config.json         release-please configuration
-.release-please-manifest.json      SemVer source of truth
-VERSION                            mirror of the internal SemVer version
+```text
+ci-runner-farm.plg                  generated installer metadata
+build-plg.sh                        packages src/ into .plg + reproducible .tgz
+deploy.sh                           complete-tree atomic dev deployment
+tests/check.sh                      Linux/CI check entry point
+tests/run-linux-checks.sh           containerized local check entry point
 src/usr/local/emhttp/plugins/ci-runner-farm/
-  RunnerFarm.page                  Settings page (Dynamix)
-  default.cfg                      seed config
-  default.Dockerfile               generic starter runner image
-  include/runner-farm.sh           provisioning/control script
-  include/exec.php                 CSRF-guarded web endpoint
-.github/workflows/
-  package-plugins.yml              PR/branch build + validate
-  release-please.yml               release automation + asset upload
-  release.yml                      tagged-release validation
+  default.Dockerfile                legacy GitHub starter (compatibility)
+  default.github.Dockerfile         named GitHub runner starter
+  default.gitlab.Dockerfile         GitLab Docker-executor job starter
+  default.cfg                       public reference defaults
+  include/runner-farm.sh            common lifecycle engine
+  include/providers/                provider adapters
+  include/exec.php                  CSRF-guarded web endpoint
 ```
 
----
+The release workflows are guarded to `unraid/ci-runner-farm`. They remain inert
+in forks even when a fork pushes `main`, tags `v*`, or dispatches them manually.
+The fork's CI stays on GitHub; no `.gitlab-ci.yml` is required to add GitLab as a
+runtime provider.
 
-## Support
+## Releases and support
 
-Questions and bug reports: <https://github.com/unraid/ci-runner-farm/issues>
+Canonical releases use release-please and GitHub Release assets. Questions and
+bug reports: <https://github.com/unraid/ci-runner-farm/issues>

--- a/build-plg.sh
+++ b/build-plg.sh
@@ -47,6 +47,273 @@ make_tgz() {
   tar ${opts[@]+"${opts[@]}"} -cf - -C "$SRCDIR" . | gzip -9n > "$TGZ"
 }
 
+# Build an explicitly local-only plugin descriptor and package without touching
+# the canonical release artifacts in the repository root. The development PLG
+# uses Unraid's <LOCAL> package source so it cannot accidentally fetch or publish
+# a GitHub release asset. Its content-addressed version makes separate source
+# states unambiguous while keeping repeat builds deterministic.
+build_dev_package() {
+  if ! tar --version 2>/dev/null | grep -qi 'gnu tar'; then
+    echo "build-plg.sh --dev requires GNU tar for deterministic package bytes" >&2
+    return 1
+  fi
+  command -v python3 >/dev/null 2>&1 || {
+    echo "build-plg.sh --dev requires python3" >&2
+    return 1
+  }
+  command -v sha256sum >/dev/null 2>&1 || {
+    echo "build-plg.sh --dev requires sha256sum" >&2
+    return 1
+  }
+
+  local base_internal dev_internal dev_build dev_date dev_version
+  local dev_workdir render_dir raw_tgz rendered_tgz package_sha package_md5
+  local package_name source_path stage_dir output_dir
+
+  base_internal="${INTERNAL_VERSION:-$( [ -f VERSION ] && tr -d '[:space:]' < VERSION || echo '0.0.0' )}"
+  base_internal="${base_internal:-0.0.0}"
+  dev_build="${BUILD_NUMBER:-${GITHUB_RUN_NUMBER:-0}}"
+  dev_date="${DATE:-$(date -u +%Y.%m.%d.%H%M)}"
+
+  [[ "$dev_date" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]{4}$ ]] || {
+    echo "DATE must be YYYY.MM.DD.HHMM: $dev_date" >&2
+    return 1
+  }
+  [[ "$dev_build" =~ ^[0-9]+$ ]] || {
+    echo "BUILD_NUMBER must be numeric: $dev_build" >&2
+    return 1
+  }
+  [[ "$base_internal" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || {
+    echo "INTERNAL_VERSION must be SemVer: $base_internal" >&2
+    return 1
+  }
+
+  mkdir -p tmp
+  dev_workdir="$(mktemp -d "tmp/.${NAME}-dev-package.XXXXXX")"
+  DEV_PACKAGE_WORKDIR="$dev_workdir"
+  trap 'rm -rf -- "$DEV_PACKAGE_WORKDIR"' EXIT HUP INT TERM
+
+  raw_tgz="$dev_workdir/${NAME}.tgz"
+  TGZ="$raw_tgz"
+  make_tgz
+  package_sha="$(sha256sum "$raw_tgz" | cut -d' ' -f1)"
+  [[ "$package_sha" =~ ^[0-9a-f]{64}$ ]] || {
+    echo "failed to calculate package SHA256" >&2
+    return 1
+  }
+
+  if [[ "$base_internal" == *-* ]]; then
+    dev_internal="${base_internal}.jcuratec.gitlab.dev.${package_sha:0:12}"
+  else
+    dev_internal="${base_internal}-jcuratec.gitlab.dev.${package_sha:0:12}"
+  fi
+  dev_version="${dev_date}.${dev_build}-${dev_internal}"
+  package_name="${NAME}-jcuratec-dev-${dev_version}.tgz"
+  source_path="/boot/config/${NAME}-dev/artifacts/${package_name}"
+
+  # Reuse the production renderer from a disposable copy. Calling it without
+  # --dev exercises the exact current release template while keeping its output
+  # and the root ci-runner-farm.plg/ci-runner-farm.tgz completely isolated.
+  render_dir="$dev_workdir/render"
+  mkdir -p "$render_dir/$SRCDIR"
+  cp build-plg.sh "$render_dir/build-plg.sh"
+  [ ! -f VERSION ] || cp VERSION "$render_dir/VERSION"
+  [ ! -f CHANGELOG.md ] || cp CHANGELOG.md "$render_dir/CHANGELOG.md"
+  cp -R "$SRCDIR"/. "$render_dir/$SRCDIR/"
+  (
+    cd "$render_dir"
+    DATE="$dev_date" \
+      BUILD_NUMBER="$dev_build" \
+      INTERNAL_VERSION="$dev_internal" \
+      REPO="j-curatec/ci-runner-farm" \
+      bash ./build-plg.sh >/dev/null
+  )
+  rendered_tgz="$render_dir/${NAME}.tgz"
+  if [ "$(sha256sum "$rendered_tgz" | cut -d' ' -f1)" != "$package_sha" ]; then
+    echo "development package changed while rendering its descriptor" >&2
+    return 1
+  fi
+
+  if command -v md5sum >/dev/null 2>&1; then
+    package_md5="$(md5sum "$raw_tgz" | cut -d' ' -f1)"
+  else
+    package_md5="$(md5 -q "$raw_tgz")"
+  fi
+
+  stage_dir="$dev_workdir/output"
+  mkdir -p "$stage_dir"
+  cp "$raw_tgz" "$stage_dir/$package_name"
+
+  DEV_PACKAGE_NAME="$package_name" \
+    DEV_PACKAGE_SHA256="$package_sha" \
+    DEV_SOURCE_PATH="$source_path" \
+    python3 - "$render_dir/${NAME}.plg" "$stage_dir/${NAME}.plg" <<'PY'
+import os
+import re
+import sys
+
+source, destination = sys.argv[1:]
+package = os.environ["DEV_PACKAGE_NAME"]
+sha256 = os.environ["DEV_PACKAGE_SHA256"]
+source_path = os.environ["DEV_SOURCE_PATH"]
+text = open(source, encoding="utf-8").read()
+
+
+def replace_once(old, new, label):
+    global text
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"cannot render dev PLG: expected one {label}, found {count}")
+    text = text.replace(old, new, 1)
+
+
+def sub_once(pattern, replacement, label, flags=0):
+    global text
+    text, count = re.subn(pattern, replacement, text, count=1, flags=flags)
+    if count != 1:
+        raise SystemExit(f"cannot render dev PLG: expected one {label}, found {count}")
+
+
+sub_once(r'<!ENTITY author\s+"[^"]*">', '<!ENTITY author        "j-curatec local dev">', "author entity")
+sub_once(r'^<!ENTITY pluginURL\s+"[^"]*">\n', '', "pluginURL entity", re.MULTILINE)
+sub_once(r'<!ENTITY packageName\s+"[^"]*">', f'<!ENTITY packageName   "{package}">', "package name entity")
+sub_once(r'^<!ENTITY packageURL\s+"[^"]*">\n', '', "packageURL entity", re.MULTILINE)
+sub_once(
+    r'(<!ENTITY packageMD5\s+"[^"]*">\n)',
+    rf'\1<!ENTITY packageSHA256 "{sha256}">\n',
+    "package MD5 entity",
+)
+sub_once(r'^\s*pluginURL="&pluginURL;"\n', '', "pluginURL attribute", re.MULTILINE)
+sub_once(
+    r'support="[^"]*"',
+    'support="https://github.com/j-curatec/ci-runner-farm/issues"',
+    "support attribute",
+)
+sub_once(
+    r'<CHANGES>\n.*?</CHANGES>',
+    '''<CHANGES>
+### &version;
+* Local development build from the j-curatec GitLab-provider working tree.
+* Adds CI_PROVIDER=github|gitlab while retaining the GitHub provider.
+* Uses an offline, content-addressed flash artifact and has no automatic update URL.
+</CHANGES>''',
+    "development changes block",
+    re.DOTALL,
+)
+sub_once(
+    r'<!-- plugin package:.*?</FILE>',
+    f'''<!-- local development package: copied from its offline flash artifact -->
+<FILE Name="/tmp/&packageName;">
+<LOCAL>{source_path}</LOCAL>
+<MD5>&packageMD5;</MD5>
+<SHA256>&packageSHA256;</SHA256>
+</FILE>''',
+    "package FILE block",
+    re.DOTALL,
+)
+
+sub_once(
+    r'# Sweep any older package versions off flash, keeping this build\'s package\.\n'
+    r'find "\$CFGDIR" -maxdepth 1 -name \'ci-runner-farm-\*\.tgz\' ! -name \'[^\']+\' -delete 2>/dev/null \|\| true',
+    '# Local dev artifacts and rollback packages are installer-owned; retain them.',
+    "cached package sweep",
+)
+
+replace_once(
+    'mkdir -p "$CFGDIR" "$PLGDIR"',
+    f'''mkdir -p "$CFGDIR" "$PLGDIR"
+PKG="/tmp/{package}"
+EXPECTED_PACKAGE_SHA256="{sha256}"
+command -v sha256sum >/dev/null 2>&1 || {{
+  echo "ci-runner-farm dev install failed: sha256sum is unavailable." >&2
+  rm -f -- "$PKG"
+  exit 1
+}}
+actual_package_sha256="$(sha256sum "$PKG" | cut -d' ' -f1)" || {{
+  rm -f -- "$PKG"
+  exit 1
+}}
+if [ "$actual_package_sha256" != "$EXPECTED_PACKAGE_SHA256" ]; then
+  echo "ci-runner-farm dev install failed: package SHA256 mismatch." >&2
+  rm -f -- "$PKG"
+  exit 1
+fi
+trap 'rm -f -- "$PKG"' EXIT HUP INT TERM''',
+    "install directory setup",
+)
+sub_once(
+    r'tar -xzf "\$CFGDIR/[^"]+" --no-same-owner --no-overwrite-dir -C "\$PLGDIR"',
+    '''tar -xzf "$PKG" --no-same-owner --no-overwrite-dir -C "$PLGDIR"
+rm -f -- "$PKG"
+trap - EXIT HUP INT TERM''',
+    "package extraction",
+)
+replace_once(
+    '# The .tgz is kept on flash so the on-boot reinstall works without a download.',
+    '# The verified temporary copy is removed after extraction; the external dev artifact is retained.',
+    "package retention comment",
+)
+sub_once(
+    r'# The downloaded package is just a cache; drop it\. Config \+ credentials stay\.\n'
+    r'if ! rm -f -- "\$CFGDIR"/ci-runner-farm-\*\.tgz; then\n'
+    r'.*?\nfi',
+    f'''# External dev artifacts and rollback packages are installer-owned and retained.
+# Do not delete upstream cached packages or /boot/config/ci-runner-farm-dev here.
+rm -f -- "/tmp/{package}" 2>/dev/null || true''',
+    "remove-time package cleanup",
+    re.DOTALL,
+)
+
+if "pluginURL" in text or "<URL>" in text or "packageURL" in text:
+    raise SystemExit("cannot render dev PLG: remote update metadata remains")
+if "<LOCAL>" + source_path + "</LOCAL>" not in text:
+    raise SystemExit("cannot render dev PLG: local artifact source is missing")
+if f'<!ENTITY packageSHA256 "{sha256}">' not in text:
+    raise SystemExit("cannot render dev PLG: package SHA256 entity is missing")
+if '<SHA256>&packageSHA256;</SHA256>' not in text:
+    raise SystemExit("cannot render dev PLG: package SHA256 reference is missing")
+
+with open(destination, "w", encoding="utf-8", newline="\n") as handle:
+    handle.write(text)
+PY
+
+  DEV_VERSION="$dev_version" \
+    DEV_PACKAGE_NAME="$package_name" \
+    DEV_PACKAGE_MD5="$package_md5" \
+    DEV_PACKAGE_SHA256="$package_sha" \
+    DEV_SOURCE_PATH="$source_path" \
+    python3 - "$stage_dir/manifest.json" <<'PY'
+import json
+import os
+import sys
+
+manifest = {
+    "schema": 1,
+    "name": "ci-runner-farm",
+    "mode": "dev",
+    "version": os.environ["DEV_VERSION"],
+    "plugin_file": "ci-runner-farm.plg",
+    "package_file": os.environ["DEV_PACKAGE_NAME"],
+    "package_md5": os.environ["DEV_PACKAGE_MD5"],
+    "package_sha256": os.environ["DEV_PACKAGE_SHA256"],
+    "source_path": os.environ["DEV_SOURCE_PATH"],
+    "runtime_root": "src/usr/local/emhttp/plugins/ci-runner-farm",
+}
+with open(sys.argv[1], "w", encoding="utf-8", newline="\n") as handle:
+    json.dump(manifest, handle, separators=(",", ":"))
+    handle.write("\n")
+PY
+
+  output_dir="tmp/dev-package"
+  rm -rf -- "$output_dir"
+  mv "$stage_dir" "$output_dir"
+  rm -rf -- "$dev_workdir"
+  trap - EXIT HUP INT TERM
+  echo "built $output_dir/${NAME}.plg + $output_dir/$package_name (version $dev_version, sha256 $package_sha)"
+}
+
+if [ "${1:-}" = "--dev" ]; then build_dev_package; exit $?; fi
+
 # `build-plg.sh --tgz-only` just (re)builds the package — used by the release
 # jobs to regenerate the exact bytes the committed .plg already advertises.
 if [ "${1:-}" = "--tgz-only" ]; then make_tgz; echo "built $TGZ ($(wc -c < "$TGZ" | tr -d ' ') bytes)"; exit 0; fi
@@ -145,15 +412,26 @@ chmod 0755 "\$PLGDIR/include/runner-farm.sh"
 [ -d "\$PLGDIR/event" ] && find "\$PLGDIR/event" -type f -exec chmod 0755 {} +
 # Config defaults are NOT seeded to flash — the settings page and runner-farm.sh
 # both fall back to built-in defaults, so flash only ever holds what the user set.
-[ -f "\$CFGDIR/Dockerfile" ] || cp "\$PLGDIR/default.Dockerfile" "\$CFGDIR/Dockerfile"
-# Migrate saved Dockerfiles seeded before the cache-ownership fix: without
+# Provider-specific editable Dockerfiles keep a GitLab job-image build from
+# replacing a customized GitHub runner image (and vice versa). Existing installs
+# used the unsuffixed Dockerfile; copy it forward once as the GitHub source while
+# retaining the old file as a compatibility/downgrade fallback.
+if [ ! -f "\$CFGDIR/Dockerfile.github" ]; then
+  if [ -f "\$CFGDIR/Dockerfile" ]; then
+    cp "\$CFGDIR/Dockerfile" "\$CFGDIR/Dockerfile.github"
+  else
+    cp "\$PLGDIR/default.github.Dockerfile" "\$CFGDIR/Dockerfile.github"
+  fi
+fi
+[ -f "\$CFGDIR/Dockerfile.gitlab" ] || cp "\$PLGDIR/default.gitlab.Dockerfile" "\$CFGDIR/Dockerfile.gitlab"
+# Migrate GitHub Dockerfiles seeded before the cache-ownership fix: without
 # runner-owned CACHE_MOUNTS destinations baked into the image, Docker's
 # bind-mount auto-creation leaves root-owned parents and a non-root runner
 # fails writing beside them (rustup: "could not create bin directory
 # '/home/runner/.cargo/bin'"). Patch only files that still carry the stock
 # packages marker and lack the fix; customized files without the marker get a
 # notice instead.
-DF="\$CFGDIR/Dockerfile"
+DF="\$CFGDIR/Dockerfile.github"
 if [ -f "\$DF" ] && ! grep -q 'mkdir -p /home/runner/.cargo/registry' "\$DF"; then
   if grep -q '^#  && rm -rf /var/lib/apt/lists/\\*' "\$DF"; then
     BLK=\$(mktemp)
@@ -173,19 +451,20 @@ EOF_CACHEDIRS
     rm -f "\$BLK"
     echo "ci-runner-farm: patched saved Dockerfile to pre-create runner-owned cache dirs (press Build to rebuild the runner image)."
   else
-    echo "ci-runner-farm: NOTE - saved \$DF lacks the runner-owned cache-dir block from default.Dockerfile; merge it manually so non-root runners can write beside the cache mounts."
+    echo "ci-runner-farm: NOTE - saved \$DF lacks the runner-owned cache-dir block from default.github.Dockerfile; merge it manually so non-root runners can write beside the cache mounts."
   fi
 fi
 ( docker pull myoung34/github-runner:latest >/dev/null 2>&1 & ) || true
+( docker pull gitlab/gitlab-runner:alpine >/dev/null 2>&1 & ) || true
 # Bring the fleet + autoscaler up. Runs on manual install AND on every boot
 # (rc.local reinstalls plugins), detached so it waits for dockerd+array without
-# blocking. No-op until a GitHub token is configured.
+# blocking. No-op until the selected provider's runner token is configured.
 ( nohup "\$PLGDIR/include/runner-farm.sh" boot-autostart >>"\$CFGDIR/boot.log" 2>&1 & ) || true
 echo ""
 echo "+=============================================================+"
 echo "| ci-runner-farm ${VERSION} installed.                         "
 echo "| Settings > Utilities > CI Runner Farm                        "
-echo "| Set a GitHub PAT, then Start (or Validate without a token).  "
+echo "| Select GitHub or GitLab, save its token, then Start.         "
 echo "+=============================================================+"
 ]]></INLINE>
 </FILE>
@@ -193,13 +472,62 @@ echo "+=============================================================+"
 <!-- remove -->
 <FILE Run="/bin/bash" Method="remove">
 <INLINE><![CDATA[
+set -euo pipefail
 PLGDIR="/usr/local/emhttp/plugins/${NAME}"
 CFGDIR="/boot/config/plugins/${NAME}"
-"\$PLGDIR/include/runner-farm.sh" stop 2>/dev/null || true
-rm -rf "\$PLGDIR"
-# The downloaded package is just a cache; drop it. Config + token stay.
-rm -f "\$CFGDIR"/${NAME}-*.tgz
-echo "ci-runner-farm removed. Config + token left in /boot/config/plugins/${NAME} (delete manually to purge)."
+ENGINE="\$PLGDIR/include/runner-farm.sh"
+if [ -x "\$ENGINE" ]; then
+  if ! "\$PLGDIR/include/runner-farm.sh" stop >>"\$CFGDIR/boot.log" 2>&1; then
+    echo "ci-runner-farm NOT removed: one or more runners, jobs, or privileged sidecars could not be stopped safely." >&2
+    echo "Review \$CFGDIR/boot.log, retry Stop, or use the separately confirmed local-forget recovery action if GitLab is permanently unreachable." >&2
+    exit 1
+  fi
+else
+  # A partially deleted runtime cannot perform the normal ownership-verified
+  # teardown. Never interpret that as an empty farm: prove through Docker that
+  # no plugin-labelled manager, validation container, privileged DinD sidecar,
+  # host-socket executor workload, or registry mirror survives before allowing
+  # the remaining package files to be removed.
+  command -v docker >/dev/null 2>&1 || {
+    echo "ci-runner-farm NOT removed: cleanup engine is missing and Docker is unavailable, so owned runtime resources cannot be enumerated." >&2
+    echo "Start Docker or restore the plugin runtime, then retry removal." >&2
+    exit 1
+  }
+  owned_runtime=""
+  for filter in \
+    'label=net.unraid.ci-runner-farm.managed=true' \
+    'label=net.unraid.ci-runner-farm.sidecar=true' \
+    'label=net.unraid.ci-runner-farm.role=mirror'
+  do
+    if ! ids=\$(docker ps -aq --filter "\$filter" 2>/dev/null); then
+      echo "ci-runner-farm NOT removed: cleanup engine is missing and Docker ownership enumeration failed." >&2
+      exit 1
+    fi
+    [ -z "\$ids" ] || owned_runtime="\${owned_runtime}\${ids} "
+  done
+  if ! ids=\$(docker ps -aq \
+      --filter 'label=com.gitlab.gitlab-runner.managed=true' \
+      --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' 2>/dev/null); then
+    echo "ci-runner-farm NOT removed: cleanup engine is missing and GitLab executor ownership enumeration failed." >&2
+    exit 1
+  fi
+  [ -z "\$ids" ] || owned_runtime="\${owned_runtime}\${ids} "
+  if [ -n "\$owned_runtime" ]; then
+    echo "ci-runner-farm NOT removed: the cleanup engine is missing while plugin-owned Docker resources still exist." >&2
+    echo "Restore the plugin runtime, then retry removal so those resources can be stopped safely." >&2
+    exit 1
+  fi
+fi
+if ! rm -rf -- "\$PLGDIR" || [ -e "\$PLGDIR" ]; then
+  echo "ci-runner-farm NOT fully removed: failed to delete the installed runtime at \$PLGDIR." >&2
+  exit 1
+fi
+# The downloaded package is just a cache; drop it. Config + credentials stay.
+if ! rm -f -- "\$CFGDIR"/${NAME}-*.tgz; then
+  echo "ci-runner-farm NOT fully removed: runtime cleanup succeeded, but a cached package could not be deleted from \$CFGDIR." >&2
+  exit 1
+fi
+echo "ci-runner-farm removed. Config + credentials left in /boot/config/plugins/${NAME} (delete manually to purge)."
 ]]></INLINE>
 </FILE>
 

--- a/community-applications/DESCRIPTION.md
+++ b/community-applications/DESCRIPTION.md
@@ -8,61 +8,64 @@ in [`ci-runner-farm.xml`](ci-runner-farm.xml).
 
 ## One-liner (CA tagline)
 
-Turn your Unraid box into a fleet of GitHub Actions self-hosted build runners —
-concurrent, cached, autoscaling, container-only. Zero cost per CI minute.
+Turn your Unraid box into a fleet of GitHub Actions or GitLab CI/CD self-hosted
+build runners — concurrent, cached, autoscaling, and container-only.
 
 ---
 
 ## Short description (CA listing `<Description>`)
 
-Turn your Unraid server into a fleet of **GitHub Actions self-hosted BUILD
-runners** — multiple concurrent, resource-capped runners running as Docker
-containers (no VM), with warm shared caches on a fast pool, queue-aware
-autoscaling, and Docker-in-Docker so jobs that use `services:` and `docker build`
-just work.
+Turn your Unraid server into a fleet of **GitHub Actions or GitLab CI/CD
+self-hosted build runners** — multiple concurrent, resource-capped runner slots
+as Docker containers (no VM), with warm shared caches on a fast pool,
+idle-buffer autoscaling, and Docker-in-Docker for services and image builds.
 
-Point it at a repo or organization, paste a GitHub token, and your CI runs on
-your own hardware — as many jobs in parallel as your box can handle, with
-pnpm/npm/yarn/Playwright caches that stay hot between runs, at zero cost per
-minute. Everything is configured from a single webGUI page.
+Select one active provider, save a GitHub PAT or modern GitLab `glrt-` runner
+token, and run CI on your own hardware. GitLab mode uses the official Runner
+manager and Docker executor; GitHub mode retains the existing runner-container
+workflow. Everything is configured from a single webGUI page.
 
 > **Security:** self-hosted runners execute arbitrary workflow code on your
-> hardware, and DinD runners run privileged. Use them **only for trusted/private
-> repositories** — never let public/fork-PR code run on a privileged self-hosted
-> runner. The plugin actively warns you when a privileged runner is pointed at a
-> public repo.
+> hardware, and DinD runners run privileged. A private per-slot daemon avoids
+> exposing Unraid's existing Docker socket but is not a host security boundary.
+> Use runners **only for trusted/private
+> projects/repositories** — never let public fork or merge-request code run on a
+> privileged self-hosted runner. Enforce protected runners, tags, groups, and
+> private scope in the selected CI provider.
 
 ---
 
 ## Forum support-thread post (BBCode)
 
 ```bbcode
-[b]CI Runner Farm[/b] turns your Unraid server into a fleet of GitHub Actions
-self-hosted [i]build[/i] runners — multiple concurrent, resource-capped runners
-as Docker containers (no VM required).
+[b]CI Runner Farm[/b] turns your Unraid server into a fleet of GitHub Actions or
+GitLab CI/CD self-hosted [i]build[/i] runners — multiple concurrent,
+resource-capped runner slots as Docker containers (no VM required).
 
 [b]What you get[/b]
 [list]
 [*][b]N concurrent runners[/b] — each its own container, optionally capped with --cpus/--memory so CI never starves the rest of the host.
-[*][b]Queue-aware autoscaling[/b] — the fleet floats between a min and max by how many jobs are waiting.
+[*][b]Idle-buffer autoscaling[/b] — the fleet floats between a configured min and max while retaining warm idle capacity.
 [*][b]Warm shared caches[/b] — pnpm/npm/yarn/Playwright caches live on a fast pool and are reused across every run.
 [*][b]Docker-in-Docker per runner[/b] — jobs using services: or docker compose just work, with an optional shared pull-through image mirror.
 [*][b]Bring your own image[/b] — build one from the in-plugin editor, or pull any registry image (public or private).
-[*][b]One webGUI page[/b] — token storage, Start/Stop/Restart/Scale, live status, and image builds. No shell required.
+[*][b]Two providers, one webGUI[/b] — provider-specific credential storage, Start/Stop/Restart/Scale, live status, and job-image builds. No shell required.
 [/list]
 
 [b]Requirements[/b]
 [list]
 [*]Unraid 6.12.0 or newer, with Docker enabled and a pool (cache) for the runner data root.
-[*]A GitHub Personal Access Token (repo scope; +admin:org for org-wide runners).
+[*]A GitHub Personal Access Token, or a modern GitLab runner authentication token beginning glrt-.
 [/list]
 
 [b]⚠ Security — read before use[/b]
 Self-hosted runners run arbitrary workflow code on your hardware, and DinD
-runners run [b]--privileged[/b]. Use them [b]only for trusted/private repos[/b].
-Fork-PR code from a public repo must [b]never[/b] run on a privileged or
-socket-mounted self-hosted runner. The plugin warns you if it detects a public
-repo target on a privileged fleet.
+runners run [b]--privileged[/b]. Per-slot DinD limits ordinary Docker access to
+one slot, but it is not a security boundary against the Unraid host. Use runners
+[b]only for trusted/private repos[/b].
+Public fork/MR code must [b]never[/b] run on a privileged or socket-mounted
+self-hosted runner. Restrict the runner to trusted private projects or
+repositories in GitHub or GitLab.
 
 [b]Source & issues:[/b] https://github.com/unraid/ci-runner-farm
 ```

--- a/community-applications/ci-runner-farm.xml
+++ b/community-applications/ci-runner-farm.xml
@@ -7,18 +7,18 @@
 <Category>Tools:System: Network:Management: Productivity:</Category>
 <Name>CI Runner Farm</Name>
 <Description>
-Turn your Unraid server into a fleet of GitHub Actions self-hosted BUILD runners — multiple concurrent, resource-capped runners running as Docker containers (no VM), with warm shared caches on a fast pool, queue-aware autoscaling, and Docker-in-Docker so jobs that use services: and docker build just work.
+Turn your Unraid server into a fleet of GitHub Actions or GitLab CI/CD self-hosted build runners — multiple concurrent, resource-capped runner slots as Docker containers (no VM), with warm shared caches on a fast pool, idle-buffer autoscaling, and Docker-in-Docker for services and image builds.
 [br][br]
-Point it at a repo or organization, paste a GitHub token, and your CI runs on your own hardware — as many jobs in parallel as your box can handle, with pnpm/npm/yarn/Playwright caches that stay hot between runs, at zero cost per minute. Everything is configured from a single webGUI page: store your token, Start/Stop/Restart/Scale, watch live status, and build your runner image.
+Select one active provider, save a GitHub PAT or modern GitLab glrt- runner token, and run CI on your own hardware. GitLab mode uses the official Runner manager and Docker executor; GitHub mode retains the existing runner-container workflow. Everything is configured from a single webGUI page.
 [br][br]
-[b]Security:[/b] self-hosted runners execute arbitrary workflow code on your hardware, and DinD runners run privileged. Use them only for trusted/private repositories — never let public/fork-PR code run on a privileged self-hosted runner. The plugin actively warns you when a privileged runner is pointed at a public repo. See the README for full guidance.
+[b]Security:[/b] self-hosted runners execute arbitrary pipeline code on your hardware, and DinD runners run privileged. Per-slot DinD avoids exposing Unraid's existing Docker socket but is not a host security boundary. Use runners only for trusted/private projects and repositories — never let public fork or merge-request code run on a privileged self-hosted runner. See the README for full guidance.
 </Description>
 <Requires>
 [b]&#9888; Security — this plugin runs arbitrary CI code as root on your server.[/b]
 [br][br]
-CI Runner Farm executes GitHub Actions jobs in [b]privileged Docker-in-Docker[/b] containers on this Unraid box. Any workflow scheduled onto the fleet — [b]including a pull request from a fork of a public repo[/b] — runs with root-equivalent access to the host Docker daemon and to any shares you expose to it.
+CI Runner Farm can execute GitHub Actions or GitLab CI/CD jobs with a [b]privileged Docker-in-Docker[/b] daemon on this Unraid box. Any pipeline scheduled onto the fleet — [b]including public fork or merge-request code if provider protections are misconfigured[/b] — can control its slot's job, helper, and service containers. Per-slot DinD reduces accidental cross-slot access but is not a host security boundary; host-socket mode directly grants root-equivalent access to Unraid's existing Docker daemon.
 [br][br]
-[b]Only run trusted workflows on trusted runners.[/b] Point the fleet at [b]private / trusted repositories only[/b]; never let public or fork-PR code run on a privileged self-hosted runner. At org scope, use a runner group restricted to your private repos. The plugin also warns you live in its settings page if it detects a public repo on a privileged fleet.
+[b]Only run trusted pipelines on trusted runners.[/b] Restrict the fleet to [b]private / trusted projects and repositories[/b]; use GitHub runner groups or GitLab protected runners, tags, and project/group scope. Never expose the Unraid Docker socket to untrusted code.
 [br][br]
 By installing you acknowledge these risks and accept responsibility for what runs on your fleet.
 </Requires>

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,29 +1,279 @@
 #!/bin/bash
-# Safe RAW deploy of the plugin runtime to an Unraid host (dev iteration only).
-# ALWAYS chowns root:root + sets explicit perms after copying, so a raw deploy
-# can never leave non-root files that would break the GUI/SSH. For real installs
-# use the .plg (build-plg.sh) — this is just for fast iteration on a dev box.
+# Deploy the complete plugin runtime to a disposable Unraid host with a staged,
+# rollback-protected tree replacement.
+#
+# This is a development shortcut, not an installer. The source tree is uploaded
+# to a staging directory, validated, assigned the same ownership/modes as the
+# packaged plugin, and only then swapped into place. A failed upload therefore
+# leaves the currently installed runtime untouched.
 set -euo pipefail
 
-HOST="${1:?usage: ./deploy.sh root@host}"
+HOST="${1:-}"
+if [ -z "$HOST" ] || [ "$HOST" = "-h" ] || [ "$HOST" = "--help" ]; then
+  echo "usage: ./deploy.sh root@unraid-host" >&2
+  exit 2
+fi
+case "$HOST" in
+  -*) echo "deploy: host must not begin with '-': $HOST" >&2; exit 2 ;;
+esac
+
 NAME="ci-runner-farm"
-SRC="src/usr/local/emhttp/plugins/${NAME}"
-DEST="/usr/local/emhttp/plugins/${NAME}"
-cd "$(dirname "$0")"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC="$SCRIPT_DIR/src/usr/local/emhttp/plugins/$NAME"
+DEST="/usr/local/emhttp/plugins/$NAME"
 
-echo "[deploy] syncing $SRC -> $HOST:$DEST"
-ssh "$HOST" "mkdir -p '$DEST/include'"
-scp -q "$SRC/RunnerFarm.page" "$SRC/RunnerFarmDashboard.page" "$SRC/default.cfg" "$SRC/default.Dockerfile" "$SRC/README.md" "$HOST:$DEST/"
-ssh "$HOST" "mkdir -p '$DEST/nchan'"
-scp -q "$SRC"/nchan/* "$HOST:$DEST/nchan/"
-scp -q "$SRC"/include/* "$HOST:$DEST/include/"
+# These sentinels catch a wrong checkout/path before anything is sent. The tar
+# stream below contains everything else too, including all .page, event, nchan,
+# Dockerfile, and include files; new runtime files need no deploy-script update.
+for required in \
+  RunnerFarm.page RunnerFarmDashboard.page RunnerFarmFleet.page RunnerFarmImage.page RunnerFarmSettings.page \
+  default.cfg default.Dockerfile default.github.Dockerfile default.gitlab.Dockerfile \
+  include/runner-farm.sh include/exec.php include/crf-core.php include/providers/github.sh include/providers/gitlab.sh \
+  event/docker_started event/stopping_docker \
+  nchan/ci_runner_farm README.md
+do
+  if [ ! -f "$SRC/$required" ]; then
+    echo "deploy: required runtime file is missing: $SRC/$required" >&2
+    exit 1
+  fi
+done
 
-echo "[deploy] enforcing root:root + perms on $HOST"
-ssh "$HOST" "
-  chown -R root:root '$DEST'
-  find '$DEST' -type d -exec chmod 0755 {} +
-  find '$DEST' -type f -exec chmod 0644 {} +
-  chmod 0755 '$DEST/include/runner-farm.sh'
-  find '$DEST/nchan' -type f -exec chmod 0755 {} + 2>/dev/null || true  # monitor_nchan execs the publisher
-  echo '[deploy] done:'; ls -la '$DEST'
-"
+echo "[deploy] staging complete runtime tree for $HOST:$DEST"
+REMOTE_STAGE="$(ssh -- "$HOST" "umask 022; mktemp -d '${DEST}.deploy.XXXXXX'")"
+case "$REMOTE_STAGE" in
+  "$DEST".deploy.*) ;;
+  *) echo "deploy: remote host returned an unsafe staging path: $REMOTE_STAGE" >&2; exit 1 ;;
+esac
+
+cleanup_stage() {
+  ssh -- "$HOST" "rm -rf -- '$REMOTE_STAGE'" >/dev/null 2>&1 || true
+}
+trap cleanup_stage EXIT HUP INT TERM
+
+# A tar stream is available on stock Unraid and preserves the full directory
+# layout without relying on shell globs (which previously omitted pages/events).
+# macOS otherwise synthesizes AppleDouble `._*` members for local extended
+# attributes; those are not runtime files and must never reach the Unraid tree.
+COPYFILE_DISABLE=1 tar --no-xattrs -C "$SRC" -cf - . | ssh -- "$HOST" "tar -xf - -C '$REMOTE_STAGE'"
+
+# Validate and permission the staging tree, then swap it in. The previous tree
+# is retained until the new one is installed so an interrupted deploy rolls back.
+ssh -- "$HOST" /bin/bash -s -- "$DEST" "$REMOTE_STAGE" <<'REMOTE'
+set -euo pipefail
+dest="$1"
+stage="$2"
+
+if [ "$dest" != "/usr/local/emhttp/plugins/ci-runner-farm" ]; then
+  echo "deploy: refusing unexpected destination: $dest" >&2
+  exit 1
+fi
+case "$stage" in
+  "$dest".deploy.*) ;;
+  *) echo "deploy: refusing unexpected staging path: $stage" >&2; exit 1 ;;
+esac
+
+for required in \
+  RunnerFarm.page RunnerFarmDashboard.page RunnerFarmFleet.page RunnerFarmImage.page RunnerFarmSettings.page \
+  default.cfg default.Dockerfile default.github.Dockerfile default.gitlab.Dockerfile \
+  include/runner-farm.sh include/exec.php include/crf-core.php include/providers/github.sh include/providers/gitlab.sh \
+  event/docker_started event/stopping_docker \
+  nchan/ci_runner_farm README.md
+do
+  [ -f "$stage/$required" ] || {
+    echo "deploy: staged runtime is incomplete: $required" >&2
+    exit 1
+  }
+done
+
+appledouble_files="$(find "$stage" -name '._*' -print)" || {
+  echo "deploy: cannot inspect the staged runtime for macOS metadata" >&2
+  exit 1
+}
+if [ -n "$appledouble_files" ]; then
+  echo "deploy: staged runtime contains unexpected macOS AppleDouble metadata" >&2
+  printf '%s\n' "$appledouble_files" >&2
+  exit 1
+fi
+
+chown -R root:root "$stage"
+find "$stage" -type d -exec chmod 0755 {} +
+find "$stage" -type f -exec chmod 0644 {} +
+chmod 0755 "$stage/include/runner-farm.sh"
+find "$stage/nchan" -type f -exec chmod 0755 {} + 2>/dev/null || true
+find "$stage/event" -type f -exec chmod 0755 {} + 2>/dev/null || true
+
+# Use the exact runtime lock location/fallback used by the installed engine. Hold
+# it from the final inactive-state snapshot through the tree swap, preventing a
+# concurrent Start/Scale/Recycle or daemon tick from passing the check on the old
+# code and mutating the fleet while the replacement is installed.
+cfgdir="/boot/config/plugins/ci-runner-farm"
+rundir="/var/local/emhttp/ci-runner-farm"
+if ! mkdir -p "$rundir" 2>/dev/null; then
+  rundir="$cfgdir"
+  mkdir -p "$rundir" || {
+    echo "deploy: cannot create the installed runtime lock directory" >&2
+    exit 1
+  }
+fi
+command -v flock >/dev/null 2>&1 || {
+  echo "deploy: flock is unavailable; refusing an unlocked runtime replacement" >&2
+  exit 1
+}
+exec 8>"$rundir/fleet.lock" || {
+  echo "deploy: cannot open the installed CI Runner Farm fleet lock" >&2
+  exit 1
+}
+flock -w 20 8 || {
+  echo "deploy: CI Runner Farm is busy; Stop it and retry deployment" >&2
+  exit 1
+}
+
+# A daemon keeps the old script inode open after an atomic swap, while new web
+# requests execute the replacement. Refuse that mixed-version state instead of
+# implicitly stopping jobs on a development host. Query every Docker ownership
+# contract emitted by the runtime, not only running managers: stopped managers,
+# GitHub validations, persistent DinD sidecars, GitLab host-socket workloads,
+# GitLab validation jobs, and the shared registry mirror all retain state made by
+# the old code. The resource and validation queries use their complete
+# class-specific label intersections, so an unrelated Docker object cannot block
+# deployment merely because it carries one generic-looking label. Any inability
+# to query Docker/pgrep fails closed.
+command -v docker >/dev/null 2>&1 || {
+  echo "deploy: Docker CLI is unavailable; cannot prove the fleet is inactive" >&2
+  exit 1
+}
+owned_managers="$(docker ps -a \
+  --filter 'label=net.unraid.ci-runner-farm.managed=true' \
+  --format '{{.Names}}' 2>/dev/null)" || {
+  echo "deploy: cannot enumerate CI Runner Farm managers; refusing deployment" >&2
+  exit 1
+}
+owned_sidecars="$(docker ps -a \
+  --filter 'label=net.unraid.ci-runner-farm.sidecar=true' \
+  --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' \
+  --filter 'label=net.unraid.ci-runner-farm.role=dind' \
+  --format '{{.Names}}' 2>/dev/null)" || {
+  echo "deploy: cannot enumerate GitLab DinD sidecars; refusing deployment" >&2
+  exit 1
+}
+owned_host_jobs="$(docker ps -a \
+  --filter 'label=com.gitlab.gitlab-runner.managed=true' \
+  --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' \
+  --filter 'label=net.unraid.ci-runner-farm.slot' \
+  --format '{{.Names}}' 2>/dev/null)" || {
+  echo "deploy: cannot enumerate GitLab host-socket jobs/helpers/services; refusing deployment" >&2
+  exit 1
+}
+owned_mirrors="$(docker ps -a \
+  --filter 'label=net.unraid.ci-runner-farm.resource=true' \
+  --filter 'label=net.unraid.ci-runner-farm.role=mirror' \
+  --format '{{.Names}}' 2>/dev/null)" || {
+  echo "deploy: cannot enumerate shared registry mirrors; refusing deployment" >&2
+  exit 1
+}
+# Releases before mirror ownership labels used the same fixed name. Recognize
+# that one upgrade object only by the engine's complete legacy provenance tuple;
+# an unrelated container named ci-runner-mirror must not block deployment.
+all_container_names="$(docker ps -a --format '{{.Names}}' 2>/dev/null)" || {
+  echo "deploy: cannot enumerate Docker names for legacy mirror verification; refusing deployment" >&2
+  exit 1
+}
+owned_legacy_mirrors=""
+if [ -z "$owned_mirrors" ] \
+   && printf '%s\n' "$all_container_names" | grep -qxF 'ci-runner-mirror'; then
+  legacy_cache_root="/mnt/cache/github-runner"
+  cfg="$cfgdir/ci-runner-farm.cfg"
+  if [ -e "$cfg" ]; then
+    [ -r "$cfg" ] || {
+      echo "deploy: cannot read plugin config for legacy mirror verification; refusing deployment" >&2
+      exit 1
+    }
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in ''|\#*) continue ;; esac
+      [ "${line#*=}" = "$line" ] && continue
+      key="${line%%=*}"; value="${line#*=}"
+      key="${key//[[:space:]]/}"
+      [ "$key" = CACHE_ROOT ] || continue
+      value="${value%\"}"; value="${value#\"}"
+      value="${value%\'}"; value="${value#\'}"
+      legacy_cache_root="$value"
+    done < "$cfg"
+  fi
+  legacy_name="$(docker inspect -f '{{.Name}}' ci-runner-mirror 2>/dev/null)" \
+    && legacy_image="$(docker inspect -f '{{.Config.Image}}' ci-runner-mirror 2>/dev/null)" \
+    && legacy_source="$(docker inspect -f '{{range .Mounts}}{{if eq .Destination "/var/lib/registry"}}{{.Source}}{{end}}{{end}}' ci-runner-mirror 2>/dev/null)" \
+    && legacy_env="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' ci-runner-mirror 2>/dev/null)" \
+    || {
+      echo "deploy: cannot verify fixed-name registry mirror provenance; refusing deployment" >&2
+      exit 1
+    }
+  if [ "$legacy_name" = /ci-runner-mirror ] \
+     && [ "$legacy_image" = registry:2 ] \
+     && [ "$legacy_source" = "$legacy_cache_root/registry-mirror" ] \
+     && printf '%s\n' "$legacy_env" | grep -qx 'REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io'; then
+    owned_legacy_mirrors=ci-runner-mirror
+  fi
+fi
+owned_github_validations="$(docker ps -a \
+  --filter 'label=net.unraid.ci-runner-farm.managed=true' \
+  --filter 'label=net.unraid.ci-runner-farm.provider=github' \
+  --filter 'label=net.unraid.ci-runner-farm.role=validate' \
+  --format '{{.Names}}' 2>/dev/null)" || {
+  echo "deploy: cannot enumerate GitHub validation containers; refusing deployment" >&2
+  exit 1
+}
+owned_gitlab_validations="$(docker ps -a \
+  --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' \
+  --filter 'label=net.unraid.ci-runner-farm.role=validate-job' \
+  --filter 'label=net.unraid.ci-runner-farm.slot' \
+  --format '{{.Names}}' 2>/dev/null)" || {
+  echo "deploy: cannot enumerate GitLab validation jobs; refusing deployment" >&2
+  exit 1
+}
+if [ -n "$owned_managers" ] || [ -n "$owned_sidecars" ] || [ -n "$owned_host_jobs" ] \
+   || [ -n "$owned_mirrors" ] || [ -n "$owned_legacy_mirrors" ] \
+   || [ -n "$owned_github_validations" ] \
+   || [ -n "$owned_gitlab_validations" ]; then
+  echo "deploy: CI Runner Farm still owns Docker objects; Stop/clean the fleet before deploying" >&2
+  [ -z "$owned_managers" ] || printf '  managers:\n%s\n' "$owned_managers" >&2
+  [ -z "$owned_sidecars" ] || printf '  GitLab sidecars:\n%s\n' "$owned_sidecars" >&2
+  [ -z "$owned_host_jobs" ] || printf '  GitLab jobs/helpers/services:\n%s\n' "$owned_host_jobs" >&2
+  [ -z "$owned_mirrors" ] || printf '  registry mirrors:\n%s\n' "$owned_mirrors" >&2
+  [ -z "$owned_legacy_mirrors" ] || printf '  legacy registry mirrors:\n%s\n' "$owned_legacy_mirrors" >&2
+  [ -z "$owned_github_validations" ] || printf '  GitHub validations:\n%s\n' "$owned_github_validations" >&2
+  [ -z "$owned_gitlab_validations" ] || printf '  GitLab validation jobs:\n%s\n' "$owned_gitlab_validations" >&2
+  exit 1
+fi
+
+daemon_check=0
+pgrep -f '[r]unner-farm.sh (autoscale-daemon|imageupdate-daemon|reconcile-drain|boot-autostart)' >/dev/null 2>&1 \
+  || daemon_check=$?
+case "$daemon_check" in
+  0)
+    echo "deploy: a CI Runner Farm background daemon is active; Stop the fleet before deploying" >&2
+    exit 1 ;;
+  1) ;;
+  *)
+    echo "deploy: cannot verify CI Runner Farm background-daemon state; refusing deployment" >&2
+    exit 1 ;;
+esac
+
+backup="${dest}.deploy-backup.$$"
+rollback() {
+  status=$?
+  if [ ! -e "$dest" ] && [ -e "$backup" ]; then mv "$backup" "$dest"; fi
+  exit "$status"
+}
+trap rollback ERR HUP INT TERM
+
+if [ -e "$dest" ]; then mv "$dest" "$backup"; fi
+mv "$stage" "$dest"
+rm -rf -- "$backup"
+trap - ERR HUP INT TERM
+
+echo "[deploy] installed complete runtime tree:"
+find "$dest" -maxdepth 2 -type f -print | sort
+REMOTE
+
+trap - EXIT HUP INT TERM
+echo "[deploy] done"

--- a/deploy.sh
+++ b/deploy.sh
@@ -41,7 +41,14 @@ done
 echo "[deploy] staging complete runtime tree for $HOST:$DEST"
 REMOTE_STAGE="$(ssh -- "$HOST" "umask 022; mktemp -d '${DEST}.deploy.XXXXXX'")"
 case "$REMOTE_STAGE" in
-  "$DEST".deploy.*) ;;
+  "$DEST".deploy.*)
+    remote_stage_suffix="${REMOTE_STAGE#"$DEST".deploy.}"
+    case "$remote_stage_suffix" in
+      ''|*[!A-Za-z0-9]*)
+        echo "deploy: remote host returned an unsafe staging path: $REMOTE_STAGE" >&2
+        exit 1 ;;
+    esac
+    ;;
   *) echo "deploy: remote host returned an unsafe staging path: $REMOTE_STAGE" >&2; exit 1 ;;
 esac
 
@@ -68,7 +75,14 @@ if [ "$dest" != "/usr/local/emhttp/plugins/ci-runner-farm" ]; then
   exit 1
 fi
 case "$stage" in
-  "$dest".deploy.*) ;;
+  "$dest".deploy.*)
+    stage_suffix="${stage#"$dest".deploy.}"
+    case "$stage_suffix" in
+      ''|*[!A-Za-z0-9]*)
+        echo "deploy: refusing unexpected staging path: $stage" >&2
+        exit 1 ;;
+    esac
+    ;;
   *) echo "deploy: refusing unexpected staging path: $stage" >&2; exit 1 ;;
 esac
 
@@ -99,8 +113,8 @@ chown -R root:root "$stage"
 find "$stage" -type d -exec chmod 0755 {} +
 find "$stage" -type f -exec chmod 0644 {} +
 chmod 0755 "$stage/include/runner-farm.sh"
-find "$stage/nchan" -type f -exec chmod 0755 {} + 2>/dev/null || true
-find "$stage/event" -type f -exec chmod 0755 {} + 2>/dev/null || true
+find "$stage/nchan" -type f -exec chmod 0755 {} +
+find "$stage/event" -type f -exec chmod 0755 {} +
 
 # Use the exact runtime lock location/fallback used by the installed engine. Hold
 # it from the final inactive-state snapshot through the tree swap, preventing a
@@ -261,10 +275,14 @@ esac
 backup="${dest}.deploy-backup.$$"
 rollback() {
   status=$?
+  if [ "$#" -gt 0 ]; then status="$1"; fi
   if [ ! -e "$dest" ] && [ -e "$backup" ]; then mv "$backup" "$dest"; fi
   exit "$status"
 }
-trap rollback ERR HUP INT TERM
+trap rollback ERR
+trap 'rollback 129' HUP
+trap 'rollback 130' INT
+trap 'rollback 143' TERM
 
 if [ -e "$dest" ]; then mv "$dest" "$backup"; fi
 mv "$stage" "$dest"

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -157,7 +157,6 @@ PY
   IFS=$'\t' read -r PACKAGE_FILE PACKAGE_SHA256 PLUGIN_SHA256 MANIFEST_SHA256 <<< "$values"
   [ -n "$PACKAGE_FILE" ] && [ -n "$PACKAGE_SHA256" ] && [ -n "$PLUGIN_SHA256" ] && [ -n "$MANIFEST_SHA256" ] \
     || die "bundle validator returned an incomplete result"
-  PACKAGE="$BUNDLE_DIR/$PACKAGE_FILE"
 }
 
 if [ "$ACTION" = install ]; then
@@ -233,6 +232,24 @@ canonical_cfg=/boot/config/plugins/ci-runner-farm
 dev_root=/boot/config/ci-runner-farm-dev
 rollback="$dev_root/rollback"
 artifacts="$dev_root/artifacts"
+rollback_tmp=
+commit_tmp=
+cleanup_install_temps() {
+  local status=$?
+  trap - EXIT
+  case "$rollback_tmp" in
+    '') ;;
+    "$dev_root"/.rollback.*) rm -rf -- "$rollback_tmp" || status=1 ;;
+    *) printf 'install-dev remote: refusing to clean unsafe rollback temporary path: %s\n' "$rollback_tmp" >&2; status=1 ;;
+  esac
+  case "$commit_tmp" in
+    '') ;;
+    "$artifacts"/.commit.*) rm -f -- "$commit_tmp" || status=1 ;;
+    *) printf 'install-dev remote: refusing to clean unsafe artifact temporary path: %s\n' "$commit_tmp" >&2; status=1 ;;
+  esac
+  exit "$status"
+}
+trap cleanup_install_temps EXIT
 umask 077
 mkdir -p "$dev_root"
 [ -d "$dev_root" ] && [ ! -L "$dev_root" ] || fail "development state root is unsafe"
@@ -298,6 +315,7 @@ else
   find "$rollback_tmp" -type d -exec chmod 0700 {} +
   find "$rollback_tmp" -type f -exec chmod 0600 {} +
   mv -- "$rollback_tmp" "$rollback"
+  rollback_tmp=
   validate_baseline
 fi
 
@@ -339,18 +357,19 @@ fi
 chmod 0700 "$artifacts"
 
 commit_artifact() {
-  local source="$1" destination="$2" expected="$3" tmp
+  local source="$1" destination="$2" expected="$3"
   if [ -e "$destination" ] || [ -L "$destination" ]; then
     regular_file "$destination" || fail "artifact destination is unsafe: $destination"
     [ "$(sha256_of "$destination")" = "$expected" ] \
       || fail "artifact basename already exists with different bytes: $destination"
     return 0
   fi
-  tmp="$(mktemp "$artifacts/.commit.XXXXXX")"
-  cp -- "$source" "$tmp"
-  chmod 0600 "$tmp"
-  [ "$(sha256_of "$tmp")" = "$expected" ] || fail "artifact changed during commit"
-  mv -- "$tmp" "$destination"
+  commit_tmp="$(mktemp "$artifacts/.commit.XXXXXX")"
+  cp -- "$source" "$commit_tmp"
+  chmod 0600 "$commit_tmp"
+  [ "$(sha256_of "$commit_tmp")" = "$expected" ] || fail "artifact changed during commit"
+  mv -- "$commit_tmp" "$destination"
+  commit_tmp=
   [ "$(sha256_of "$destination")" = "$expected" ] || fail "committed artifact verification failed"
 }
 
@@ -453,7 +472,32 @@ docker_names "GitLab validation jobs" \
 all_names="$(docker ps -a --format '{{.Names}}' 2>/dev/null)" \
   || fail "cannot enumerate Docker names for legacy mirror verification"
 if printf '%s\n' "$all_names" | grep -qxF ci-runner-mirror; then
-  fail "fixed-name registry mirror remains after Stop"
+  legacy_cache_root=/mnt/cache/github-runner
+  cfg="$canonical_cfg/ci-runner-farm.cfg"
+  if [ -e "$cfg" ]; then
+    [ -r "$cfg" ] || fail "cannot read plugin config for legacy mirror verification"
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in ''|\#*) continue ;; esac
+      [ "${line#*=}" = "$line" ] && continue
+      key="${line%%=*}"; value="${line#*=}"
+      key="${key//[[:space:]]/}"
+      [ "$key" = CACHE_ROOT ] || continue
+      value="${value%\"}"; value="${value#\"}"
+      value="${value%\'}"; value="${value#\'}"
+      legacy_cache_root="$value"
+    done < "$cfg"
+  fi
+  legacy_name="$(docker inspect -f '{{.Name}}' ci-runner-mirror 2>/dev/null)" \
+    && legacy_image="$(docker inspect -f '{{.Config.Image}}' ci-runner-mirror 2>/dev/null)" \
+    && legacy_source="$(docker inspect -f '{{range .Mounts}}{{if eq .Destination "/var/lib/registry"}}{{.Source}}{{end}}{{end}}' ci-runner-mirror 2>/dev/null)" \
+    && legacy_env="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' ci-runner-mirror 2>/dev/null)" \
+    || fail "cannot verify fixed-name registry mirror provenance"
+  if [ "$legacy_name" = /ci-runner-mirror ] \
+     && [ "$legacy_image" = registry:2 ] \
+     && [ "$legacy_source" = "$legacy_cache_root/registry-mirror" ] \
+     && printf '%s\n' "$legacy_env" | grep -qx 'REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io'; then
+    fail "fixed-name registry mirror remains after Stop"
+  fi
 fi
 daemon_status=0
 pgrep -f '[r]unner-farm.sh (autoscale-daemon|imageupdate-daemon|reconcile-drain|boot-autostart)' >/dev/null 2>&1 \

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -1,0 +1,547 @@
+#!/usr/bin/env bash
+# Persist a `build-plg.sh --dev` bundle on a disposable Unraid development host.
+# The live runtime is replaced by deploy.sh before any boot-time descriptor is
+# changed.  Rollback restores only flash artifacts and deliberately requires a
+# reboot instead of overlaying an old runtime onto the running system.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUNDLE_DIR="$SCRIPT_DIR/tmp/dev-package"
+MANIFEST="$BUNDLE_DIR/manifest.json"
+PLUGIN="$BUNDLE_DIR/ci-runner-farm.plg"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: ./install-dev.sh root@unraid-host
+       ./install-dev.sh --rollback root@unraid-host
+EOF
+  exit 2
+}
+
+die() { printf 'install-dev: %s\n' "$*" >&2; exit 1; }
+
+ACTION=install
+case "$#:${1:-}" in
+  1:*) HOST="$1" ;;
+  2:--rollback) ACTION=rollback; HOST="$2" ;;
+  *) usage ;;
+esac
+
+# Keep HOST usable as one opaque ssh argument and as an scp/tar peer.  In
+# particular, reject options, ports, IPv6 brackets, whitespace, and shell
+# syntax.  Unraid administration for these paths must be performed as root.
+case "$HOST" in
+  root@[A-Za-z0-9]* ) ;;
+  *) die "host must be root@ followed by a simple SSH hostname or IPv4 address" ;;
+esac
+case "${HOST#root@}" in
+  *[!A-Za-z0-9._-]*|'') die "unsafe host: $HOST" ;;
+esac
+
+command -v ssh >/dev/null 2>&1 || die "ssh is required"
+
+validate_bundle() {
+  command -v python3 >/dev/null 2>&1 || die "python3 is required to validate the development bundle"
+  [ -f "$MANIFEST" ] && [ ! -L "$MANIFEST" ] || die "missing regular manifest: $MANIFEST"
+  [ -f "$PLUGIN" ] && [ ! -L "$PLUGIN" ] || die "missing regular plugin descriptor: $PLUGIN"
+
+  local values
+  if ! values="$(python3 - "$MANIFEST" "$PLUGIN" "$BUNDLE_DIR" <<'PY'
+import hashlib
+import json
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+manifest_path, plugin_path, bundle_dir = sys.argv[1:]
+
+def fail(message):
+    raise SystemExit("install-dev: bundle validation failed: " + message)
+
+try:
+    with open(manifest_path, "r", encoding="utf-8") as stream:
+        manifest = json.load(stream)
+except (OSError, ValueError) as exc:
+    fail(f"invalid manifest JSON: {exc}")
+
+keys = {
+    "schema", "name", "mode", "version", "plugin_file", "package_file",
+    "package_md5", "package_sha256", "source_path", "runtime_root",
+}
+if not isinstance(manifest, dict) or set(manifest) != keys:
+    fail("manifest fields do not exactly match schema 1")
+if type(manifest["schema"]) is not int or manifest["schema"] != 1:
+    fail("schema must be integer 1")
+for key in keys - {"schema"}:
+    if not isinstance(manifest[key], str):
+        fail(f"{key} must be a string")
+if manifest["name"] != "ci-runner-farm" or manifest["mode"] != "dev":
+    fail("manifest is not a ci-runner-farm development bundle")
+if manifest["plugin_file"] != "ci-runner-farm.plg":
+    fail("unexpected plugin_file")
+if manifest["runtime_root"] != "src/usr/local/emhttp/plugins/ci-runner-farm":
+    fail("unexpected runtime_root")
+if not re.fullmatch(r"[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]{4}\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?", manifest["version"]):
+    fail("unsafe external version")
+expected_package = f'ci-runner-farm-jcuratec-dev-{manifest["version"]}.tgz'
+if manifest["package_file"] != expected_package or os.path.basename(expected_package) != expected_package:
+    fail("package_file does not match the external version")
+if not re.fullmatch(r"[0-9a-f]{32}", manifest["package_md5"]):
+    fail("package_md5 must be lowercase hexadecimal")
+if not re.fullmatch(r"[0-9a-f]{64}", manifest["package_sha256"]):
+    fail("package_sha256 must be lowercase hexadecimal")
+expected_source = "/boot/config/ci-runner-farm-dev/artifacts/" + expected_package
+if manifest["source_path"] != expected_source:
+    fail("source_path is outside the dedicated development artifact directory")
+
+package_path = os.path.join(bundle_dir, expected_package)
+if not os.path.isfile(package_path) or os.path.islink(package_path):
+    fail("versioned package is missing, non-regular, or a symlink")
+
+def digest(path, algorithm):
+    value = hashlib.new(algorithm)
+    with open(path, "rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            value.update(block)
+    return value.hexdigest()
+
+if digest(package_path, "md5") != manifest["package_md5"]:
+    fail("package MD5 does not match the manifest")
+if digest(package_path, "sha256") != manifest["package_sha256"]:
+    fail("package SHA-256 does not match the manifest")
+
+try:
+    tree = ET.parse(plugin_path)
+except (OSError, ET.ParseError) as exc:
+    fail(f"invalid plugin XML: {exc}")
+root = tree.getroot()
+if root.tag != "PLUGIN" or root.attrib.get("name") != manifest["name"]:
+    fail("plugin root/name does not match the manifest")
+if root.attrib.get("version") != manifest["version"]:
+    fail("plugin version does not match the manifest")
+package_nodes = [node for node in root.findall("FILE") if "Name" in node.attrib]
+if len(package_nodes) != 1:
+    fail("plugin must contain exactly one named package FILE")
+node = package_nodes[0]
+if node.attrib.get("Name") != "/tmp/" + manifest["package_file"]:
+    fail("plugin package FILE does not use the isolated temporary destination")
+local_node = node.find("LOCAL")
+if local_node is None or (local_node.text or "").strip() != manifest["source_path"]:
+    fail("plugin package LOCAL source does not match manifest source_path")
+md5_node = node.find("MD5")
+if md5_node is None or (md5_node.text or "").strip() != manifest["package_md5"]:
+    fail("plugin package MD5 does not match the manifest")
+sha_node = node.find("SHA256")
+if sha_node is None or (sha_node.text or "").strip() != manifest["package_sha256"]:
+    fail("plugin package SHA-256 does not match the manifest")
+
+raw = open(plugin_path, "r", encoding="utf-8").read()
+for entity, expected in (
+    ("version", manifest["version"]),
+    ("packageName", manifest["package_file"]),
+    ("packageMD5", manifest["package_md5"]),
+):
+    matches = re.findall(rf'^<!ENTITY {entity}[ \t]+"([^"]*)">$', raw, re.MULTILINE)
+    if matches != [expected]:
+        fail(f"plugin {entity} entity is missing or ambiguous")
+
+print("\t".join((
+    manifest["package_file"], manifest["package_sha256"],
+    digest(plugin_path, "sha256"), digest(manifest_path, "sha256"),
+)))
+PY
+)"; then
+    exit 1
+  fi
+  IFS=$'\t' read -r PACKAGE_FILE PACKAGE_SHA256 PLUGIN_SHA256 MANIFEST_SHA256 <<< "$values"
+  [ -n "$PACKAGE_FILE" ] && [ -n "$PACKAGE_SHA256" ] && [ -n "$PLUGIN_SHA256" ] && [ -n "$MANIFEST_SHA256" ] \
+    || die "bundle validator returned an incomplete result"
+  PACKAGE="$BUNDLE_DIR/$PACKAGE_FILE"
+}
+
+if [ "$ACTION" = install ]; then
+  validate_bundle
+
+  # This is intentionally the first remote mutation.  deploy.sh holds the
+  # engine lock, proves every fleet resource inactive, and swaps the live tree
+  # atomically.  A failure must leave flash persistence untouched.
+  bash "$SCRIPT_DIR/deploy.sh" "$HOST"
+
+  REMOTE_STAGE="$(ssh -- "$HOST" "umask 077; mktemp -d /tmp/ci-runner-farm-dev.XXXXXX")" \
+    || die "could not create remote upload directory"
+  case "$REMOTE_STAGE" in
+    /tmp/ci-runner-farm-dev.* ) ;;
+    *) die "remote host returned an unsafe upload directory" ;;
+  esac
+  case "${REMOTE_STAGE#/tmp/ci-runner-farm-dev.}" in
+    ''|*[!A-Za-z0-9]*) die "remote host returned an unsafe upload directory" ;;
+  esac
+  cleanup_stage() {
+    ssh -- "$HOST" "rm -rf -- '$REMOTE_STAGE'" >/dev/null 2>&1 || true
+  }
+  trap cleanup_stage EXIT HUP INT TERM
+
+  tar -C "$BUNDLE_DIR" -cf - manifest.json ci-runner-farm.plg "$PACKAGE_FILE" \
+    | ssh -- "$HOST" "tar -xf - -C '$REMOTE_STAGE'"
+
+  ssh -- "$HOST" /bin/bash -s -- \
+    "$REMOTE_STAGE" "$PACKAGE_FILE" "$PACKAGE_SHA256" "$PLUGIN_SHA256" "$MANIFEST_SHA256" <<'REMOTE_INSTALL'
+set -euo pipefail
+stage="$1"
+package_name="$2"
+package_sha256="$3"
+plugin_sha256="$4"
+manifest_sha256="$5"
+
+fail() { printf 'install-dev remote: %s\n' "$*" >&2; exit 1; }
+sha256_of() { sha256sum "$1" | awk '{print $1}'; }
+entity_value() {
+  local file="$1" entity="$2" values count
+  values="$(sed -n "s/^<!ENTITY ${entity}[[:space:]]*\"\([^\"]*\)\">$/\\1/p" "$file")"
+  count="$(printf '%s\n' "$values" | sed '/^$/d' | wc -l | tr -d ' ')"
+  [ "$count" = 1 ] || return 1
+  printf '%s\n' "$values"
+}
+regular_file() { [ -f "$1" ] && [ ! -L "$1" ]; }
+
+case "$stage" in /tmp/ci-runner-farm-dev.*) ;; *) fail "unsafe upload directory" ;; esac
+case "${stage#/tmp/ci-runner-farm-dev.}" in ''|*[!A-Za-z0-9]*) fail "unsafe upload directory" ;; esac
+case "$package_name" in ci-runner-farm-*.tgz) ;; *) fail "unsafe package basename" ;; esac
+case "$package_name" in *[!A-Za-z0-9._-]*) fail "unsafe package basename" ;; esac
+case "$package_sha256:$plugin_sha256:$manifest_sha256" in
+  *[!0-9a-f:]* ) fail "unsafe SHA-256 argument" ;;
+esac
+[ "${#package_sha256}" = 64 ] && [ "${#plugin_sha256}" = 64 ] && [ "${#manifest_sha256}" = 64 ] \
+  || fail "invalid SHA-256 length"
+[ "$(id -u)" = 0 ] || fail "root SSH access is required"
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is unavailable"
+command -v flock >/dev/null 2>&1 || fail "flock is unavailable"
+
+uploaded_package="$stage/$package_name"
+uploaded_plugin="$stage/ci-runner-farm.plg"
+uploaded_manifest="$stage/manifest.json"
+for uploaded in "$uploaded_package" "$uploaded_plugin" "$uploaded_manifest"; do
+  regular_file "$uploaded" || fail "uploaded bundle contains a missing, non-regular, or symlinked file"
+done
+[ "$(sha256_of "$uploaded_package")" = "$package_sha256" ] || fail "uploaded package SHA-256 mismatch"
+[ "$(sha256_of "$uploaded_plugin")" = "$plugin_sha256" ] || fail "uploaded plugin SHA-256 mismatch"
+[ "$(sha256_of "$uploaded_manifest")" = "$manifest_sha256" ] || fail "uploaded manifest SHA-256 mismatch"
+
+canonical_plg=/boot/config/plugins/ci-runner-farm.plg
+canonical_cfg=/boot/config/plugins/ci-runner-farm
+dev_root=/boot/config/ci-runner-farm-dev
+rollback="$dev_root/rollback"
+artifacts="$dev_root/artifacts"
+umask 077
+mkdir -p "$dev_root"
+[ -d "$dev_root" ] && [ ! -L "$dev_root" ] || fail "development state root is unsafe"
+chmod 0700 "$dev_root"
+exec 9>"$dev_root/transaction.lock"
+flock -w 20 9 || fail "another development install/rollback transaction is active"
+
+validate_baseline() {
+  [ -d "$rollback" ] && [ ! -L "$rollback" ] || fail "rollback baseline is not a regular directory"
+  [ "$(stat -c '%a' "$rollback")" = 700 ] || fail "rollback baseline mode is not 0700"
+  regular_file "$rollback/state" || fail "rollback baseline state is missing or unsafe"
+  local state name expected actual
+  state="$(cat "$rollback/state")"
+  case "$state" in
+    absent)
+      [ ! -e "$rollback/ci-runner-farm.plg" ] && [ ! -L "$rollback/ci-runner-farm.plg" ] \
+        || fail "absent baseline unexpectedly contains a descriptor"
+      ;;
+    present)
+      regular_file "$rollback/ci-runner-farm.plg" || fail "baseline descriptor is missing or unsafe"
+      regular_file "$rollback/package-name" || fail "baseline package name is missing or unsafe"
+      regular_file "$rollback/descriptor.sha256" || fail "baseline descriptor hash is missing or unsafe"
+      regular_file "$rollback/package.sha256" || fail "baseline package hash is missing or unsafe"
+      name="$(cat "$rollback/package-name")"
+      case "$name" in ci-runner-farm-*.tgz) ;; *) fail "baseline package name is unsafe" ;; esac
+      case "$name" in */*|*' '*) fail "baseline package name is unsafe" ;; esac
+      regular_file "$rollback/packages/$name" || fail "baseline package is missing or unsafe"
+      [ "$(entity_value "$rollback/ci-runner-farm.plg" packageName)" = "$name" ] \
+        || fail "baseline descriptor/package mismatch"
+      expected="$(cat "$rollback/descriptor.sha256")"; actual="$(sha256_of "$rollback/ci-runner-farm.plg")"
+      [ "$expected" = "$actual" ] || fail "baseline descriptor hash mismatch"
+      expected="$(cat "$rollback/package.sha256")"; actual="$(sha256_of "$rollback/packages/$name")"
+      [ "$expected" = "$actual" ] || fail "baseline package hash mismatch"
+      ;;
+    *) fail "rollback baseline state is ambiguous" ;;
+  esac
+}
+
+if [ -e "$rollback" ] || [ -L "$rollback" ]; then
+  validate_baseline
+else
+  rollback_tmp="$(mktemp -d "$dev_root/.rollback.XXXXXX")"
+  chmod 0700 "$rollback_tmp"
+  if [ -e "$canonical_plg" ] || [ -L "$canonical_plg" ]; then
+    regular_file "$canonical_plg" || fail "canonical plugin descriptor is not a regular file"
+    baseline_name="$(entity_value "$canonical_plg" packageName)" \
+      || fail "canonical plugin packageName is missing or ambiguous"
+    case "$baseline_name" in ci-runner-farm-*.tgz) ;; *) fail "canonical package name is unsafe" ;; esac
+    case "$baseline_name" in */*|*' '*) fail "canonical package name is unsafe" ;; esac
+    baseline_package="$canonical_cfg/$baseline_name"
+    regular_file "$baseline_package" \
+      || fail "canonical descriptor's exact cached package is unavailable; refusing an incomplete baseline"
+    mkdir "$rollback_tmp/packages"
+    cp -- "$canonical_plg" "$rollback_tmp/ci-runner-farm.plg"
+    cp -- "$baseline_package" "$rollback_tmp/packages/$baseline_name"
+    printf '%s\n' present >"$rollback_tmp/state"
+    printf '%s\n' "$baseline_name" >"$rollback_tmp/package-name"
+    sha256_of "$rollback_tmp/ci-runner-farm.plg" >"$rollback_tmp/descriptor.sha256"
+    sha256_of "$rollback_tmp/packages/$baseline_name" >"$rollback_tmp/package.sha256"
+  else
+    printf '%s\n' absent >"$rollback_tmp/state"
+  fi
+  find "$rollback_tmp" -type d -exec chmod 0700 {} +
+  find "$rollback_tmp" -type f -exec chmod 0600 {} +
+  mv -- "$rollback_tmp" "$rollback"
+  validate_baseline
+fi
+
+# If a baseline already existed, refuse to replace an unrelated descriptor.
+# A recognized development descriptor must exactly match one of the immutable
+# copies retained beside its externally persisted package.
+known_dev_descriptor() {
+  local current_sha candidate
+  regular_file "$canonical_plg" || return 1
+  current_sha="$(sha256_of "$canonical_plg")"
+  [ -d "$artifacts" ] && [ ! -L "$artifacts" ] || return 1
+  for candidate in "$artifacts"/ci-runner-farm-*.plg; do
+    regular_file "$candidate" || continue
+    [ "$(sha256_of "$candidate")" = "$current_sha" ] && return 0
+  done
+  return 1
+}
+
+baseline_state="$(cat "$rollback/state")"
+if [ -e "$canonical_plg" ] || [ -L "$canonical_plg" ]; then
+  regular_file "$canonical_plg" || fail "canonical plugin descriptor is unsafe"
+  if [ "$baseline_state" = present ] \
+     && [ "$(sha256_of "$canonical_plg")" = "$(cat "$rollback/descriptor.sha256")" ]; then
+    :
+  elif known_dev_descriptor; then
+    :
+  else
+    fail "canonical descriptor is neither the baseline nor a retained development descriptor"
+  fi
+elif [ "$baseline_state" != absent ]; then
+  fail "canonical descriptor disappeared after a present baseline was recorded"
+fi
+
+if [ -e "$artifacts" ] || [ -L "$artifacts" ]; then
+  [ -d "$artifacts" ] && [ ! -L "$artifacts" ] || fail "development artifact directory is unsafe"
+else
+  mkdir "$artifacts"
+fi
+chmod 0700 "$artifacts"
+
+commit_artifact() {
+  local source="$1" destination="$2" expected="$3" tmp
+  if [ -e "$destination" ] || [ -L "$destination" ]; then
+    regular_file "$destination" || fail "artifact destination is unsafe: $destination"
+    [ "$(sha256_of "$destination")" = "$expected" ] \
+      || fail "artifact basename already exists with different bytes: $destination"
+    return 0
+  fi
+  tmp="$(mktemp "$artifacts/.commit.XXXXXX")"
+  cp -- "$source" "$tmp"
+  chmod 0600 "$tmp"
+  [ "$(sha256_of "$tmp")" = "$expected" ] || fail "artifact changed during commit"
+  mv -- "$tmp" "$destination"
+  [ "$(sha256_of "$destination")" = "$expected" ] || fail "committed artifact verification failed"
+}
+
+# The package is the boot-time source and therefore commits first.  The
+# retained descriptor/manifest are provenance records; the canonical plugin
+# descriptor is not changed until plugin install succeeds below.
+commit_artifact "$uploaded_package" "$artifacts/$package_name" "$package_sha256"
+dev_plugin_name="${package_name%.tgz}.plg"
+dev_manifest_name="${package_name%.tgz}.manifest.json"
+commit_artifact "$uploaded_plugin" "$artifacts/$dev_plugin_name" "$plugin_sha256"
+commit_artifact "$uploaded_manifest" "$artifacts/$dev_manifest_name" "$manifest_sha256"
+
+command -v plugin >/dev/null 2>&1 || fail "Unraid plugin command is unavailable"
+plugin install "$uploaded_plugin"
+
+regular_file "$canonical_plg" || fail "plugin install did not persist the canonical descriptor"
+[ "$(sha256_of "$canonical_plg")" = "$plugin_sha256" ] \
+  || fail "canonical descriptor verification failed after plugin install"
+[ "$(sha256_of "$artifacts/$package_name")" = "$package_sha256" ] \
+  || fail "external development package changed during plugin install"
+printf 'install-dev remote: development descriptor installed; rollback baseline retained at %s\n' "$rollback"
+REMOTE_INSTALL
+
+  trap - EXIT HUP INT TERM
+  cleanup_stage
+  printf 'install-dev: development bundle installed on %s\n' "$HOST"
+  exit 0
+fi
+
+# Rollback intentionally operates entirely from the verified flash baseline.
+# It never installs or overlays the baseline's old runtime.
+ssh -- "$HOST" /bin/bash -s <<'REMOTE_ROLLBACK'
+set -euo pipefail
+fail() { printf 'install-dev remote: %s\n' "$*" >&2; exit 1; }
+sha256_of() { sha256sum "$1" | awk '{print $1}'; }
+regular_file() { [ -f "$1" ] && [ ! -L "$1" ]; }
+entity_value() {
+  local file="$1" entity="$2" values count
+  values="$(sed -n "s/^<!ENTITY ${entity}[[:space:]]*\"\([^\"]*\)\">$/\\1/p" "$file")"
+  count="$(printf '%s\n' "$values" | sed '/^$/d' | wc -l | tr -d ' ')"
+  [ "$count" = 1 ] || return 1
+  printf '%s\n' "$values"
+}
+[ "$(id -u)" = 0 ] || fail "root SSH access is required"
+command -v docker >/dev/null 2>&1 || fail "Docker is unavailable"
+command -v flock >/dev/null 2>&1 || fail "flock is unavailable"
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is unavailable"
+
+canonical_plg=/boot/config/plugins/ci-runner-farm.plg
+canonical_cfg=/boot/config/plugins/ci-runner-farm
+dev_root=/boot/config/ci-runner-farm-dev
+rollback="$dev_root/rollback"
+artifacts="$dev_root/artifacts"
+engine=/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+regular_file "$engine" && [ -x "$engine" ] || fail "current cleanup engine is unavailable or unsafe"
+
+# Stop through the currently deployed engine.  Suppress its potentially broad
+# diagnostics rather than risk echoing credentials supplied by an external
+# command; the engine's own restricted boot log remains available on the host.
+if ! "$engine" stop >/dev/null 2>&1; then
+  fail "current engine Stop failed; no rollback files were changed"
+fi
+
+rundir=/var/local/emhttp/ci-runner-farm
+if ! mkdir -p "$rundir" 2>/dev/null; then
+  rundir=/boot/config/plugins/ci-runner-farm
+  mkdir -p "$rundir" || fail "cannot create the fleet lock directory"
+fi
+exec 8>"$rundir/fleet.lock"
+flock -w 20 8 || fail "fleet is busy after Stop"
+
+docker_names() {
+  local description="$1"; shift
+  local names
+  names="$(docker ps -a "$@" --format '{{.Names}}' 2>/dev/null)" \
+    || fail "cannot enumerate $description"
+  [ -z "$names" ] || fail "$description remain after Stop"
+}
+docker_names "runner managers" \
+  --filter 'label=net.unraid.ci-runner-farm.managed=true'
+docker_names "GitLab DinD sidecars" \
+  --filter 'label=net.unraid.ci-runner-farm.sidecar=true' \
+  --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' \
+  --filter 'label=net.unraid.ci-runner-farm.role=dind'
+docker_names "GitLab host-socket jobs/helpers/services" \
+  --filter 'label=com.gitlab.gitlab-runner.managed=true' \
+  --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' \
+  --filter 'label=net.unraid.ci-runner-farm.slot'
+docker_names "registry mirrors" \
+  --filter 'label=net.unraid.ci-runner-farm.resource=true' \
+  --filter 'label=net.unraid.ci-runner-farm.role=mirror'
+docker_names "GitHub validation containers" \
+  --filter 'label=net.unraid.ci-runner-farm.managed=true' \
+  --filter 'label=net.unraid.ci-runner-farm.provider=github' \
+  --filter 'label=net.unraid.ci-runner-farm.role=validate'
+docker_names "GitLab validation jobs" \
+  --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' \
+  --filter 'label=net.unraid.ci-runner-farm.role=validate-job' \
+  --filter 'label=net.unraid.ci-runner-farm.slot'
+all_names="$(docker ps -a --format '{{.Names}}' 2>/dev/null)" \
+  || fail "cannot enumerate Docker names for legacy mirror verification"
+if printf '%s\n' "$all_names" | grep -qxF ci-runner-mirror; then
+  fail "fixed-name registry mirror remains after Stop"
+fi
+daemon_status=0
+pgrep -f '[r]unner-farm.sh (autoscale-daemon|imageupdate-daemon|reconcile-drain|boot-autostart)' >/dev/null 2>&1 \
+  || daemon_status=$?
+case "$daemon_status" in
+  0) fail "CI Runner Farm background daemon remains after Stop" ;;
+  1) ;;
+  *) fail "cannot verify CI Runner Farm background daemon state" ;;
+esac
+
+[ -d "$rollback" ] && [ ! -L "$rollback" ] || fail "rollback baseline is unavailable or unsafe"
+[ "$(stat -c '%a' "$rollback")" = 700 ] || fail "rollback baseline mode is not 0700"
+regular_file "$rollback/state" || fail "rollback baseline state is unavailable or unsafe"
+state="$(cat "$rollback/state")"
+case "$state" in absent|present) ;; *) fail "rollback baseline state is ambiguous" ;; esac
+
+known_dev_descriptor() {
+  local current_sha candidate
+  regular_file "$canonical_plg" || return 1
+  current_sha="$(sha256_of "$canonical_plg")"
+  [ -d "$artifacts" ] && [ ! -L "$artifacts" ] || return 1
+  for candidate in "$artifacts"/ci-runner-farm-*.plg; do
+    regular_file "$candidate" || continue
+    [ "$(sha256_of "$candidate")" = "$current_sha" ] && return 0
+  done
+  return 1
+}
+
+baseline_name=
+baseline_descriptor_sha=
+baseline_package_sha=
+if [ "$state" = present ]; then
+  regular_file "$rollback/ci-runner-farm.plg" || fail "baseline descriptor is unavailable or unsafe"
+  regular_file "$rollback/package-name" || fail "baseline package name is unavailable or unsafe"
+  regular_file "$rollback/descriptor.sha256" || fail "baseline descriptor hash is unavailable or unsafe"
+  regular_file "$rollback/package.sha256" || fail "baseline package hash is unavailable or unsafe"
+  baseline_name="$(cat "$rollback/package-name")"
+  case "$baseline_name" in ci-runner-farm-*.tgz) ;; *) fail "baseline package name is unsafe" ;; esac
+  case "$baseline_name" in */*|*' '*) fail "baseline package name is unsafe" ;; esac
+  regular_file "$rollback/packages/$baseline_name" || fail "baseline package is unavailable or unsafe"
+  [ "$(entity_value "$rollback/ci-runner-farm.plg" packageName)" = "$baseline_name" ] \
+    || fail "baseline descriptor/package mismatch"
+  baseline_descriptor_sha="$(cat "$rollback/descriptor.sha256")"
+  baseline_package_sha="$(cat "$rollback/package.sha256")"
+  [ "$(sha256_of "$rollback/ci-runner-farm.plg")" = "$baseline_descriptor_sha" ] \
+    || fail "baseline descriptor hash mismatch"
+  [ "$(sha256_of "$rollback/packages/$baseline_name")" = "$baseline_package_sha" ] \
+    || fail "baseline package hash mismatch"
+fi
+
+if [ "$state" = present ]; then
+  if regular_file "$canonical_plg" \
+     && [ "$(sha256_of "$canonical_plg")" = "$baseline_descriptor_sha" ]; then
+    : # Idempotent rollback after a previous successful restore.
+  elif known_dev_descriptor; then
+    mkdir -p "$canonical_cfg"
+    destination="$canonical_cfg/$baseline_name"
+    if [ -e "$destination" ] || [ -L "$destination" ]; then
+      regular_file "$destination" || fail "canonical baseline package destination is unsafe"
+      [ "$(sha256_of "$destination")" = "$baseline_package_sha" ] \
+        || fail "canonical baseline package basename contains different bytes"
+    else
+      package_tmp="$(mktemp "$canonical_cfg/.rollback-package.XXXXXX")"
+      cp -- "$rollback/packages/$baseline_name" "$package_tmp"
+      chmod 0644 "$package_tmp"
+      [ "$(sha256_of "$package_tmp")" = "$baseline_package_sha" ] || fail "baseline package changed during restore"
+      mv -- "$package_tmp" "$destination"
+    fi
+    descriptor_tmp="$(mktemp /boot/config/plugins/.ci-runner-farm.plg.XXXXXX)"
+    cp -- "$rollback/ci-runner-farm.plg" "$descriptor_tmp"
+    chmod 0644 "$descriptor_tmp"
+    [ "$(sha256_of "$descriptor_tmp")" = "$baseline_descriptor_sha" ] || fail "baseline descriptor changed during restore"
+    mv -- "$descriptor_tmp" "$canonical_plg"
+  else
+    fail "canonical descriptor is not a retained development descriptor; refusing rollback"
+  fi
+  [ "$(sha256_of "$canonical_plg")" = "$baseline_descriptor_sha" ] || fail "restored descriptor verification failed"
+  [ "$(sha256_of "$canonical_cfg/$baseline_name")" = "$baseline_package_sha" ] || fail "restored package verification failed"
+else
+  if [ -e "$canonical_plg" ] || [ -L "$canonical_plg" ]; then
+    known_dev_descriptor || fail "canonical descriptor is not a retained development descriptor; refusing removal"
+    rm -f -- "$canonical_plg"
+  fi
+  [ ! -e "$canonical_plg" ] && [ ! -L "$canonical_plg" ] || fail "failed to remove development descriptor"
+fi
+
+printf 'install-dev remote: flash rollback verified. Reboot is required; this script did not reboot.\n'
+printf 'install-dev remote: external development artifacts remain at %s until explicitly reviewed.\n' "$artifacts"
+REMOTE_ROLLBACK
+
+printf 'install-dev: rollback staged on %s; reboot is required and was not performed\n' "$HOST"

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/README.md
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/README.md
@@ -1,4 +1,99 @@
 **CI Runner Farm**
 
-Self-hosted GitHub Actions runners for Unraid &mdash; an autoscaling fleet of
-docker-in-docker runners with a shared image cache and warm package caches.
+Self-hosted GitHub Actions or GitLab CI/CD runners for Unraid, with concurrent
+resource-capped slots, warm package/image caches, Docker-in-Docker, and optional
+autoscaling. One provider owns the farm at a time; GitHub remains the default so
+existing installations keep their behavior.
+
+For GitLab, create the runner and its tags/protection/scope in GitLab, then save
+the reusable `glrt-` runner authentication token in the plugin. A separate
+`read_api` token is optional and is used only for advisory queue/recent-job
+statistics for configured monitored projects. A project access token covers only
+one project; use a suitably scoped group token or dedicated PAT when monitoring
+several projects. GitLab.com and self-managed HTTPS instances are supported,
+including an uploaded custom PEM CA.
+
+Paste only the raw runner-token value, not GitLab's `gitlab-runner register`
+command, a flag, or surrounding quotes. GitLab 18.0 and later can issue routable
+runner tokens whose opaque payload contains periods; those are supported.
+
+The shared-token fleet accepts only modern manager tokens beginning exactly
+`glrt-`, not registration-created `glrtr-` or instance-prefixed token variants.
+Current official Runner releases select manager-only unregister by that exact
+prefix; accepting another shape could delete the shared runner entity.
+Retiring a slot uses its persisted system ID and saved manager name to remove only
+that manager record; the shared runner entity and the other slots remain intact.
+
+GitLab uses the official `gitlab/gitlab-runner` manager with the Docker executor.
+The editable GitLab Dockerfile builds the default **job image**, not a modified
+Runner manager. Leave DinD enabled for a private per-slot daemon, or explicitly
+choose host-socket sharing only for trusted jobs; host Docker socket access is
+root-equivalent. Host-socket Start and Validate require an official Runner image
+reporting version 18.5.0 or newer, where exact build/helper/service slot labels
+are reliable; DinD requires Runner 16.0.0 or newer for manager-only unregister
+with system IDs. A GitLab
+job, helper, or service container can control its slot's DinD socket and sibling
+helper/service containers, and the DinD sidecar itself runs privileged; the
+slot boundary prevents accidental cross-slot Docker access but is not a security
+boundary against the Unraid host. Because every executor container receives that
+Docker socket, its code can also pull/run images outside Runner's allowlists and request
+privileged containers inside DinD. Image/service allowlists and locked pull
+policies are admission guardrails, not a sandbox for untrusted pipelines.
+
+GitLab job containers are always ephemeral even though managers and configured
+caches persist. Native `/cache` data is disjoint per slot; custom cache mounts
+are shared across slots and should be used only with concurrency-safe tools.
+Optional image/service wildcard allowlists restrict `.gitlab-ci.yml` overrides;
+blank allowlists preserve GitLab Runner's permissive default. Pull policy is
+locked against job overrides, and job shared-memory size is configurable in
+bytes. GitLab maximum job duration remains configured on the runner in GitLab,
+not in the local manager TOML.
+
+Autoscaling is off by default. When explicitly enabled for GitLab, scale demand
+comes only from live manager metrics and observed job containers; advisory queue
+telemetry for monitored projects is never used to drive capacity.
+
+Credentials are stored separately under
+`/boot/config/plugins/ci-runner-farm/` and never in the main configuration:
+`token` (GitHub), `gitlab-runner-token`, optional `gitlab-api-token`, optional
+`gitlab-ca.crt`, and optional `registry-token`. GitLab Runner necessarily copies
+the reusable runner token into each mode-`0600`
+`gitlab-runners/ci-runner-N/config.toml`. A successful slot retirement removes
+that TOML, derived Docker auth, CA snapshot, and unregister marker while
+preserving its system ID; any lifecycle failure keeps all retry material.
+Clearing the active token applies the same cleanup across the fleet. The
+plugin registers no diagnostics collector for these token-bearing files or the
+derived Docker auth files; current Unraid diagnostics list the configuration
+directory but do not copy their contents. They must not be attached manually to
+support requests.
+
+If GitLab is permanently unreachable or the manager token is revoked, normal
+cleanup fails closed. The warning action on a GitLab Fleet row is a separately
+confirmed local-only escape hatch: it interrupts that slot and removes its local
+manager, jobs, privileged sidecar, token-bearing config, and slot Docker/cache
+roots without contacting
+GitLab. It can leave an offline manager record that must be removed in GitLab.
+
+GitLab manager Stop/Restart/replacement sends `SIGQUIT`, stops accepting new
+jobs, and waits up to `GITLAB_SHUTDOWN_TIMEOUT` (7200 seconds by default) for an
+in-flight job before Docker forces shutdown. Before an Unraid array stop or
+Docker-service restart, the `stopping_docker` hook quiesces every GitLab manager
+in parallel while its DinD sidecar is still available. Provider changes use the same
+idle-drained slot replacement, so a busy old-provider slot finishes and
+deregisters before its new-provider replacement starts.
+
+The uploaded CA is snapshotted per manager so an old manager can still
+unregister during a trust-root rotation. It is used for manager API traffic and
+mounted at GitLab Runner's standard helper trust path. Jobs receive the CA file but arbitrary job images
+must install or explicitly use it themselves. In DinD mode it is also installed
+for the configured private-registry authority. Registry auth and strict-network
+access remain available in GitLab mode when a locally built default is overridden
+by a job or service. Host-socket mode instead depends on the Unraid Docker
+daemon's own registry trust configuration. GitLab registry endpoints must use
+HTTPS; plain HTTP is rejected rather than transmitting registry credentials
+through an insecure DinD registry.
+
+The private daemon creates per-build networks from Docker's default address
+pools. A self-managed GitLab or registry CIDR that overlaps those pools can be
+shadowed by an inner Docker route; keep those endpoints on non-overlapping
+subnets or configure suitable Docker default address pools for the deployment.

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/RunnerFarmFleet.page
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/RunnerFarmFleet.page
@@ -18,7 +18,7 @@ Tag="server"
   <uui-card-wrapper class="crf-stat"><div class="crf-stat-inner"><span class="crf-stat-label">Runners up</span><span class="crf-stat-value" id="crf-s-up">&ndash;</span></div></uui-card-wrapper>
   <uui-card-wrapper class="crf-stat"><div class="crf-stat-inner"><span class="crf-stat-label">Busy</span><span class="crf-stat-value crf-c-busy" id="crf-s-busy">&ndash;</span></div></uui-card-wrapper>
   <uui-card-wrapper class="crf-stat"><div class="crf-stat-inner"><span class="crf-stat-label">Idle</span><span class="crf-stat-value crf-c-ok" id="crf-s-idle">&ndash;</span></div></uui-card-wrapper>
-  <uui-card-wrapper class="crf-stat"><div class="crf-stat-inner"><span class="crf-stat-label">Queued</span><span class="crf-stat-value" id="crf-s-q">&ndash;</span></div></uui-card-wrapper>
+  <uui-card-wrapper class="crf-stat"><div class="crf-stat-inner"><span class="crf-stat-label" id="crf-s-q-label">Queued</span><span class="crf-stat-value" id="crf-s-q">&ndash;</span></div></uui-card-wrapper>
   <uui-card-wrapper class="crf-stat"><div class="crf-stat-inner"><span class="crf-stat-label">Autoscale</span><span class="crf-stat-small" id="crf-s-as">&ndash;</span></div></uui-card-wrapper>
   <uui-card-wrapper class="crf-stat"><div class="crf-stat-inner"><span class="crf-stat-label">Image update</span><span class="crf-stat-small" id="crf-s-iu">&ndash;</span></div></uui-card-wrapper>
   <uui-card-wrapper class="crf-stat"><div class="crf-stat-inner"><span class="crf-stat-label">Cache</span><span class="crf-stat-value" id="crf-s-cache">&ndash;</span><a class="crf-cache-clear" id="crf-cache-clear" href="javascript:void(0)" role="button" onclick="crfCacheClear()">Clear caches</a></div></uui-card-wrapper>
@@ -46,7 +46,7 @@ Tag="server"
   <span class="crf-rs-seg"><b id="crf-rs-fail" style="color:var(--crf-err)">&ndash;</b> failed</span>
   <span class="crf-rs-seg"><b class="crf-muted" id="crf-rs-cancel">&ndash;</b> cancelled</span>
   <span class="crf-rs-seg"><b id="crf-rs-rate">&ndash;</b> pass rate</span>
-  <span class="crf-rs-seg crf-muted" id="crf-rs-total">&ndash; total across your repos</span>
+  <span class="crf-rs-seg crf-muted" id="crf-rs-total">&ndash; total across configured projects</span>
 </div>
 
 <div class="crf-console">
@@ -81,7 +81,7 @@ Tag="server"
   .crf-scale{margin-left:auto;display:flex;align-items:center;gap:6px;color:var(--alt-text-color);font-size:13px}
   .crf-scale input[type=number]{width:4em;height:26px;box-sizing:border-box;border-radius:6px;padding:0 8px;font-size:12px;margin:0}
   .crf-bays{border:1px solid var(--border-color);border-radius:6px;overflow:hidden;margin:0 0 8px}
-  .crf-bay{display:grid;grid-template-columns:22px minmax(110px,1fr) 88px minmax(120px,1.6fr) 120px 160px 26px;gap:8px;align-items:center;padding:4px 10px;border-top:1px solid var(--table-border-color,var(--border-color))}
+  .crf-bay{display:grid;grid-template-columns:22px minmax(110px,1fr) 88px minmax(120px,1.6fr) 120px 160px 48px;gap:8px;align-items:center;padding:4px 10px;border-top:1px solid var(--table-border-color,var(--border-color))}
   .crf-bay:first-child{border-top:none}
   .crf-bay-head{background:var(--table-header-background-color);font-size:11px;color:var(--alt-text-color);padding:5px 10px}
   #crf-bays-body .crf-bay:hover{background:var(--hover-table-row-background-color)}
@@ -104,7 +104,10 @@ Tag="server"
   #crf-bays-body .crf-bay{cursor:pointer}
   .crf-recycle{cursor:pointer;color:var(--alt-text-color);font-size:15px;line-height:1;text-align:center;border-radius:4px;padding:1px 2px}
   .crf-recycle:hover{color:var(--crf-busy)}
-  #crf-bays-body .crf-bay:focus-visible,.crf-recycle:focus-visible{outline:2px solid var(--link-text-color,#29b6f6);outline-offset:-2px;border-radius:4px}
+  .crf-row-actions{display:flex;align-items:center;justify-content:flex-end;gap:5px}
+  .crf-forget{cursor:pointer;color:var(--crf-err);font-size:13px;line-height:1;text-align:center;border-radius:4px;padding:1px 2px;opacity:.72}
+  .crf-forget:hover{opacity:1}
+  #crf-bays-body .crf-bay:focus-visible,.crf-recycle:focus-visible,.crf-forget:focus-visible{outline:2px solid var(--link-text-color,#29b6f6);outline-offset:-2px;border-radius:4px}
   @media (max-width:860px){
     .crf-bay{grid-template-columns:22px minmax(80px,1fr) 74px minmax(70px,1.3fr) 26px}
     .crf-bay > :nth-child(5),.crf-bay > :nth-child(6){display:none}
@@ -138,14 +141,21 @@ crfFarmLog(); setInterval(crfFarmLog,10000);
 const CRF_TOAST_MSG={start:'Fleet started',stop:'Fleet stopped',restart:'Fleet restarted',validate:'Validation finished'};
 function crfDoAction(a){ crfPost({action:a}).then(o=>{crfLog(o); crfRefresh(); if(o.ok!==false) crfToast(CRF_TOAST_MSG[a]||a); else crfToast((CRF_TOAST_MSG[a]||a)+' failed'+(o.error?': '+o.error:'')); }).catch(e=>{ crfToast((CRF_TOAST_MSG[a]||a)+' failed'); console.error('ci-runner-farm '+a+':',e); }); }
 function crfAction(a){
-  /* Stop/Restart kill whatever the runners are building — confirm with the
-     live impact when any runner is mid-job (sweetalert ships with the webgui). */
+  /* Confirm the live impact when any runner is mid-job. GitLab managers drain
+     gracefully with SIGQUIT; GitHub keeps its existing force-stop behavior. */
   if((a==='stop'||a==='restart')&&window.swal){
     const busy=((window.CRF_LAST||{}).runners||[]).filter(r=>r.state==='running'&&r.phase==='busy');
     if(busy.length){
       const lines=busy.map(r=>r.name+(r.job?' — '+r.job:'')).join('\n');
+      const farmProvider=(window.CRF_LAST||{}).provider||'github';
+      const gitlabBusy=busy.filter(r=>(r.provider||farmProvider)==='gitlab');
+      const githubBusy=busy.filter(r=>(r.provider||farmProvider)!=='gitlab');
+      const impact=[
+        gitlabBusy.length ? 'GitLab managers stop accepting work and wait for their '+gitlabBusy.length+' job'+(gitlabBusy.length>1?'s':'')+' to finish; the configured graceful-shutdown timeout is the force-stop limit.' : '',
+        githubBusy.length ? githubBusy.length+' GitHub job'+(githubBusy.length>1?'s will':' will')+' fail and re-queue.' : ''
+      ].filter(Boolean).join(' ');
       swal({title:(a==='stop'?'Stop':'Restart')+' the fleet?',
-        text:busy.length+' runner'+(busy.length>1?'s are':' is')+' mid-job:\n'+lines+'\n\nTheir jobs will fail and re-queue.',
+        text:busy.length+' runner'+(busy.length>1?'s are':' is')+' mid-job:\n'+lines+'\n\n'+impact,
         type:'warning',showCancelButton:true,confirmButtonText:a==='stop'?'Stop fleet':'Restart fleet',cancelButtonText:'Cancel'},
         ok=>{ if(ok) crfDoAction(a); });
       return;
@@ -164,6 +174,28 @@ function crfBar(pct){
   const p=Math.max(0,Math.min(100,Math.round(pct)));
   const cls=p>90?' crf-hot':p>60?' crf-mid':'';
   return '<span class="crf-ubar'+cls+'"><span style="width:'+p+'%"></span></span>';
+}
+function crfSafeUrl(value){
+  if(!value)return '';
+  const raw=String(value); if(!/^https?:\/\//i.test(raw))return '';
+  try{const u=new URL(raw);return (u.protocol==='https:'||u.protocol==='http:')?u.href:'';}catch(_){return '';}
+}
+/* Normalize the provider-neutral status contract while retaining support for
+   the original GitHub repo/run_id/pr/branch fields during rolling upgrades. */
+function crfJobMeta(r,provider){
+  const project=r.project||r.repo||'';
+  const jobId=String(r.job_id||r.run_id||'');
+  let jobUrl=crfSafeUrl(r.job_url||'');
+  let ref='',refUrl='';
+  if(!jobUrl&&provider==='github'&&project&&/^\d+$/.test(jobId))jobUrl=crfSafeUrl('https://github.com/'+project+'/actions/runs/'+jobId);
+  if(r.ref){
+    ref=r.ref; refUrl=crfSafeUrl(r.ref_url||'');
+  }else if(provider==='github'&&project&&/^\d+$/.test(String(r.pr||''))){
+    ref='#'+r.pr; refUrl=crfSafeUrl('https://github.com/'+project+'/pull/'+r.pr);
+  }else{
+    ref=r.branch||''; refUrl=crfSafeUrl(r.ref_url||'');
+  }
+  return {project,jobId,jobUrl,ref,refUrl};
 }
 /* The per-poll VOLATILE cells — the elapsed timer and the CPU/mem bars, which tick
    every 5s for a busy runner. Factored out so the full row builder and crfRefresh's
@@ -190,6 +222,7 @@ function crfRefresh(){
   window.__crfBusyStatus=true;
   crfPost({action:'status-json'}).then(d=>{
     window.CRF_LAST=d;
+    const provider=(d.provider==='gitlab'||d.provider==='github')?d.provider:((d.runners||[]).some(r=>r.provider==='gitlab')?'gitlab':'github');
     const warn=document.getElementById('crf-warn');
     if(warn){ if(d.warning){ warn.textContent='⚠ '+d.warning; warn.style.display='block'; } else { warn.textContent=''; warn.style.display='none'; } }
     const sec=document.getElementById('crf-sec');
@@ -212,7 +245,7 @@ function crfRefresh(){
     if(odr){ window.CRF_DRAWER_PINNED=crfDrawerPinned(odr); window.CRF_DRAWER_SCROLL=odr.scrollTop; }
     if(!rs.length){
       tb.innerHTML='<div class="crf-empty"><span class="crf-ball"></span>'+
-        '<div><strong>No managed runners</strong><div class="crf-muted">Configured for '+crfEsc(d.configured||0)+' — start the fleet to register them with GitHub.</div></div>'+
+        '<div><strong>No managed runners</strong><div class="crf-muted">Configured for '+crfEsc(d.configured||0)+' — start the '+(provider==='gitlab'?'GitLab':'GitHub')+' fleet.</div></div>'+
         '<uui-button size="sm"'+(crfDark()?' class="dark"':'')+' onclick="crfAction(\'start\')">Start the fleet</uui-button></div>';
       return;
     }
@@ -226,7 +259,7 @@ function crfRefresh(){
     // and falls through to the full rebuild below. busy-with-job_started is in the
     // signature so the .crf-elapsed span's presence always matches what the row was built
     // with — the in-place branch can then update it without ever needing to create it.
-    const sig=JSON.stringify([dark,window.CRF_DRAWER,rs.map(r=>[r.name,r.state,r.phase,r.job,r.repo,r.run_id,r.pr,r.branch,r.cpus,r.mem_gb,r.state==='running'&&r.phase==='busy'&&!!r.job_started])]);
+    const sig=JSON.stringify([dark,provider,window.CRF_DRAWER,rs.map(r=>[r.name,r.provider,r.state,r.phase,r.job,r.project,r.job_id,r.job_url,r.ref,r.ref_url,r.repo,r.run_id,r.pr,r.branch,r.cpus,r.mem_gb,r.state==='running'&&r.phase==='busy'&&!!r.job_started])]);
     if(tb.__crfSig===sig && tb.querySelector('.crf-bay[data-name]')){
       rs.forEach(r=>{
         const row=tb.querySelector('.crf-bay[data-name="'+(window.CSS&&CSS.escape?CSS.escape(r.name):r.name)+'"]'); if(!row) return;
@@ -242,6 +275,7 @@ function crfRefresh(){
     }
     tb.__crfSig=sig;
     tb.innerHTML=rs.map(r=>{
+      const rowProvider=(r.provider==='gitlab'||r.provider==='github')?r.provider:provider;
       const running=r.state==='running';
       const ph=running?r.phase:'exited';
       const ball=running?('crf-ball-'+r.phase):'crf-ball';
@@ -249,26 +283,27 @@ function crfRefresh(){
       let jobHtml;
       const v=crfVolatile(r);
       if(running&&r.phase==='busy'){
-        const repoShort=r.repo?crfEsc(String(r.repo).split('/').pop()):'';
-        const runOk=/^\d+$/.test(r.run_id||'');
-        const jobTxt=crfEsc(r.job||'\u2014');
-        const core=(repoShort?'<span class="crf-repo" title="'+crfEsc(r.repo)+'">'+repoShort+'</span> \u00b7 ':'')+jobTxt;
-        jobHtml=(runOk&&r.repo)?'<a href="https://github.com/'+crfEsc(r.repo)+'/actions/runs/'+r.run_id+'" target="_blank" rel="noopener" title="open run">'+core+'</a>':core;
-        if(/^\d+$/.test(r.pr||'')&&r.repo) jobHtml+='<a class="crf-ref" href="https://github.com/'+crfEsc(r.repo)+'/pull/'+r.pr+'" target="_blank" rel="noopener">#'+r.pr+'</a>';
-        else if(r.branch) jobHtml+='<span class="crf-ref">'+crfEsc(r.branch)+'</span>';
+        const meta=crfJobMeta(r,rowProvider);
+        const projectShort=meta.project?crfEsc(String(meta.project).split('/').pop()):'';
+        const jobTxt=crfEsc(r.job||(meta.jobId?'job #'+meta.jobId:'\u2014'));
+        const core=(projectShort?'<span class="crf-repo" title="'+crfEsc(meta.project)+'">'+projectShort+'</span> \u00b7 ':'')+jobTxt;
+        jobHtml=meta.jobUrl?'<a href="'+crfEsc(meta.jobUrl)+'" target="_blank" rel="noopener" title="open job">'+core+'</a>':core;
+        if(meta.refUrl&&meta.ref)jobHtml+='<a class="crf-ref" href="'+crfEsc(meta.refUrl)+'" target="_blank" rel="noopener">'+crfEsc(meta.ref)+'</a>';
+        else if(meta.ref)jobHtml+='<span class="crf-ref">'+crfEsc(meta.ref)+'</span>';
         jobHtml+=v.elapsedHtml;
       } else {
         jobHtml=crfEsc(running?'waiting for jobs':r.state);
       }
-      const jobCls=running&&r.phase==='busy'&&r.job?'crf-job':'crf-job crf-muted';
+      const jobCls=running&&r.phase==='busy'&&(r.job||r.job_id||r.run_id)?'crf-job':'crf-job crf-muted';
       return '<div class="crf-bay" data-name="'+crfEsc(r.name)+'" tabindex="0" role="button" aria-expanded="'+(window.CRF_DRAWER===r.name?'true':'false')+'" aria-label="Runner '+crfEsc(r.name)+', toggle log">'+
         '<span class="crf-ball '+ball+'"></span>'+
         '<span class="crf-name">'+crfEsc(r.name)+'</span>'+
         '<span class="crf-phase"><uui-badge variant="'+bvar+'" size="xs"'+dark+'>'+crfEsc(ph)+'</uui-badge></span>'+
-        '<span class="'+jobCls+'" title="'+crfEsc(r.job||'')+'">'+jobHtml+'</span>'+
+        '<span class="'+jobCls+'" title="'+crfEsc(r.job||(r.job_id?'job #'+r.job_id:''))+'">'+jobHtml+'</span>'+
         '<span class="crf-usage">'+crfBar(v.cpuPct)+'<span class="crf-uval">'+v.cpuTxt+'</span></span>'+
         '<span class="crf-usage">'+crfBar(v.memPct)+'<span class="crf-uval">'+v.memTxt+'</span></span>'+
-        '<span class="crf-recycle" tabindex="0" role="button" aria-label="Recycle '+crfEsc(r.name)+'" title="Recycle this runner">&#10227;</span>'+
+        '<span class="crf-row-actions"><span class="crf-recycle" tabindex="0" role="button" aria-label="Recycle '+crfEsc(r.name)+'" title="Recycle this runner">&#10227;</span>'+
+        (rowProvider==='gitlab'?'<span class="crf-forget" tabindex="0" role="button" aria-label="Force local forget '+crfEsc(r.name)+'" title="Emergency: forget this GitLab manager locally without unregistering">&#9888;</span>':'')+'</span>'+
       '</div>';
     }).join('');
     crfDrawerMount();
@@ -287,6 +322,8 @@ function crfQueued(){
   if(!crfFleetActive()) return;
   crfPost({action:'queued-json'}).then(d=>{
     const el=document.getElementById('crf-s-q'); if(!el) return;
+    const label=document.getElementById('crf-s-q-label');
+    if(label){const gl=d.provider==='gitlab'||((window.CRF_LAST||{}).provider==='gitlab');label.textContent=gl?'Queued*':'Queued';label.title=gl?'Advisory count across configured monitored projects only':'';}
     const q=(typeof d.queued==='number'&&d.queued>=0)?d.queued:null;
     el.textContent=q===null?'\u2013':q;
     el.classList.toggle('crf-c-busy',!!q);
@@ -310,12 +347,13 @@ function crfStats(){
     const dash='\u2013';
     if(!(typeof d.total==='number'&&d.total>=0)){  // no token / API down — signal, don't show a confident 0
       put('crf-rs-ok',dash); put('crf-rs-fail',dash); put('crf-rs-cancel',dash); put('crf-rs-rate',dash);
-      put('crf-rs-total',dash+' total across your repos'); return;
+      put('crf-rs-total',dash+' total across configured projects'); return;
     }
     const settled=(d.ok||0)+(d.fail||0)+(d.cancel||0);
     put('crf-rs-ok',d.ok??dash); put('crf-rs-fail',d.fail??dash); put('crf-rs-cancel',d.cancel??dash);
     put('crf-rs-rate', settled>0 ? Math.round(100*(d.ok||0)/settled)+'%' : dash);
-    put('crf-rs-total', d.total+' total across your repos');
+    const gl=d.provider==='gitlab'||((window.CRF_LAST||{}).provider==='gitlab');
+    put('crf-rs-total',d.total+' total across '+(gl?'monitored projects':'your repos'));
   }).catch(()=>{});
 }
 crfStats(); setInterval(crfStats,60000);
@@ -334,8 +372,20 @@ function crfRecycle(name){
     .then(o=>{ crfToast(o.ok?('Recycled '+name):('Recycle failed'+(o.error?': '+o.error:''))); crfRefresh(); })
     .catch(e=>{ crfToast('Recycle failed'); console.error('ci-runner-farm recycle:',e); });
   if(r.state==='running'&&r.phase==='busy'&&window.swal){
-    swal({title:'Recycle '+name+'?',text:'It is mid-job'+(r.job?': '+r.job:'')+'.\nThe job will fail and re-queue.',type:'warning',showCancelButton:true,confirmButtonText:'Recycle',cancelButtonText:'Cancel'},ok=>{ if(ok) go(); });
+    const impact=r.provider==='gitlab'
+      ? 'The manager stops accepting work and waits for this job to finish, up to the configured graceful-shutdown timeout.'
+      : 'The job will fail and re-queue.';
+    swal({title:'Recycle '+name+'?',text:'It is mid-job'+(r.job?': '+r.job:'')+'.\n'+impact,type:'warning',showCancelButton:true,confirmButtonText:'Recycle',cancelButtonText:'Cancel'},ok=>{ if(ok) go(); });
   } else go();
+}
+function crfForceForgetGitLab(name){
+  const warning='Emergency recovery only. This immediately interrupts the manager and every job/helper/service container in its slot, removes its privileged sidecar and local token-bearing config, and does NOT contact GitLab. An offline manager record may remain in GitLab and must be removed there manually.';
+  const go=()=>crfPost({action:'force-forget-gitlab',name,confirm:'FORGET_LOCAL_GITLAB_MANAGER'})
+    .then(o=>{crfLog(o);crfToast(o.ok?('Locally forgot '+name+'; check GitLab for an offline manager'):('Local forget failed'+(o.error?': '+o.error:'')));crfRefresh();})
+    .catch(e=>{crfToast('Local forget failed');console.error('ci-runner-farm force-forget:',e);});
+  if(window.swal){
+    swal({title:'Force local forget '+name+'?',text:warning,type:'warning',showCancelButton:true,confirmButtonText:'Interrupt and forget locally',cancelButtonText:'Cancel'},ok=>{if(ok)go();});
+  }else if(window.confirm(warning))go();
 }
 /* Click a bay to open a live log drawer for that runner. It persists across the
    5s re-render: crfRefresh rebuilds crf-bays-body's innerHTML (destroying this
@@ -384,6 +434,8 @@ function crfToggleDrawer(name){
   crfDrawerMount();
 }
 document.getElementById('crf-bays-body').addEventListener('click',e=>{
+  const fg=e.target.closest('.crf-forget');
+  if(fg){ const b=fg.closest('.crf-bay[data-name]'); if(b) crfForceForgetGitLab(b.dataset.name); return; }
   const rc=e.target.closest('.crf-recycle');
   if(rc){ const b=rc.closest('.crf-bay[data-name]'); if(b) crfRecycle(b.dataset.name); return; }
   if(e.target.closest('a,uui-button,.crf-bay-drawer')) return;
@@ -392,6 +444,8 @@ document.getElementById('crf-bays-body').addEventListener('click',e=>{
 });
 document.getElementById('crf-bays-body').addEventListener('keydown',e=>{
   if(e.key!=='Enter'&&e.key!==' ') return;
+  const fg=e.target.closest('.crf-forget');
+  if(fg){ e.preventDefault(); const b=fg.closest('.crf-bay[data-name]'); if(b) crfForceForgetGitLab(b.dataset.name); return; }
   const rc=e.target.closest('.crf-recycle');
   if(rc){ e.preventDefault(); const b=rc.closest('.crf-bay[data-name]'); if(b) crfRecycle(b.dataset.name); return; }
   const row=e.target.closest('.crf-bay[data-name]');

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/RunnerFarmImage.page
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/RunnerFarmImage.page
@@ -9,9 +9,18 @@ include_once '/usr/local/emhttp/plugins/ci-runner-farm/include/crf-core.php';
    The crf* JS core + .crf-* styles come from include/crf-core.php (above, shared
    by all tabs via include_once). */
 $crf_plugin = 'ci-runner-farm';
-$crf_df     = "/boot/config/plugins/$crf_plugin/Dockerfile";
+$crf_cfgdir = "/boot/config/plugins/$crf_plugin";
+$crf_cfg = @parse_ini_file("$crf_cfgdir/ci-runner-farm.cfg") ?: [];
+$crf_provider = (($crf_cfg['CI_PROVIDER'] ?? 'github') === 'gitlab') ? 'gitlab' : 'github';
+$crf_df = "$crf_cfgdir/Dockerfile.$crf_provider";
 $crf_df_saved = is_file($crf_df);
-if (!$crf_df_saved) $crf_df = "/usr/local/emhttp/plugins/$crf_plugin/default.Dockerfile";
+/* Compatibility: releases before provider support stored the GitHub editor in
+   an unsuffixed Dockerfile. Read it until the next Save migrates naturally. */
+if (!$crf_df_saved && $crf_provider === 'github' && is_file("$crf_cfgdir/Dockerfile")) {
+  $crf_df = "$crf_cfgdir/Dockerfile";
+  $crf_df_saved = true;
+}
+if (!$crf_df_saved) $crf_df = "/usr/local/emhttp/plugins/$crf_plugin/default.$crf_provider.Dockerfile";
 $crf_dockerfile = is_file($crf_df) ? file_get_contents($crf_df) : '';
 
 /* Toolchain install blocks the Runner image tab can splice into the Dockerfile.
@@ -65,8 +74,8 @@ DFBLOCK;
   <div class="crfs-tok-status">
     <span class="crf-ball" id="crfi-ball"></span>
     <span class="crfs-tok-text">
-      <strong id="crfi-title">Checking runner image...</strong>
-      <span class="crfs-tok-sub" id="crfi-sub">ci-runner-farm-runner:latest</span>
+      <strong id="crfi-title">Checking <?= $crf_provider === 'gitlab' ? 'GitLab default job' : 'GitHub runner' ?> image...</strong>
+      <span class="crfs-tok-sub" id="crfi-sub"><?= $crf_provider === 'gitlab' ? 'ci-runner-farm-gitlab-job:latest' : 'ci-runner-farm-runner:latest' ?></span>
     </span>
   </div>
   <div class="crfi-chips" id="crfi-chips"></div>
@@ -100,7 +109,7 @@ DFBLOCK;
     <span>Build log</span>
     <uui-button variant="outline" size="xs" onclick="crfCopyFrom('crf-build-log',this)">Copy</uui-button>
   </div>
-  <div id="crf-build-log" class="crf-console-body"><span class="crf-muted">Build output appears here. Set Image source to Built-in on the Settings tab and restart the fleet to use a new build.</span></div>
+  <div id="crf-build-log" class="crf-console-body"><span class="crf-muted">Build output appears here. Set Image source to Built-in on the Settings tab and restart the fleet to use the new <?= $crf_provider === 'gitlab' ? 'default job' : 'runner' ?> image.</span></div>
 </div>
 
 <style>
@@ -129,6 +138,7 @@ DFBLOCK;
 </style>
 
 <script>
+let CRFI_EDITOR_PROVIDER=<?=json_encode($crf_provider)?>;
 function crfiRelTime(iso){
   const t=Date.parse(iso); if(isNaN(t)) return '';
   const m=Math.round((Date.now()-t)/60000);
@@ -140,21 +150,30 @@ function crfiInfo(){
   crfPost({action:'image-info'}).then(d=>{
     const ball=document.getElementById('crfi-ball'), title=document.getElementById('crfi-title'),
           sub=document.getElementById('crfi-sub'), chips=document.getElementById('crfi-chips');
+    const provider=d.provider==='gitlab'?'gitlab':(d.provider==='github'?'github':CRFI_EDITOR_PROVIDER);
+    const role=provider==='gitlab'?'GitLab default job image':'GitHub runner image';
+    const fallbackTag=provider==='gitlab'?'ci-runner-farm-gitlab-job:latest':'ci-runner-farm-runner:latest';
     if(!d.exists){
-      ball.className='crf-ball crf-ball-error';
-      title.textContent='Runner image not built yet';
-      sub.textContent=(d.image||'ci-runner-farm-runner:latest')+' — save the Dockerfile and press Save + Build.';
+      if(d.source==='remote'){
+        ball.className='crf-ball crf-ball-idle';
+        title.textContent=role+' configured remotely';
+        sub.textContent=(d.image||fallbackTag)+' — pulled by the selected Docker endpoint when a slot starts.';
+      }else{
+        ball.className='crf-ball crf-ball-error';
+        title.textContent=role+' not built yet';
+        sub.textContent=(d.image||fallbackTag)+' — save the Dockerfile and press Save + Build.';
+      }
       chips.innerHTML='';
       return;
     }
     ball.className='crf-ball crf-ball-idle';
-    title.textContent='Runner image built '+crfiRelTime(d.created);
+    title.textContent=role+(d.source==='remote'?' cached ':' built ')+crfiRelTime(d.created);
     sub.textContent=d.image+' · '+d.id;
     const chip=(l,v)=>'<span class="crfi-chip">'+l+' <b>'+crfEsc(v)+'</b></span>';
     chips.innerHTML=
       chip('base',d.base||'?')+
       chip('size',(d.size_mb||0)+' MB')+
-      chip('runners on it',d.in_use+'')+
+      chip(provider==='gitlab'?'slots configured for it':'runners on it',d.in_use+'')+
       (d.source==='remote'?chip('image source','Remote — builds here are unused until Settings switches to Built-in'):'');
   }).catch(()=>{});
 }
@@ -183,11 +202,31 @@ let crfiAce=null, crfiSaved='';
    first click. Switching to a dynamix sub-tab doesn't fire visibilitychange, so
    re-measure when the Runner image sub-tab (tab2) is shown. */
 document.getElementById('tab2') && document.getElementById('tab2').addEventListener('click',()=>{ setTimeout(()=>{ if(crfiAce) crfiAce.resize(true); },60); });
+document.getElementById('tab2') && document.getElementById('tab2').addEventListener('click',crfiReloadForProvider);
 crfiSyncTC();
+function crfiReloadForProvider(){
+  crfPost({action:'get-dockerfile'}).then(d=>{
+    if(!d.ok||!d.provider||d.provider===CRFI_EDITOR_PROVIDER)return;
+    const load=()=>{
+      CRFI_EDITOR_PROVIDER=d.provider;
+      crfiSet(d.dockerfile||''); crfiSaved=d.dockerfile||'';
+      document.getElementById('crfi-dirty').classList.remove('on');
+      document.getElementById('crfi-df-path').textContent=d.path||'';
+      document.getElementById('crf-build-status').textContent=(d.provider==='gitlab'?'GitLab default job':'GitHub runner')+' Dockerfile loaded';
+      crfiSyncTC(); crfiInfo();
+    };
+    if(crfiGet()!==crfiSaved){
+      if(window.swal)swal({title:'The active provider changed',text:'Load the '+(d.provider==='gitlab'?'GitLab default job':'GitHub runner')+' Dockerfile? Unsaved edits for the previous provider will be discarded.',type:'warning',showCancelButton:true,confirmButtonText:'Load Dockerfile',cancelButtonText:'Keep editor'},ok=>{if(ok)load();});
+      else document.getElementById('crf-build-status').textContent='active provider changed — reload before saving';
+    } else load();
+  }).catch(e=>console.error('ci-runner-farm provider Dockerfile refresh:',e));
+}
 function crfiResetDf(){
   crfPost({action:'get-default-dockerfile'}).then(d=>{
     if(!d.dockerfile) return;
+    if(d.provider)CRFI_EDITOR_PROVIDER=d.provider;
     crfiSet(d.dockerfile);  // via crfiSet so the dirty marker updates in both the ACE and textarea-fallback paths
+    if(d.path)document.getElementById('crfi-df-path').textContent=d.path;
     document.getElementById('crf-build-status').textContent='shipped default loaded — not saved yet';
     crfiSyncTC();
   }).catch(e=>{ document.getElementById('crf-build-status').textContent='could not load default — see console'; console.error('ci-runner-farm reset:',e); });
@@ -195,7 +234,7 @@ function crfiResetDf(){
 // NOTE: the toolchain install blocks + their splice/idempotency logic are a
 // BROWSER-ONLY convenience of the image builder — there is no engine (runner-farm.sh
 // / CLI) equivalent, so they can't be composed headlessly, and the block library
-// must be kept in sync with default.Dockerfile by hand.
+// must be kept in sync with both shipped provider Dockerfiles by hand.
 const CRFI_TC = <?=json_encode($crfi_tc)?>;
 function crfiGet(){ return crfiAce ? crfiAce.getValue() : document.getElementById('crf-dockerfile').value; }
 function crfiSet(v){
@@ -233,9 +272,9 @@ function crfiBuildState(state,msg){
   b.className='crf-ball '+(state==='busy'?'crf-ball-busy':state==='ok'?'crf-ball-idle':state==='err'?'crf-ball-error':'');
   document.getElementById('crf-build-status').textContent=msg||'';
 }
-function crfSaveDf(cb){ crfPost({action:'save-dockerfile',dockerfile:document.getElementById('crf-dockerfile').value}).then(o=>{
+function crfSaveDf(cb){ crfPost({action:'save-dockerfile',provider:CRFI_EDITOR_PROVIDER,dockerfile:document.getElementById('crf-dockerfile').value}).then(o=>{
   if(o.ok){ crfiSaved=document.getElementById('crf-dockerfile').value; document.getElementById('crfi-dirty').classList.remove('on');
-    document.getElementById('crfi-df-path').textContent='/boot/config/plugins/ci-runner-farm/Dockerfile'; }
+    document.getElementById('crfi-df-path').textContent=o.path||('/boot/config/plugins/ci-runner-farm/Dockerfile.'+CRFI_EDITOR_PROVIDER); }
   crfiBuildState(o.ok?'ok':'err', o.ok?'saved':('error: '+(o.error||'')));
   if(typeof cb==='function') cb(!!o.ok); }).catch(e=>{ crfiBuildState('err','could not save Dockerfile — see console'); console.error('ci-runner-farm save-dockerfile:',e); if(typeof cb==='function') cb(false); }); }
 function crfBuild(){

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/RunnerFarmSettings.page
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/RunnerFarmSettings.page
@@ -13,6 +13,9 @@ $plugin   = 'ci-runner-farm';
    the flash cfg only ever holds what the user actually changed. */
 $cfg      = parse_plugin_cfg($plugin);
 $has_token= file_exists("/boot/config/plugins/$plugin/token");
+$has_gitlab_runner_token = file_exists("/boot/config/plugins/$plugin/gitlab-runner-token");
+$has_gitlab_api_token = file_exists("/boot/config/plugins/$plugin/gitlab-api-token");
+$has_gitlab_ca = file_exists("/boot/config/plugins/$plugin/gitlab-ca.crt");
 $has_regtok = file_exists("/boot/config/plugins/$plugin/registry-token");
 $host_mem_gb = (int)round(((int)preg_replace('/[^0-9]/', '', (string)shell_exec("grep MemTotal /proc/meminfo"))) / 1048576);
 $csrf     = $var['csrf_token'] ?? '';
@@ -20,7 +23,11 @@ $csrf     = $var['csrf_token'] ?? '';
    rendered fallback (via crf_g/crf_sel) and the client-side "Reset to defaults"
    button (emitted as CRF_DEFAULTS), so the two can never drift apart. */
 $defaults = [
+  'CI_PROVIDER'=>'github',
   'GH_SCOPE'=>'repo', 'GH_OWNER'=>'unraid', 'GH_REPOS'=>'unraid/repo-a unraid/repo-b',
+  'GITLAB_URL'=>'https://gitlab.com', 'GITLAB_RUNNER_IMAGE'=>'gitlab/gitlab-runner:alpine', 'GITLAB_PROJECTS'=>'',
+  'GITLAB_SHUTDOWN_TIMEOUT'=>'7200',
+  'GITLAB_ALLOWED_IMAGES'=>'', 'GITLAB_ALLOWED_SERVICES'=>'', 'GITLAB_PULL_POLICY'=>'auto', 'GITLAB_SHM_SIZE'=>'0',
   'RUNNER_GROUP'=>'', 'RUNNER_COUNT'=>'4', 'RUNNER_LABELS'=>'self-hosted,unraid,build',
   'RUNNER_CPUS'=>'', 'RUNNER_MEMORY'=>'16g', 'EPHEMERAL'=>'false', 'RUN_AS_ROOT'=>'false',
   'IMAGE_SOURCE'=>'builtin', 'IMAGE'=>'', 'REGISTRY_SERVER'=>'', 'REGISTRY_USERNAME'=>'',
@@ -32,6 +39,7 @@ $defaults = [
   'AUTOSCALE'=>'false', 'AUTOSCALE_MIN'=>'2', 'AUTOSCALE_MAX'=>'16', 'AUTOSCALE_MIN_IDLE'=>'2',
   'AUTOSCALE_STEP'=>'2', 'AUTOSCALE_INTERVAL'=>'30', 'AUTOSCALE_IDLE_GRACE'=>'5',
 ];
+$saved_provider = ($cfg['CI_PROVIDER'] ?? $defaults['CI_PROVIDER']) === 'gitlab' ? 'gitlab' : 'github';
 /* GitHub Packages currently requires a classic PAT. Preselect the least-privilege
    preset that matches the saved runner scope and remote GHCR configuration, while
    still letting an operator deliberately choose a different (for example,
@@ -47,7 +55,7 @@ if (!function_exists('crf_sel')) { function crf_sel($cfg,$k,$val,$d=''){ global 
 ?>
 <link type="text/css" rel="stylesheet" href="<?autov('/webGui/styles/jquery.filetree.css')?>">
 <script src="<?autov('/webGui/javascript/jquery.filetree.js')?>" charset="utf-8"></script>
-<div class="crfs-tokband<?= $has_token ? '' : ' crfs-tokband-missing' ?>" id="crf-tokband">
+<div class="crfs-tokband<?= $has_token ? '' : ' crfs-tokband-missing' ?>" id="crf-github-auth" data-provider="github" style="<?= $saved_provider === 'github' ? '' : 'display:none' ?>">
   <div class="crfs-tok-status">
     <span class="crf-ball <?= $has_token ? 'crf-ball-idle' : 'crf-ball-error' ?>" id="crf-tok-ball"></span>
     <span class="crfs-tok-text">
@@ -75,16 +83,58 @@ if (!function_exists('crf_sel')) { function crf_sel($cfg,$k,$val,$d=''){ global 
   </div>
   <div class="crfs-pat-note"><strong>Token creation flow:</strong> choose a type, create the PAT on GitHub, then paste and save it here. Classic PATs apply to every repository the token owner can access. These presets minimize scopes, not repository or organization reach; use a dedicated service account/token with only the access this farm needs.</div>
 </div>
+<div class="crfs-tokband<?= $has_gitlab_runner_token ? '' : ' crfs-tokband-missing' ?>" id="crf-gitlab-runner-auth" data-provider="gitlab" style="<?= $saved_provider === 'gitlab' ? '' : 'display:none' ?>">
+  <div class="crfs-tok-status">
+    <span class="crf-ball <?= $has_gitlab_runner_token ? 'crf-ball-idle' : 'crf-ball-error' ?>" id="crf-gitlab-runner-ball"></span>
+    <span class="crfs-tok-text">
+      <strong id="crf-gitlab-runner-status"><?= $has_gitlab_runner_token ? 'GitLab runner token configured' : 'GitLab runner token not set' ?></strong>
+      <span class="crfs-tok-sub" id="crf-gitlab-runner-sub"><?= $has_gitlab_runner_token ? 'Stored in a mode-0600 bootstrap file and per-slot config.toml copies; never in ci-runner-farm.cfg.' : 'Required to start GitLab runner managers. Paste only the raw modern glrt- authentication token.' ?></span>
+    </span>
+  </div>
+  <div class="crfs-tok-input">
+    <a href="https://docs.gitlab.com/ci/runners/new_creation_workflow/" target="_blank" rel="noopener">Create runner in GitLab &#8599;</a>
+    <span class="crfs-field"><input type="password" id="crf-gitlab-runner-token" autocomplete="new-password" placeholder="glrt-..."><button type="button" class="crfs-fx" title="Clear saved runner token" aria-label="Clear saved GitLab runner token" onclick="crfClearGitLabRunnerToken()">&times;</button></span>
+    <uui-button size="xs" onclick="crfSetGitLabRunnerToken()">Save runner token</uui-button>
+  </div>
+  <div class="crfs-pat-note"><strong>Runner authentication:</strong> create the runner and configure its tags, protected status, scope, and untagged-job policy in GitLab. Paste only the reusable <code>glrt-</code> value—not the <code>gitlab-runner register</code> command, a flag, or quotes. Current routable tokens can contain periods. The token is shared by this farm's persistent manager slots; it is not an API token.</div>
+</div>
+<div class="crfs-tokband" id="crf-gitlab-api-auth" data-provider="gitlab" style="<?= $saved_provider === 'gitlab' ? '' : 'display:none' ?>">
+  <div class="crfs-tok-status">
+    <span class="crf-ball <?= $has_gitlab_api_token ? 'crf-ball-idle' : '' ?>" id="crf-gitlab-api-ball"></span>
+    <span class="crfs-tok-text">
+      <strong id="crf-gitlab-api-status"><?= $has_gitlab_api_token ? 'GitLab API token configured' : 'GitLab API token not set (optional)' ?></strong>
+      <span class="crfs-tok-sub">Optional token with <code>read_api</code> for advisory queued/recent-job statistics. A project access token covers only its project; for several monitored projects use a group access token scoped to their group or a dedicated PAT that can read every listed project. GitLab.com tokens commonly begin <code>glpat-</code>; self-managed prefixes may differ. Runner execution does not use it.</span>
+    </span>
+  </div>
+  <div class="crfs-tok-input">
+    <span class="crfs-field"><input type="password" id="crf-gitlab-api-token" autocomplete="new-password" placeholder="glpat-... or configured prefix"><button type="button" class="crfs-fx" title="Clear saved API token" aria-label="Clear saved GitLab API token" onclick="crfClearGitLabApiToken()">&times;</button></span>
+    <uui-button size="xs" onclick="crfSetGitLabApiToken()">Save API token</uui-button>
+  </div>
+</div>
+<div class="crfs-tokband" id="crf-gitlab-ca-auth" data-provider="gitlab" style="<?= $saved_provider === 'gitlab' ? '' : 'display:none' ?>">
+  <div class="crfs-tok-status">
+    <span class="crf-ball <?= $has_gitlab_ca ? 'crf-ball-idle' : '' ?>" id="crf-gitlab-ca-ball"></span>
+    <span class="crfs-tok-text">
+      <strong id="crf-gitlab-ca-status"><?= $has_gitlab_ca ? 'GitLab custom CA configured' : 'GitLab custom CA not set (optional)' ?></strong>
+      <span class="crfs-tok-sub">PEM CA chain for a self-managed GitLab instance. It is used by the manager and helper, and is made available to job containers; arbitrary job images must install/use it themselves. In DinD mode it also trusts the configured private registry authority.</span>
+    </span>
+  </div>
+  <div class="crfs-tok-input">
+    <input type="file" id="crf-gitlab-ca" accept=".pem,.crt,application/x-pem-file,application/pem-certificate-chain">
+    <uui-button size="xs" onclick="crfSetGitLabCa()">Upload CA</uui-button>
+    <uui-button variant="secondary" size="xs" onclick="crfClearGitLabCa()">Remove CA</uui-button>
+  </div>
+</div>
 <div class="crfs-tokband crfs-regband" id="crf-remote-auth">
   <div class="crfs-tok-status">
     <span class="crf-ball <?= $has_regtok ? 'crf-ball-idle' : '' ?>" id="crf-regtok-ball"></span>
     <span class="crfs-tok-text">
       <strong id="crf-regtok"><?= $has_regtok ? 'Registry token configured' : 'Registry token not set' ?></strong>
-      <span class="crfs-tok-sub">Password/token for the private registry (e.g. a PAT with read:packages for ghcr.io). For ghcr.io, leaving it blank reuses the GitHub PAT.</span>
+      <span class="crfs-tok-sub">Password/token for pulling a private job image. In GitHub mode only, a blank ghcr.io token can reuse the GitHub PAT.</span>
     </span>
   </div>
   <div class="crfs-tok-input">
-    <uui-button variant="secondary" size="xs" onclick="crfGetPat('packages')">Create GHCR pull PAT &#8599;</uui-button>
+    <uui-button variant="secondary" size="xs" data-provider="github" onclick="crfGetPat('packages')">Create GHCR pull PAT &#8599;</uui-button>
     <span class="crfs-field"><input type="password" id="crf-registry-token" autocomplete="new-password" placeholder="registry password / token"><button type="button" class="crfs-fx" title="Clear saved registry token" aria-label="Clear saved registry token" onclick="crfClearRegistryToken()">&times;</button></span>
     <uui-button size="xs" onclick="crfSetRegistryToken()">Save registry token</uui-button>
   </div>
@@ -98,6 +148,18 @@ if (!function_exists('crf_sel')) { function crf_sel($cfg,$k,$val,$d=''){ global 
      (see cmd_reconcile_config); the Fleet tab shows a "migrating" count until it settles. -->
 <input type="hidden" name="#command" value="/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh">
 <input type="hidden" name="#arg[1]" value="reconcile-config">
+
+### CI provider
+
+_(Active provider)_:
+: <select name="CI_PROVIDER" onchange="crfProviderChange()">
+  <option value="github" <?=crf_sel($cfg,'CI_PROVIDER','github','github')?>>GitHub Actions</option>
+  <option value="gitlab" <?=crf_sel($cfg,'CI_PROVIDER','gitlab','github')?>>GitLab CI/CD</option>
+  </select>
+
+:crf_provider_plug:
+> One provider owns the farm at a time. Switching provider drains/recreates the managed runner slots with that provider's credentials and runtime. GitHub remains the default for existing installations.
+:end
 
 ### GitHub
 
@@ -134,6 +196,68 @@ _(Runner group)_:
 > Optional runner group (org scope) to restrict which repos may use the pool — e.g. exclude public repos so fork PRs never run here.
 :end
 
+### GitLab
+
+_(GitLab URL)_:
+: <input type="url" name="GITLAB_URL" value="<?=crf_g($cfg,'GITLAB_URL','https://gitlab.com')?>" placeholder="https://gitlab.com">
+
+:crf_gitlab_url_plug:
+> Base URL for GitLab.com or a self-managed GitLab instance. Use HTTPS. If the instance uses a private CA, upload its PEM certificate above. In strict network mode the engine permits only this configured endpoint through the LAN block.
+:end
+
+_(Runner manager image)_:
+: <input type="text" name="GITLAB_RUNNER_IMAGE" value="<?=crf_g($cfg,'GITLAB_RUNNER_IMAGE','gitlab/gitlab-runner:alpine')?>" placeholder="gitlab/gitlab-runner:alpine">
+
+:crf_gitlab_runner_image_plug:
+> Official GitLab Runner image used for each persistent manager slot. Pin a version matching your self-managed GitLab instance when required, e.g. <code>gitlab/gitlab-runner:v18.5.0</code>. Every mode requires Runner 16.0.0 or newer for manager-only unregister with a persisted system ID. Explicit host-socket mode requires Runner 18.5.0 or newer so build, helper, and service containers carry the exact slot labels needed for safe cleanup. Start and Validate reject older or unparseable versions. This is separate from the default job image edited on the Runner image tab.
+:end
+
+_(Graceful shutdown timeout (s))_:
+: <input type="number" name="GITLAB_SHUTDOWN_TIMEOUT" min="30" max="86400" value="<?=crf_g($cfg,'GITLAB_SHUTDOWN_TIMEOUT','7200')?>">
+
+:crf_gitlab_shutdown_plug:
+> GitLab only. Stop, Restart, token removal, manager replacement, array stop, and Docker-service restart send <code>SIGQUIT</code>, stop accepting new jobs, and wait this long for an in-flight job to finish before Docker force-stops the manager. An array/Docker stop can therefore remain in progress for up to this timeout. Default 7200 seconds (2 hours).
+:end
+
+_(Allowed job images)_:
+: <input type="text" name="GITLAB_ALLOWED_IMAGES" value="<?=crf_g($cfg,'GITLAB_ALLOWED_IMAGES','')?>" placeholder="blank = all, e.g. registry.example/team/*:* node:*">
+
+:crf_gitlab_allowed_images_plug:
+> GitLab only. Optional, space-separated wildcard patterns for <code>.gitlab-ci.yml image:</code> overrides. Blank preserves GitLab Runner's permissive default and allows every image. Set an explicit allowlist when pipeline authors should use only trusted registries or image families; prefix an exclusion with <code>!</code> where supported by GitLab Runner. This is a Runner-admission guardrail, not a sandbox: job code receives a Docker socket and can pull/run other images directly.
+:end
+
+_(Allowed service images)_:
+: <input type="text" name="GITLAB_ALLOWED_SERVICES" value="<?=crf_g($cfg,'GITLAB_ALLOWED_SERVICES','')?>" placeholder="blank = all, e.g. postgres:* redis:*">
+
+:crf_gitlab_allowed_services_plug:
+> GitLab only. Optional, space-separated wildcard patterns for job <code>services:</code>. Blank allows every service image. This controls which service images the Docker executor may start; it does not make an allowed image trustworthy.
+:end
+
+_(Job image pull policy)_:
+: <select name="GITLAB_PULL_POLICY">
+  <option value="auto" <?=crf_sel($cfg,'GITLAB_PULL_POLICY','auto','auto')?>>auto (built-in: if-not-present; remote: always)</option>
+  <option value="always" <?=crf_sel($cfg,'GITLAB_PULL_POLICY','always','auto')?>>always</option>
+  <option value="if-not-present" <?=crf_sel($cfg,'GITLAB_PULL_POLICY','if-not-present','auto')?>>if-not-present</option>
+  </select>
+
+:crf_gitlab_pull_policy_plug:
+> GitLab only. Sets both <code>pull_policy</code> and <code>allowed_pull_policies</code>, so a job cannot request a different policy through GitLab's job/service declarations. <strong>auto</strong> preserves the existing behavior: locally built images are reused and remote images are refreshed. Explicit <strong>always</strong> requires a remote default image; a locally built tag has no registry source for real jobs. The Runner's <code>never</code> policy is intentionally unsupported because a fresh per-slot daemon cannot obtain its helper/service images. Job scripts can still call the mounted Docker API directly, so this is an admission guardrail for trusted pipelines, not a security boundary.
+:end
+
+_(Job shared memory (bytes))_:
+: <input type="number" name="GITLAB_SHM_SIZE" min="0" step="1" value="<?=crf_g($cfg,'GITLAB_SHM_SIZE','0')?>" placeholder="0 = Docker default">
+
+:crf_gitlab_shm_size_plug:
+> GitLab only. Size of <code>/dev/shm</code> for Docker-executor job and service containers, in bytes. <code>0</code> uses Docker's default; browser and test suites commonly need a larger value such as <code>1073741824</code> (1 GiB). Maximum job runtime is configured on the runner in GitLab (or through GitLab's Runners API), not in this local <code>config.toml</code>.
+:end
+
+_(Monitored projects)_:
+: <input type="text" name="GITLAB_PROJECTS" value="<?=crf_g($cfg,'GITLAB_PROJECTS','')?>" placeholder="group/project group/another-project">
+
+:crf_gitlab_projects_plug:
+> Optional, space-separated project paths used only for advisory queued/recent-job statistics. Requires the optional API token. A project access token covers only one project; for several paths use a group token scoped to their common group or a dedicated PAT that can read every listed project. This setting does not limit which projects may use the runner; configure runner scope and tags in GitLab.
+:end
+
 ### Runners
 
 _(Concurrent runners)_:
@@ -147,7 +271,7 @@ _(Runner labels)_:
 : <input type="text" name="RUNNER_LABELS" value="<?=crf_g($cfg,'RUNNER_LABELS','self-hosted,unraid,build')?>">
 
 :crf_labels_plug:
-> Comma-separated labels that workflows target with runs-on, e.g. self-hosted,unraid,build.
+> GitHub only. Comma-separated labels that workflows target with runs-on, e.g. self-hosted,unraid,build. Configure GitLab tags on the runner in GitLab instead.
 :end
 
 _(CPUs per runner)_:
@@ -168,10 +292,10 @@ _(Ephemeral)_:
 : <select name="EPHEMERAL">
   <option value="false" <?=crf_sel($cfg,'EPHEMERAL','false','false')?>>false (persistent, warm cache)</option>
   <option value="true" <?=crf_sel($cfg,'EPHEMERAL','true','false')?>>true (clean per job)</option>
-  </select>
+  </select><span id="crfs-gitlab-ephemeral" style="display:<?= $saved_provider === 'gitlab' ? 'inline' : 'none' ?>">always ephemeral (clean Docker job container per job)</span>
 
 :crf_ephemeral_plug:
-> false = persistent runner, package caches stay warm between jobs. true = fresh runner re-registered per job (cleanest state, slightly slower first run).
+> GitHub: false = persistent runner; true = a fresh runner re-registered per job. GitLab is always ephemeral at the job-container layer: manager slots and explicitly mounted caches persist, but the Docker executor creates a clean job container for every job.
 :end
 
 _(Run jobs as root)_:
@@ -181,7 +305,7 @@ _(Run jobs as root)_:
   </select>
 
 :crf_runasroot_plug:
-> false (recommended): jobs run as the non-root `runner` user with passwordless sudo, matching GitHub-hosted runners — so tests that assert non-root file permissions behave correctly. Package caches mount under /home/runner for that user. true: jobs run as root (legacy); permission-sensitive tests may behave differently and caches mounted under /home/runner won't be auto-discovered by root tooling.
+> GitHub only. false (recommended): jobs run as the non-root `runner` user with passwordless sudo, matching GitHub-hosted runners. GitLab job users are controlled by the selected job image and Docker executor.
 :end
 
 ### Runner image
@@ -193,21 +317,21 @@ _(Image source)_:
   </select>
 
 :crf_imgsrc_plug:
-> **Built-in** (default): run the image you build with the Runner image builder below &mdash; no registry needed. **Remote**: pull the image named in "Remote image" from a registry (fill in the registry fields too).
+> **Built-in** (default): use the image you build on the Runner image tab &mdash; no registry needed. For GitHub it contains the runner process; for GitLab it is the Docker executor's default job image. **Remote**: pull the image named in "Remote image" from a registry (fill in the registry fields too).
 :end
 
 _(Remote image)_:
 : <input type="text" name="IMAGE" value="<?=crf_g($cfg,'IMAGE','')?>" placeholder="ghcr.io/org/image:tag">
 
 :crf_image_plug:
-> Used only when Image source = **Remote**. Full image ref to pull, e.g. `ghcr.io/org/ci-runner-image:latest`. For a private image, also set the registry fields below.
+> Used only when Image source = **Remote**. Full image ref to pull, e.g. `ghcr.io/org/ci-runner-image:latest`. In GitLab, a job's `.gitlab-ci.yml image:` may override this default. For a private image, also set the registry fields below.
 :end
 
 _(Registry server)_:
 : <input type="text" name="REGISTRY_SERVER" value="<?=crf_g($cfg,'REGISTRY_SERVER','')?>" placeholder="blank = none, e.g. ghcr.io">
 
 :crf_registry_server_plug:
-> Private registry to `docker login` so the host can pull a private runner image (the Runner image above). Blank disables it. Set the username below and the password/token with "Save registry token". For `ghcr.io`, if you leave the registry token blank the GitHub PAT is reused automatically (the PAT must have the `read:packages` scope), and the username defaults to the org/owner.
+> Private HTTPS registry authority for the default or a GitLab job/service override (for example `registry.example.test:5443` or `https://registry.example.test:5443`). Blank disables registry authentication. GitLab refuses plain HTTP because it would expose registry credentials and the private DinD daemon is not configured as an insecure registry. GitLab writes mode-restricted auth into every manager slot even when the default job image is built locally; DinD also installs the uploaded custom CA for this exact authority. GitHub keeps its remote-image-only host login behavior. Set the username below and the password/token with "Save registry token". For `ghcr.io` in GitHub mode, a blank registry token can reuse the GitHub PAT (it needs `read:packages`) and the username defaults to the org/owner.
 :end
 
 _(Registry username)_:
@@ -234,14 +358,14 @@ _(Workspace tmpfs size)_:
 : <input type="text" name="WORK_TMPFS_SIZE" value="<?=crf_g($cfg,'WORK_TMPFS_SIZE','8g')?>" placeholder="blank = bind to pool">
 
 :crf_tmpfs_plug:
-> Size of the RAM-backed per-job workspace, e.g. 8g — a clean, fast workspace each job while caches stay warm. Blank binds the workspace to the pool instead of RAM.
+> GitHub only. Size of the RAM-backed per-job workspace, e.g. 8g — a clean, fast workspace each job while caches stay warm. GitLab's Docker executor creates a clean workspace in each job container.
 :end
 
 _(Cache mounts)_:
 : <input type="text" name="CACHE_MOUNTS" value="<?=crf_g($cfg,'CACHE_MOUNTS','pnpm-store:/home/runner/.local/share/pnpm/store npm:/home/runner/.npm yarn:/home/runner/.cache/yarn ms-playwright:/home/runner/.cache/ms-playwright')?>">
 
 :crf_cache_mounts_plug:
-> Space-separated `host-subdir:container-path` warm caches mounted into every runner (created under the cache root). Defaults cover pnpm/npm/yarn/Playwright — edit for your stack.
+> Space-separated `host-subdir:container-path` warm caches mounted into every runner (created under the cache root). Defaults cover pnpm/npm/yarn/Playwright — edit for your stack. These named directories are shared concurrently by all slots, so use only caches whose tools tolerate multi-process access. GitLab requires unique absolute destinations and rejects its reserved <code>/cache</code>, Docker-socket, and helper-CA paths. GitLab's native <code>/cache</code> directory is separate per slot; the plugin does not currently configure a shared S3/MinIO cache backend.
 :end
 
 ### Docker
@@ -255,7 +379,7 @@ _(Docker-in-docker mode)_:
 :crf_dind_plug:
 > Docker-in-docker: each runner runs its own Docker daemon (requires --privileged).
 >
-> Fixes GitHub Actions services: networking (localhost:port becomes reachable from job steps) and "port already allocated" collisions between parallel jobs. Recommended when workflows use services: or service containers.
+> GitHub: fixes Actions services networking and port collisions between parallel jobs. GitLab: provides the private daemon used by the Docker executor for job images and services; keep this on for the slot-scoped default. Every job also receives this daemon's socket, so Docker commands in the job can inspect or remove that slot's job, helper, and service containers. `concurrent=1` limits cross-job exposure to one slot, but the sidecar itself is privileged and is not a security boundary against the Unraid host.
 >
 > Each runner's `/var/lib/docker` is stored under **Cache root**, so when this is on, Cache root **must** be a real pool dataset (not a `/mnt/user` FUSE share) or `docker build`/`buildx`/`services:` will fail with overlay mount errors.
 :end
@@ -267,7 +391,7 @@ _(Share host docker.sock)_:
   </select>
 
 :crf_sock_plug:
-> Mount the host Docker socket so jobs can start service containers (e.g. postgres for integration tests). PRIVATE repos only — never expose this to public/fork-PR code (root-equivalent host access).
+> Mount the host Docker socket. In GitLab this is the explicit alternative to Docker-in-Docker; at least one of these two settings must be on, and host-socket mode requires Network isolation = <strong>off</strong> because the host daemon creates job/helper/service networks outside the manager's dedicated bridge. PRIVATE projects/repositories only — never expose the host socket to public or fork/MR code (root-equivalent host access).
 :end
 
 _(Shared image cache)_:
@@ -292,9 +416,9 @@ _(Network isolation)_:
 >
 > **off** — runners share the default Docker bridge (legacy behavior).
 >
-> **isolate** — runners run on a dedicated bridge (`ci-runner-net`), so they can't reach your **other Unraid containers**. The shared image cache joins the same network. Low-risk; recommended.
+> **isolate** — runners run on a dedicated bridge (`ci-runner-net`), so they can't reach your **other Unraid containers**. The shared image cache joins the same network. GitLab host-socket mode cannot guarantee this for executor-created networks and is rejected; use the default per-slot DinD mode. Low-risk; recommended.
 >
-> **strict** — everything `isolate` does, **plus** IPv4 firewall rules (Docker's `DOCKER-USER`/`INPUT` chains) that block runners from reaching the **Unraid host and your LAN** while still allowing the internet and the shared cache. Treat this as **defense-in-depth against accidental egress** (a build script phoning home by mistake), **not a hard boundary**: with Docker-in-Docker on (the default) runners are **privileged** and determined malicious code could break out and remove these rules, and the rules are IPv4-only. For genuinely untrusted code, prefer non-privileged runners and treat strict as an extra layer, not the wall. Requires `iptables`; if it can't be applied, Start logs a warning and continues without the egress rules.
+> **strict** — everything `isolate` does, **plus** IPv4 firewall rules (Docker's `DOCKER-USER`/`INPUT` chains) that block runners from reaching the **Unraid host and your LAN** while still allowing the internet and the shared cache. Treat this as **defense-in-depth against accidental egress** (a build script phoning home by mistake), **not a hard boundary**: with Docker-in-Docker on (the default) runners are **privileged** and determined malicious code could break out and remove these rules, and the rules are IPv4-only. For genuinely untrusted code, prefer non-privileged runners and treat strict as an extra layer, not the wall. Requires `iptables`; Start fails closed if the required policy cannot be inspected or installed.
 :end
 
 ### Image auto-update
@@ -306,9 +430,9 @@ _(Auto-update runner image)_:
   </select>
 
 :crf_imgupd_plug:
-> When on, a daemon checks the runner image on a schedule and, when a newer image is published, recreates each runner on it — **draining** first (waits for the runner's current job to finish, never interrupts a build). The shared image-cache mirror is refreshed in the same pass.
+> When on, a daemon checks provider runtime images on a schedule and, when one changes, recreates each runner on it — **draining** first (waits for the runner's current job to finish, never interrupts a build). The shared image-cache mirror is refreshed in the same pass.
 >
-> Only **remote** images (Image source = Remote) can auto-pull — a built-in image has no upstream, so rebuild it from the Runner image builder instead.
+> For GitHub, this tracks the configured remote runner image. For GitLab, it tracks the official manager and private DinD images. A remote GitLab job image is refreshed inside each slot according to **Job image pull policy** (`auto` means `always`); a locally built job image has no upstream, so rebuild it in the image editor and restart/reconcile the fleet.
 >
 > Takes effect on the next **Start/Restart** of the fleet (like Autoscaling).
 :end
@@ -317,7 +441,7 @@ _(Auto-update: check interval (s))_:
 : <input type="number" name="IMAGE_AUTOUPDATE_INTERVAL" min="300" max="86400" value="<?=crf_g($cfg,'IMAGE_AUTOUPDATE_INTERVAL','1800')?>">
 
 :crf_imgupd_int_plug:
-> Seconds between update checks. Default 1800 (30 min). A check is a cheap registry digest comparison; the fleet only rolls when the image actually changed.
+> Seconds between update checks. Default 1800 (30 min). The fleet only rolls when a tracked provider image actually changed.
 :end
 
 _(Auto-update: drain timeout (s))_:
@@ -337,6 +461,8 @@ _(Autoscaling)_:
 
 :crf_autoscale_plug:
 > When on, a daemon grows/shrinks the fleet by demand instead of using a fixed count. It keeps a warm idle buffer: when idle runners drop below the buffer (jobs are consuming them) it adds runners; when too many sit idle it removes them. Bounded by Min/Max, with grace to avoid flapping. Only ever removes idle runners, never a runner mid-job.
+>
+> Autoscaling is off by default and is an explicit opt-in for GitLab. GitLab demand comes from live manager metrics and observed job containers; the incomplete Monitored-project queue count is dashboard-only and never drives scale decisions.
 :end
 
 _(Autoscale: min runners)_:
@@ -406,21 +532,74 @@ const CRF_DEFAULTS = <?=json_encode($defaults)?>;
 // nothing is written to flash until the user clicks Apply.
 function crfResetDefaults(){
   for (const k in CRF_DEFAULTS){ const el=document.getElementsByName(k)[0]; if(el) el.value=CRF_DEFAULTS[k]; }
-  crfImgSrc();
+  crfProviderChange(); crfImgSrc();
   // programmatic .value changes fire no input event, so nudge the advisory
   // listeners (Min>Max, memory envelope) to re-evaluate against the reset values.
   ['AUTOSCALE_MIN','AUTOSCALE_MAX','RUNNER_MEMORY','RUNNER_COUNT','AUTOSCALE'].forEach(n=>{ const el=document.getElementsByName(n)[0]; if(el) el.dispatchEvent(new Event('input')); });
 }
 function crfTokState(ok){
-  const band=document.getElementById('crf-tokband'), ball=document.getElementById('crf-tok-ball');
+  const band=document.getElementById('crf-github-auth'), ball=document.getElementById('crf-tok-ball');
   document.getElementById('crf-tok').textContent = ok?'GitHub token configured':'GitHub token not set';
   document.getElementById('crf-tok-sub').textContent = ok?'Stored at /boot/config/plugins/ci-runner-farm/token (chmod 600), never in ci-runner-farm.cfg.':'The farm cannot register runners until a token is saved.';
   band.classList.toggle('crfs-tokband-missing',!ok);
   ball.className='crf-ball '+(ok?'crf-ball-idle':'crf-ball-error');
 }
+function crfCredentialOk(o,label){
+  if(o&&o.ok===true)return true;
+  crfToast(label+': '+((o&&o.error)||'operation failed')); return false;
+}
+function crfCredentialDone(o,message){
+  if(o&&o.reconcile_requested&&!o.reconcile_started){
+    const why=o.reconcile_error?': '+String(o.reconcile_error).slice(0,240):'';
+    crfToast(message+'; fleet reconcile could not start'+why);
+  }else if(o&&o.warning)crfToast(message+'; '+String(o.warning).slice(0,280));
+  else crfToast(message);
+}
 function crfSetToken(){ const t=document.getElementById('crf-token').value; if(!t)return;
-  crfPost({action:'set-token',token:t}).then(o=>{crfTokState(!!o.ok);document.getElementById('crf-token').value='';}).catch(e=>{ crfToast&&crfToast('Save failed'); console.error('ci-runner-farm set-token:',e); }); }
-function crfClearToken(){ crfPost({action:'clear-token'}).then(()=>crfTokState(false)).catch(e=>console.error('ci-runner-farm clear-token:',e)); }
+  crfPost({action:'set-token',token:t}).then(o=>{if(!crfCredentialOk(o,'GitHub token save failed'))return;crfTokState(true);document.getElementById('crf-token').value='';crfCredentialDone(o,'GitHub token saved');}).catch(e=>{ crfToast&&crfToast('Save failed'); console.error('ci-runner-farm set-token:',e); }); }
+function crfClearToken(){ crfPost({action:'clear-token'}).then(o=>{if(!crfCredentialOk(o,'GitHub token removal failed')){if(o&&o.token_removed)crfTokState(false);return;}crfTokState(false);crfCredentialDone(o,'GitHub token removed');}).catch(e=>console.error('ci-runner-farm clear-token:',e)); }
+function crfGitLabRunnerState(ok){
+  const band=document.getElementById('crf-gitlab-runner-auth'), ball=document.getElementById('crf-gitlab-runner-ball');
+  document.getElementById('crf-gitlab-runner-status').textContent=ok?'GitLab runner token configured':'GitLab runner token not set';
+  document.getElementById('crf-gitlab-runner-sub').textContent=ok?'Stored in a mode-0600 bootstrap file and per-slot config.toml copies; never in ci-runner-farm.cfg.':'Required to start GitLab runner managers. Paste only the raw modern glrt- authentication token.';
+  band.classList.toggle('crfs-tokband-missing',!ok); ball.className='crf-ball '+(ok?'crf-ball-idle':'crf-ball-error');
+}
+function crfSetGitLabRunnerToken(){ const el=document.getElementById('crf-gitlab-runner-token'), t=el.value; if(!t)return;
+  crfPost({action:'set-gitlab-runner-token',token:t}).then(o=>{if(!crfCredentialOk(o,'Runner token rejected'))return;crfGitLabRunnerState(true);el.value='';crfCredentialDone(o,'GitLab runner token saved');}).catch(e=>{const m=String(e&&e.message||'request failed');crfToast(m.includes('session expired')?'Session expired — reload this page':('Save failed — '+m.slice(0,120)));console.error('ci-runner-farm set-gitlab-runner-token:',e);}); }
+function crfDoClearGitLabRunnerToken(confirmed){
+  crfPost({action:'clear-gitlab-runner-token',confirm_stop:confirmed?'1':'0'}).then(o=>{
+    if(o&&o.confirmation_required){
+      const seconds=(document.getElementsByName('GITLAB_SHUTDOWN_TIMEOUT')[0]||{}).value||'7200';
+      const warning='This stops accepting new GitLab jobs, waits up to '+seconds+' seconds for in-flight jobs to finish, then stops and unregisters every active manager. Jobs still running after the timeout are forced to stop. The saved token and per-slot config copies will be removed.';
+      if(window.swal){
+        swal({title:'Remove the active GitLab runner token?',text:warning,type:'warning',showCancelButton:true,confirmButtonText:'Stop fleet and remove token',cancelButtonText:'Cancel'},ok=>{if(ok)crfDoClearGitLabRunnerToken(true);});
+      }else if(window.confirm(warning))crfDoClearGitLabRunnerToken(true);
+      return;
+    }
+    if(!crfCredentialOk(o,'Runner token removal failed')){if(o&&o.token_removed)crfGitLabRunnerState(false);return;}
+    crfGitLabRunnerState(false);crfCredentialDone(o,'GitLab runner token removed');
+  }).catch(e=>console.error('ci-runner-farm clear-gitlab-runner-token:',e));
+}
+function crfClearGitLabRunnerToken(){crfDoClearGitLabRunnerToken(false);}
+function crfGitLabApiState(ok){
+  document.getElementById('crf-gitlab-api-status').textContent=ok?'GitLab API token configured':'GitLab API token not set (optional)';
+  document.getElementById('crf-gitlab-api-ball').className='crf-ball '+(ok?'crf-ball-idle':'');
+}
+function crfSetGitLabApiToken(){ const el=document.getElementById('crf-gitlab-api-token'), t=el.value; if(!t)return;
+  crfPost({action:'set-gitlab-api-token',token:t}).then(o=>{if(!crfCredentialOk(o,'API token rejected'))return;crfGitLabApiState(true);el.value='';crfCredentialDone(o,'GitLab API token saved');}).catch(e=>{crfToast('Save failed');console.error('ci-runner-farm set-gitlab-api-token:',e);}); }
+function crfClearGitLabApiToken(){ crfPost({action:'clear-gitlab-api-token'}).then(o=>{if(!crfCredentialOk(o,'API token removal failed'))return;crfGitLabApiState(false);crfCredentialDone(o,'GitLab API token removed');}).catch(e=>console.error('ci-runner-farm clear-gitlab-api-token:',e)); }
+function crfGitLabCaState(ok){
+  document.getElementById('crf-gitlab-ca-status').textContent=ok?'GitLab custom CA configured':'GitLab custom CA not set (optional)';
+  document.getElementById('crf-gitlab-ca-ball').className='crf-ball '+(ok?'crf-ball-idle':'');
+}
+function crfSetGitLabCa(){
+  const el=document.getElementById('crf-gitlab-ca'), f=el.files&&el.files[0]; if(!f){crfToast('Choose a PEM certificate first');return;}
+  if(f.size>1048576){crfToast('CA file is larger than 1 MiB');return;}
+  const reader=new FileReader();
+  reader.onload=()=>crfPost({action:'set-gitlab-ca',ca:String(reader.result||'')}).then(o=>{if(!crfCredentialOk(o,'CA rejected'))return;crfGitLabCaState(true);el.value='';crfCredentialDone(o,'GitLab CA saved');}).catch(e=>{crfToast('CA upload failed');console.error('ci-runner-farm set-gitlab-ca:',e);});
+  reader.onerror=()=>crfToast('Could not read CA file'); reader.readAsText(f);
+}
+function crfClearGitLabCa(){crfPost({action:'clear-gitlab-ca'}).then(o=>{if(!crfCredentialOk(o,'CA removal failed'))return;crfGitLabCaState(false);document.getElementById('crf-gitlab-ca').value='';crfCredentialDone(o,'GitLab CA removed');}).catch(e=>console.error('ci-runner-farm clear-gitlab-ca:',e));}
 function crfGetPat(presetOrId){
   const preset=document.getElementById(presetOrId), key=preset ? preset.value : presetOrId;
   const scopes={
@@ -440,10 +619,36 @@ function crfRegState(ok){
   document.getElementById('crf-regtok-ball').className='crf-ball '+(ok?'crf-ball-idle':'');
 }
 function crfSetRegistryToken(){ const t=document.getElementById('crf-registry-token').value; if(!t)return;
-  crfPost({action:'set-registry-token',token:t}).then(o=>{crfRegState(!!o.ok);document.getElementById('crf-registry-token').value='';}).catch(e=>console.error('ci-runner-farm set-registry-token:',e)); }
-function crfClearRegistryToken(){ crfPost({action:'clear-registry-token'}).then(()=>crfRegState(false)).catch(e=>console.error('ci-runner-farm clear-registry-token:',e)); }
-// show/hide the remote-only fields (Remote image + registry server/username/token)
-// based on the Image source select. Targets each field's <dd>+<dt> (Unraid
+  crfPost({action:'set-registry-token',token:t}).then(o=>{if(!crfCredentialOk(o,'Registry token save failed'))return;crfRegState(true);document.getElementById('crf-registry-token').value='';crfCredentialDone(o,'Registry token saved');}).catch(e=>console.error('ci-runner-farm set-registry-token:',e)); }
+function crfClearRegistryToken(){ crfPost({action:'clear-registry-token'}).then(o=>{if(!crfCredentialOk(o,'Registry token removal failed')){if(o&&o.token_removed)crfRegState(false);return;}crfRegState(false);crfCredentialDone(o,'Registry token removed');}).catch(e=>console.error('ci-runner-farm clear-registry-token:',e)); }
+function crfFieldVisible(name,on){
+  const el=document.getElementsByName(name)[0]; if(!el)return;
+  const dd=el.closest('dd'), row=dd||el.closest('tr'); if(row)row.style.display=on?'':'none';
+  if(dd&&dd.previousElementSibling)dd.previousElementSibling.style.display=on?'':'none';
+}
+function crfProviderChange(){
+  const sel=document.getElementsByName('CI_PROVIDER')[0], provider=sel&&sel.value==='gitlab'?'gitlab':'github';
+  document.querySelectorAll('[data-provider]').forEach(el=>{el.style.display=el.dataset.provider===provider?'':'none';});
+  ['GH_SCOPE','GH_OWNER','GH_REPOS','RUNNER_GROUP','RUNNER_LABELS','RUN_AS_ROOT','WORK_TMPFS_SIZE'].forEach(n=>crfFieldVisible(n,provider==='github'));
+  ['GITLAB_URL','GITLAB_RUNNER_IMAGE','GITLAB_PROJECTS','GITLAB_SHUTDOWN_TIMEOUT','GITLAB_ALLOWED_IMAGES','GITLAB_ALLOWED_SERVICES','GITLAB_PULL_POLICY','GITLAB_SHM_SIZE'].forEach(n=>crfFieldVisible(n,provider==='gitlab'));
+  const ephemeral=document.getElementsByName('EPHEMERAL')[0], gitlabEphemeral=document.getElementById('crfs-gitlab-ephemeral');
+  if(ephemeral)ephemeral.style.display=provider==='github'?'':'none';
+  if(gitlabEphemeral)gitlabEphemeral.style.display=provider==='gitlab'?'inline':'none';
+  document.querySelectorAll('.crfs-card').forEach(card=>{
+    const title=(card.querySelector('h2,h3,h4')||{}).textContent||'';
+    if(title.trim()==='GitHub')card.style.display=provider==='github'?'':'none';
+    if(title.trim()==='GitLab')card.style.display=provider==='gitlab'?'':'none';
+  });
+  const dind=document.getElementsByName('DIND')[0], sock=document.getElementsByName('SHARE_DOCKER_SOCK')[0];
+  let w=document.getElementById('crfs-gitlab-docker-warn');
+  if(!w&&dind){w=document.createElement('div');w.id='crfs-gitlab-docker-warn';w.className='crfs-as-warn';w.textContent='GitLab needs Docker-in-Docker or explicit host docker.sock sharing; Start will reject this configuration.';(dind.closest('dl')||dind.parentElement).after(w);}
+  if(w)w.classList.toggle('on',provider==='gitlab'&&dind&&dind.value!=='true'&&sock&&sock.value!=='true');
+  crfImgSrc();
+}
+// The default image field is remote-only. GitLab keeps registry auth visible for
+// built-in defaults too because .gitlab-ci.yml image/service overrides can use it;
+// GitHub retains its historical remote-only registry UI. Targets each field's
+// <dd>+<dt> (Unraid
 // markdown forms are MarkdownExtra definition lists). Hide-only (never disable):
 // disabled inputs aren't submitted, which would drop the values on Apply;
 // display:none inputs still submit, so values persist when switching modes. If
@@ -451,16 +656,20 @@ function crfClearRegistryToken(){ crfPost({action:'clear-registry-token'}).then(
 function crfImgSrc(){
   const sel=document.getElementsByName('IMAGE_SOURCE')[0];
   const remote=sel&&sel.value==='remote';
-  const disp=remote?'':'none';
-  ['IMAGE','REGISTRY_SERVER','REGISTRY_USERNAME'].forEach(n=>{
+  const providerSel=document.getElementsByName('CI_PROVIDER')[0];
+  const gitlab=providerSel&&providerSel.value==='gitlab';
+  const setRow=(n,on)=>{
     const el=document.getElementsByName(n)[0]; if(!el) return;
     const dd=el.closest('dd'); const row=dd||el.closest('tr');
-    if(row) row.style.display=disp;
-    if(dd&&dd.previousElementSibling) dd.previousElementSibling.style.display=disp;
-  });
-  const auth=document.getElementById('crf-remote-auth'); if(auth) auth.style.display=disp;
+    if(row) row.style.display=on?'':'none';
+    if(dd&&dd.previousElementSibling) dd.previousElementSibling.style.display=on?'':'none';
+  };
+  setRow('IMAGE',remote);
+  ['REGISTRY_SERVER','REGISTRY_USERNAME'].forEach(n=>setRow(n,remote||gitlab));
+  const auth=document.getElementById('crf-remote-auth'); if(auth) auth.style.display=(remote||gitlab)?'':'none';
 }
-crfImgSrc();
+['DIND','SHARE_DOCKER_SOCK'].forEach(n=>{const el=document.getElementsByName(n)[0];if(el)el.addEventListener('change',crfProviderChange);});
+crfProviderChange(); crfImgSrc();
 /* Inline sanity check: a floor above the ceiling is the classic autoscale
    misconfiguration — warn right at the fields (the daemon clamps it anyway). */
 (function(){
@@ -513,7 +722,7 @@ if (window.jQuery) jQuery(function($){ if ($.fn.fileTreeAttach) $("#CACHE_ROOT")
   .crfs-card dl{margin:0!important;padding:2px 0!important;display:flex;align-items:center;gap:10px;background:none!important}
   .crfs-card dt{float:none!important;width:44%!important;min-width:110px;text-align:right;font-size:12px;margin:0!important;padding:0!important;background:none!important}
   .crfs-card dd{float:none!important;flex:1;width:auto!important;margin:0!important;padding:0!important;background:none!important}
-  .crfs-card dd input[type=text],.crfs-card dd input[type=number],.crfs-card dd select{width:100%!important;max-width:none!important;font-size:12px;padding:3px 6px;margin:0}
+  .crfs-card dd input[type=text],.crfs-card dd input[type=url],.crfs-card dd input[type=number],.crfs-card dd select{width:100%!important;max-width:none!important;font-size:12px;padding:3px 6px;margin:0}
   .crfs-actions{display:flex;gap:8px;justify-content:flex-end;padding:4px 0 2px}
   .crfs-actions input{width:auto!important;margin:0!important}
   .crfs-tokband{display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;border:1px solid var(--border-color);border-radius:6px;background:var(--shade-bg-color,transparent);padding:10px 14px;margin:6px 0 8px}
@@ -569,5 +778,6 @@ if (window.jQuery) jQuery(function($){ if ($.fn.fileTreeAttach) $("#CACHE_ROOT")
     actions.remove();
     form.appendChild(bar);
   }
+  crfProviderChange();
 })();
 </script>

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/default.Dockerfile
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/default.Dockerfile
@@ -34,6 +34,7 @@ RUN printf '%s\n' \
   '( while true; do docker info >/dev/null 2>&1 || { rm -f /var/run/docker.pid; service docker start >>/var/log/dockerd.log 2>&1; }; sleep 3; done ) &' \
   '# wait for first readiness before the runner accepts jobs' \
   'for i in $(seq 1 90); do docker info >/dev/null 2>&1 && break; sleep 1; done' \
+  'docker info >/dev/null 2>&1 || { echo "Docker did not become ready" >&2; exit 1; }' \
   'exec "$@"' \
   > /usr/local/bin/wait-docker.sh \
  && chmod +x /usr/local/bin/wait-docker.sh

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/default.cfg
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/default.cfg
@@ -1,16 +1,32 @@
-# CI Runner Farm - reference defaults (documentation only)
-# NOT copied to flash. The live defaults are the built-in fallbacks in the
-# settings page ($defaults in RunnerFarmSettings.page) and in runner-farm.sh; the flash
-# config /boot/config/plugins/ci-runner-farm/ci-runner-farm.cfg only ever holds
-# what the user changed. This file mirrors those defaults for reference.
-# The GitHub PAT is stored separately in .../ci-runner-farm/token (chmod 600).
-# A private-registry password/token (for pulling a private IMAGE) is stored in
-# .../ci-runner-farm/registry-token (chmod 600).
+; CI Runner Farm - reference defaults (documentation only)
+; NOT copied to flash. The live defaults are the built-in fallbacks in the
+; settings page ($defaults in RunnerFarmSettings.page) and in runner-farm.sh; the flash
+; config /boot/config/plugins/ci-runner-farm/ci-runner-farm.cfg only ever holds
+; what the user changed. This file mirrors those defaults for reference.
+; Semicolon comments keep this file compatible with Unraid's PHP INI parser.
+; The active CI provider is selected with CI_PROVIDER. GitHub stays the default
+; so existing installations keep their current behavior after an upgrade.
+; The GitHub PAT is stored separately in .../ci-runner-farm/token (chmod 600).
+; GitLab credentials are stored separately in .../gitlab-runner-token and the
+; optional .../gitlab-api-token; a custom CA is .../gitlab-ca.crt (all chmod 600).
+; The CA covers manager/helper GitLab traffic and, in DinD mode, the configured
+; REGISTRY_SERVER. Arbitrary job images must install or explicitly use it.
+; A private-registry password/token (for pulling a private IMAGE) is stored in
+; .../ci-runner-farm/registry-token (chmod 600).
 
+CI_PROVIDER="github"
 GH_SCOPE="repo"
 GH_OWNER="unraid"
 GH_REPOS="unraid/repo-a unraid/repo-b"
 RUNNER_GROUP=""
+GITLAB_URL="https://gitlab.com"
+GITLAB_RUNNER_IMAGE="gitlab/gitlab-runner:alpine" ; every mode requires Runner >=16.0.0; host-socket mode requires >=18.5.0
+GITLAB_PROJECTS=""
+GITLAB_SHUTDOWN_TIMEOUT="7200"
+GITLAB_ALLOWED_IMAGES=""
+GITLAB_ALLOWED_SERVICES=""
+GITLAB_PULL_POLICY="auto"
+GITLAB_SHM_SIZE="0"
 RUNNER_COUNT="4"
 RUNNER_LABELS="self-hosted,unraid,build"
 RUNNER_CPUS=""
@@ -19,11 +35,11 @@ CACHE_ROOT="/mnt/cache/github-runner"
 WORK_TMPFS_SIZE="8g"
 IMAGE_SOURCE="builtin"
 IMAGE=""
-EPHEMERAL="false"
+EPHEMERAL="false" ; GitHub only; GitLab always creates a clean job container
 RUN_AS_ROOT="false"
 REGISTRY_SERVER=""
 REGISTRY_USERNAME=""
-CACHE_MOUNTS="pnpm-store:/home/runner/.local/share/pnpm/store npm:/home/runner/.npm yarn:/home/runner/.cache/yarn ms-playwright:/home/runner/.cache/ms-playwright"
+CACHE_MOUNTS="pnpm-store:/home/runner/.local/share/pnpm/store npm:/home/runner/.npm yarn:/home/runner/.cache/yarn ms-playwright:/home/runner/.cache/ms-playwright" ; shared concurrently by every slot
 SHARE_DOCKER_SOCK="false"
 DIND="true"
 SHARED_IMAGE_CACHE="true"

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/default.github.Dockerfile
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/default.github.Dockerfile
@@ -1,0 +1,67 @@
+# ci-runner-farm runner image (starter). Edit this from the plugin UI
+# (Settings -> Utilities -> CI Runner Farm -> Runner image builder), then Build,
+# and point the IMAGE setting at the resulting tag.
+#
+# This is a minimal starting point: the stock self-hosted runner base plus a
+# docker-in-docker readiness wrapper. Add whatever your CI needs (language
+# runtimes, browsers, build tools) in the marked section below.
+FROM myoung34/github-runner:latest
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+
+# --- Add your packages / tools here ---
+# RUN apt-get update && apt-get install -y --no-install-recommends <your-packages> \
+#  && rm -rf /var/lib/apt/lists/*
+
+# Pre-create the default CACHE_MOUNTS destinations as runner-owned. When these
+# paths are absent from the image, Docker's bind-mount auto-creation makes the
+# missing parent directories root-owned, and a non-root runner (RUN_AS_ROOT=false)
+# can then no longer write beside them — e.g. rustup fails with "could not
+# create bin directory '/home/runner/.cargo/bin': Permission denied".
+RUN mkdir -p /home/runner/.cargo/registry /home/runner/.cargo/git \
+      /home/runner/.cache/sccache /home/runner/.cache/yarn /home/runner/.cache/ms-playwright \
+      /home/runner/.npm /home/runner/.local/share/pnpm/store \
+ && chown -R runner:runner /home/runner/.cargo /home/runner/.cache /home/runner/.npm /home/runner/.local
+
+# DinD: the base entrypoint starts dockerd (START_DOCKER_SERVICE=true) but does
+# NOT wait for it to be ready. Wrap the runner CMD so it waits for docker before
+# the runner accepts jobs — otherwise 'Checking docker version'/services: race a
+# cold daemon.
+RUN printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  '# supervise dockerd: it can die under the services: workload (nested overlay)' \
+  '( while true; do docker info >/dev/null 2>&1 || { rm -f /var/run/docker.pid; service docker start >>/var/log/dockerd.log 2>&1; }; sleep 3; done ) &' \
+  '# wait for first readiness before the runner accepts jobs' \
+  'for i in $(seq 1 90); do docker info >/dev/null 2>&1 && break; sleep 1; done' \
+  'exec "$@"' \
+  > /usr/local/bin/wait-docker.sh \
+ && chmod +x /usr/local/bin/wait-docker.sh
+
+# Health probe so ci-runner-farm can reap a runner whose GitHub registration was
+# removed: its listener then loops forever on "Registration was not found /
+# Retrying until reconnected" instead of exiting, so it never gets recycled and
+# silently counts as idle capacity. Reports unhealthy ONLY in that stuck state —
+# never a runner that is running a job or still starting.
+RUN printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -uo pipefail' \
+  '# Running a job => healthy, unconditionally (never interrupt a build).' \
+  'pgrep -x Runner.Worker >/dev/null 2>&1 && exit 0' \
+  '# No listener => nothing services jobs; recycle it.' \
+  'pgrep -x Runner.Listener >/dev/null 2>&1 || exit 1' \
+  '# Idle: require positive proof of a live session in the newest listener log.' \
+  'log="$(ls -1t /actions-runner/_diag/Runner_*.log 2>/dev/null | head -1)"' \
+  '[ -n "$log" ] || exit 0   # too early to tell; --start-period covers startup' \
+  'last="$(grep -niE "Session created|Listening for Jobs|create session|connect error|Registration.*not found|has been removed|SessionConflict|SessionExpired|Retrying until reconnected|Runner listener exit" "$log" 2>/dev/null | tail -1)"' \
+  'case "$last" in' \
+  '  *"Session created"*|*"Listening for Jobs"*) exit 0 ;;  # connected' \
+  '  "") exit 0 ;;                                          # inconclusive -> healthy' \
+  '  *) exit 1 ;;                                           # stuck disconnected' \
+  'esac' \
+  > /usr/local/bin/runner-healthcheck.sh \
+ && chmod +x /usr/local/bin/runner-healthcheck.sh
+HEALTHCHECK --start-period=120s --interval=30s --timeout=10s --retries=3 \
+  CMD ["/usr/local/bin/runner-healthcheck.sh"]
+
+CMD ["/usr/local/bin/wait-docker.sh", "./bin/Runner.Listener", "run", "--startuptype", "service"]

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/default.github.Dockerfile
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/default.github.Dockerfile
@@ -34,6 +34,7 @@ RUN printf '%s\n' \
   '( while true; do docker info >/dev/null 2>&1 || { rm -f /var/run/docker.pid; service docker start >>/var/log/dockerd.log 2>&1; }; sleep 3; done ) &' \
   '# wait for first readiness before the runner accepts jobs' \
   'for i in $(seq 1 90); do docker info >/dev/null 2>&1 && break; sleep 1; done' \
+  'docker info >/dev/null 2>&1 || { echo "Docker did not become ready" >&2; exit 1; }' \
   'exec "$@"' \
   > /usr/local/bin/wait-docker.sh \
  && chmod +x /usr/local/bin/wait-docker.sh

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/default.gitlab.Dockerfile
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/default.gitlab.Dockerfile
@@ -1,0 +1,49 @@
+# ci-runner-farm GitLab job image (starter). Edit this from the plugin UI,
+# build it, and use the resulting tag as GitLab's default Docker-executor image.
+# A job may override it with `image:` in .gitlab-ci.yml.
+#
+# This is deliberately a JOB image, not a GitLab Runner manager image. The farm
+# runs the official gitlab/gitlab-runner image separately and asks it to launch
+# one container from this image for each accepted job.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    HOME=/home/runner
+
+# A practical baseline for shell-based build scripts plus a Docker client for
+# jobs that talk to the slot's private DinD daemon. Add project toolchains below.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      bash \
+      build-essential \
+      ca-certificates \
+      curl \
+      docker.io \
+      git \
+      jq \
+      openssh-client \
+      unzip \
+      zip \
+ && rm -rf /var/lib/apt/lists/*
+
+# --- Add your packages / tools here ---
+# RUN apt-get update && apt-get install -y --no-install-recommends <your-packages> \
+#  && rm -rf /var/lib/apt/lists/*
+
+# Common cache destinations match the plugin's backwards-compatible cache-mount
+# defaults. The image still runs as root, but HOME points at /home/runner so npm,
+# cargo, yarn, pnpm, and similar tools naturally use the warm mounted paths.
+RUN mkdir -p \
+      /home/runner/.cargo/git \
+      /home/runner/.cargo/registry \
+      /home/runner/.cache/ms-playwright \
+      /home/runner/.cache/sccache \
+      /home/runner/.cache/yarn \
+      /home/runner/.local/share/pnpm/store \
+      /home/runner/.npm
+
+WORKDIR /builds
+
+# GitLab Runner supplies the job script; no runner daemon or custom entrypoint
+# belongs in this image.
+CMD ["/bin/bash"]

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/event/docker_started
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/event/docker_started
@@ -11,7 +11,8 @@
 # the fleet would otherwise stay down until the next reboot. boot-autostart waits
 # for dockerd + the cache pool to be ready, restarts any stopped runners in place,
 # refills the fleet to its floor, and relaunches the autoscale/image-update
-# daemons. It is idempotent and a no-op until a GitHub token is configured.
+# daemons. It is idempotent and a no-op until the selected provider's runner
+# token is configured.
 #
 # Detached so we never block Unraid's start sequence.
 PLGDIR="/usr/local/emhttp/plugins/ci-runner-farm"

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/event/stopping_docker
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/event/stopping_docker
@@ -2,15 +2,15 @@
 # Unraid event hook: the Docker service is about to stop (array stop, a Docker
 # service restart, or shutdown).
 #
-# Stop our host-side daemons first so they don't thrash trying to manage a fleet
-# whose Docker is going away (the autoscaler would otherwise keep firing failed
-# `docker run`s during the down window). The docker_started hook relaunches them
-# when Docker returns.
+# Stop our host-side daemons so they don't thrash trying to manage a fleet whose
+# Docker is going away. For GitLab, also SIGQUIT every manager and wait for its
+# active job before Docker stops the per-slot DinD sidecar. The docker_started
+# hook restarts those same persisted manager identities when Docker returns.
 #
-# We deliberately do NOT tear down the runner containers here — leaving them in
-# place lets docker_started restart them with their caches, registration and DinD
-# data root intact, rather than recreating from scratch. Unraid/Docker stops the
-# containers themselves as part of the normal shutdown.
+# We deliberately do NOT unregister or remove runner containers here. Leaving
+# them in place preserves caches, registrations, and DinD data roots. GitHub's
+# existing container behavior is unchanged; Unraid/Docker stops those containers
+# itself as part of the normal shutdown.
 PLGDIR="/usr/local/emhttp/plugins/ci-runner-farm"
-"$PLGDIR/include/runner-farm.sh" autoscale-stop  >/dev/null 2>&1 || true
-"$PLGDIR/include/runner-farm.sh" imageupdate-stop >/dev/null 2>&1 || true
+CFGDIR="/boot/config/plugins/ci-runner-farm"
+"$PLGDIR/include/runner-farm.sh" docker-stopping >>"$CFGDIR/boot.log" 2>&1 || true

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/crf-core.php
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/crf-core.php
@@ -6,7 +6,9 @@
    relied on by document order (renaming crfPost or reordering the tab ordinals used
    to silently break the other tabs). Emitted once per document via include_once.
    Runs in the tab's scope, so $var (the CSRF token) is available. */
-$crf_csrf = $var['csrf_token'] ?? '';
+$crf_var = @parse_ini_file('/var/local/emhttp/var.ini');
+$crf_csrf = is_array($crf_var) && is_string($crf_var['csrf_token'] ?? null)
+  ? $crf_var['csrf_token'] : '';
 $crf_uui_base = '/plugins/dynamix.my.servers/unraid-components/uui/';
 $crf_util_css = '';
 foreach (glob('/usr/local/emhttp/plugins/dynamix.my.servers/unraid-components/standalone/standalone-apps-*.css') ?: [] as $f) {
@@ -42,7 +44,7 @@ foreach (glob('/usr/local/emhttp/plugins/dynamix.my.servers/unraid-components/st
   @media (prefers-reduced-motion:reduce){.crf-ball-busy,.crf-ball-starting{animation:none}}
 </style>
 <script>
-const CRF_CSRF = "<?=$crf_csrf?>";
+const CRF_CSRF_FALLBACK = <?=json_encode($crf_csrf, JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT)?>;
 const CRF_URL  = "/plugins/ci-runner-farm/include/exec.php";
 const CRF_UUI_BASE = "<?=$crf_uui_base?>";
 const CRF_UTIL_CSS = "<?=$crf_util_css?>";
@@ -85,7 +87,11 @@ window.CRF_UUI = (async () => {
   } catch (e) { console.warn('ci-runner-farm: @unraid/ui unavailable, using fallback styling', e); return false; }
 })();
 function crfPost(p){
-  p.csrf_token = CRF_CSRF;
+  // Unraid 7.3 publishes the request token from DefaultPageLayout as a global.
+  // Resolve it when the action runs; the PHP fallback covers older layouts and
+  // avoids depending on whichever include scope happened to render this tab.
+  const liveCsrf=(typeof globalThis.csrf_token==='string'&&globalThis.csrf_token)?globalThis.csrf_token:CRF_CSRF_FALLBACK;
+  p.csrf_token = liveCsrf;
   return fetch(CRF_URL,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},
     body:Object.entries(p).map(([k,v])=>encodeURIComponent(k)+'='+encodeURIComponent(v)).join('&')})
     .then(r=>r.text().then(t=>{

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/exec.php
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/exec.php
@@ -4,19 +4,50 @@
    runner-farm.sh. Token writes go to a chmod-600 file, never ci-runner-farm.cfg. */
 header('Content-Type: application/json');
 
-$var = @parse_ini_file('/var/local/emhttp/var.ini');
-$csrf = $var['csrf_token'] ?? '';
-$given = $_REQUEST['csrf_token'] ?? '';
-if (!$csrf || !hash_equals($csrf, $given)) {
-  http_response_code(403);
-  echo json_encode(['ok' => false, 'error' => 'csrf']);
+// Every UI call already uses POST. Reject GET (and every other method) before
+// reading a CSRF value so a token can never be placed in a URL, browser history,
+// proxy log, or referrer by this endpoint's action contract.
+$method = $_SERVER['REQUEST_METHOD'] ?? '';
+if (!is_string($method) || $method !== 'POST') {
+  http_response_code(405);
+  header('Allow: POST');
+  echo json_encode(['ok' => false, 'error' => 'method not allowed']);
   exit;
+}
+
+$csrfState = isset($var) && is_array($var)
+  ? $var : @parse_ini_file('/var/local/emhttp/var.ini');
+$csrf = is_array($csrfState) && is_string($csrfState['csrf_token'] ?? null)
+  ? $csrfState['csrf_token'] : '';
+$platformCsrfValidated = function_exists('csrf_terminate')
+  && isset($csrf_token) && is_string($csrf_token)
+  && $csrf !== ''
+  // Unraid 7.3's auto_prepend_file validates either transport, then unsets both
+  // before this endpoint runs. Requiring that consumed state prevents a stray
+  // same-named variable from bypassing the standalone fallback below.
+  && !array_key_exists('csrf_token', $_POST)
+  && !array_key_exists('HTTP_X_CSRF_TOKEN', $_SERVER)
+  && hash_equals($csrf, $csrf_token);
+if (!$platformCsrfValidated) {
+  // Standalone/CLI fallback for tests and any host that does not use Unraid's
+  // local_prepend.php. On Unraid, a missing or incorrect token has already been
+  // terminated before the plugin endpoint is evaluated.
+  $given = $_POST['csrf_token'] ?? ($_SERVER['HTTP_X_CSRF_TOKEN'] ?? '');
+  if ($csrf === '' || !is_string($given) || !hash_equals($csrf, $given)) {
+    http_response_code(403);
+    echo json_encode(['ok' => false, 'error' => 'csrf']);
+    exit;
+  }
+  unset($_POST['csrf_token'], $_SERVER['HTTP_X_CSRF_TOKEN']);
 }
 
 $PLUGIN  = 'ci-runner-farm';
 $CFGDIR  = "/boot/config/plugins/$PLUGIN";
 $SCRIPT  = "/usr/local/emhttp/plugins/$PLUGIN/include/runner-farm.sh";
-$action  = $_REQUEST['action'] ?? 'status-json';
+$rawAction = $_POST['action'] ?? 'status-json';
+// A crafted action[]=... must reach the ordinary unknown-action response, not
+// trigger PHP type juggling/warnings in switch. Bound the dispatch string too.
+$action = is_string($rawAction) && strlen($rawAction) <= 64 ? $rawAction : '';
 
 function run($cmd) { exec($cmd . ' 2>&1', $out, $rc); return [implode("\n", $out), $rc]; }
 // For actions whose stdout is a JSON body the frontend parses: keep stderr OUT of
@@ -31,6 +62,139 @@ function last_json($out) {
   $lines = array_values(array_filter(explode("\n", $out), fn($l) => trim($l) !== ''));
   $last = $lines ? trim(end($lines)) : '';
   return (strlen($last) && $last[0] === '{') ? $last : '';
+}
+// Credentials and trust material never belong in the shell-sourced cfg. Keep
+// writes in one helper so every provider secret gets the same locked write and
+// restrictive mode. Paths passed here are fixed plugin-owned filenames.
+function write_secret($path, $value) {
+  $dir = dirname($path);
+  if (!is_dir($dir) && !@mkdir($dir, 0755, true)) return false;
+  $tmp = @tempnam($dir, '.crf-secret-');
+  if ($tmp === false) return false;
+  $ok = @chmod($tmp, 0600)
+    && file_put_contents($tmp, $value, LOCK_EX) !== false
+    && @rename($tmp, $path)
+    && @chmod($path, 0600);
+  if (!$ok) @unlink($tmp);
+  return $ok;
+}
+
+// Validate only the local, injection-safe shape of a GitLab runner
+// authentication token. Current GitLab routable tokens contain two literal
+// dots, so the payload alphabet is the URL-safe base64 alphabet plus '.'. Keep
+// the total value bounded to 512 bytes, matching GitLab's token storage limit.
+//
+// The exact glrt- prefix is also a lifecycle safety boundary: official Runner
+// uses it to select manager-only unregister. A glrtr- or custom-prefixed value
+// can take the legacy runner-removal path and delete the shared runner entity.
+// Every rejection is static and deliberately reveals neither the submitted
+// value, its exact length, nor an offending character.
+function gitlab_runner_token_validation($raw, &$normalized) {
+  $normalized = '';
+  if (!is_string($raw)) {
+    return ['code'=>'runner_token_prefix', 'error'=>'The runner authentication token must begin exactly glrt-.'];
+  }
+
+  // A copied token may carry an outer newline. Strip only ordinary paste
+  // whitespace; unlike trim(), this does not silently discard NUL bytes.
+  $tok = trim($raw, " \t\r\n");
+  if ($tok === '') {
+    return ['code'=>'runner_token_empty', 'error'=>'No runner authentication token was provided.'];
+  }
+
+  if (strncmp($tok, 'glrt-', 5) === 0) {
+    $payload = substr($tok, 5);
+    $length = strlen($payload);
+    if ($length < 10 || $length > 507) {
+      return ['code'=>'runner_token_length', 'error'=>'The runner authentication token must contain 10–507 characters after glrt-.'];
+    }
+    if (!preg_match('/\A[A-Za-z0-9_.-]+\z/D', $payload)) {
+      // An exact-prefix value followed by command text or a closing quote gets
+      // the same actionable guidance as a full copied registration command.
+      if (preg_match('/[ \t\r\n\'"`]/', $payload)) {
+        return ['code'=>'runner_token_wrapped', 'error'=>'Paste only the raw glrt- runner authentication token, without a command, flag, variable assignment, or quotes.'];
+      }
+      return ['code'=>'runner_token_characters', 'error'=>'After glrt-, use only ASCII letters, digits, dots, hyphens, and underscores.'];
+    }
+    $normalized = $tok;
+    return null;
+  }
+
+  if (strncmp($tok, 'glrtr-', 6) === 0) {
+    return ['code'=>'runner_token_legacy', 'error'=>'Tokens beginning glrtr- come from GitLab’s legacy registration-token flow and are not supported; create a runner with GitLab’s modern workflow and use its glrt- token.'];
+  }
+  if (strncmp($tok, 'glpat-', 6) === 0) {
+    return ['code'=>'runner_token_api', 'error'=>'That looks like a GitLab API token. Paste the runner authentication token beginning glrt-.'];
+  }
+
+  $embedded = strpos($tok, 'glrt-');
+  if ($embedded !== false) {
+    if (preg_match('/\A[A-Za-z0-9_.@-]{1,64}glrt-[A-Za-z0-9_.-]+\z/D', $tok)) {
+      return ['code'=>'runner_token_custom_prefix', 'error'=>'This token has a custom instance prefix. This build requires glrt- at the start for safe manager-only removal.'];
+    }
+    return ['code'=>'runner_token_wrapped', 'error'=>'Paste only the raw glrt- runner authentication token, without a command, flag, variable assignment, or quotes.'];
+  }
+
+  return ['code'=>'runner_token_prefix', 'error'=>'The runner authentication token must begin exactly glrt-.'];
+}
+
+// Accept only a PEM certificate chain: no private-key blocks, comments, or
+// arbitrary text. Validate the envelope/base64 shape first and, when PHP's
+// OpenSSL extension is present, also require every certificate to parse.
+function normalize_pem_ca($raw) {
+  if (!is_string($raw) || $raw === '' || strlen($raw) > 1048576 || strpos($raw, "\0") !== false) return false;
+  $pem = str_replace(["\r\n", "\r"], "\n", trim($raw)) . "\n";
+  $pattern = '/-----BEGIN CERTIFICATE-----\n[A-Za-z0-9+\/=\n]+-----END CERTIFICATE-----/';
+  if (!preg_match_all($pattern, $pem, $certs) || trim(preg_replace($pattern, '', $pem)) !== '') return false;
+  foreach ($certs[0] as $cert) {
+    $body = str_replace(['-----BEGIN CERTIFICATE-----', '-----END CERTIFICATE-----', "\n"], '', $cert);
+    if ($body === '' || base64_decode($body, true) === false) return false;
+  }
+  if (function_exists('openssl_x509_read')) {
+    foreach ($certs[0] as $cert) {
+      $x509 = @openssl_x509_read($cert);
+      if ($x509 === false) return false;
+      if (function_exists('openssl_x509_free')) @openssl_x509_free($x509);
+    }
+  }
+  return $pem;
+}
+
+function active_provider($cfgdir) {
+  $cfg = @parse_ini_file("$cfgdir/ci-runner-farm.cfg") ?: [];
+  return (($cfg['CI_PROVIDER'] ?? 'github') === 'gitlab') ? 'gitlab' : 'github';
+}
+
+// Secret removal must not claim success when flash is read-only or an I/O
+// error leaves the credential behind. A missing file is already the requested
+// end state and remains a successful, idempotent clear.
+function unlink_secret($path) {
+  return !file_exists($path) || @unlink($path);
+}
+
+// GitLab managers bake their runner token and trust/auth mounts into each slot.
+// Updating one of those inputs while GitLab is active therefore needs the same
+// idle-draining reconcile used by Settings Apply. Pre-staging GitLab secrets
+// while GitHub is active deliberately does not disturb the GitHub fleet.
+function reconcile_active_gitlab($cfgdir, $script) {
+  if (active_provider($cfgdir) !== 'gitlab') return ['requested' => false, 'ok' => true, 'log' => ''];
+  [$out, $rc] = run(escapeshellarg($script) . ' reconcile-config');
+  return ['requested' => true, 'ok' => $rc === 0, 'log' => $out];
+}
+
+function credential_response($action, $ok, $error = null, $reconcile = null, $extra = []) {
+  $body = array_merge(['ok' => $ok, 'action' => $action, 'error' => $ok ? null : $error], $extra);
+  if (is_array($reconcile)) {
+    $body['reconcile_requested'] = $reconcile['requested'];
+    $body['reconcile_started'] = $reconcile['requested'] && $reconcile['ok'];
+    if ($reconcile['requested'] && !$reconcile['ok']) $body['reconcile_error'] = $reconcile['log'] ?: 'could not start reconcile';
+  }
+  echo json_encode($body);
+}
+
+function dockerfile_paths($cfgdir, $plugin, $provider) {
+  $suffix = $provider === 'gitlab' ? 'gitlab' : 'github';
+  return ["$cfgdir/Dockerfile.$suffix", "/usr/local/emhttp/plugins/$plugin/default.$suffix.Dockerfile"];
 }
 
 switch ($action) {
@@ -54,13 +218,21 @@ switch ($action) {
   case 'scale':
     // Clamp server-side too — the form max is presentation-only and the engine
     // hard-caps; this is defense-in-depth against a crafted POST (n=99999).
-    $n = max(0, min(64, (int)($_REQUEST['n'] ?? 0)));
+    $raw = $_POST['n'] ?? '';
+    if (!is_string($raw) || !preg_match('/\A[0-9]{1,20}\z/D', $raw)) {
+      echo json_encode(['ok'=>false,'error'=>'bad scale target']); break;
+    }
+    // Avoid integer-overflow behavior for a very large but syntactically valid
+    // decimal: anything above two digits necessarily clamps to the hard limit.
+    $digits = ltrim($raw, '0');
+    $n = strlen($digits) > 2 ? 64 : min(64, (int)$raw);
     [$out, $rc] = run(escapeshellarg($SCRIPT) . ' scale ' . escapeshellarg((string)$n));
     echo json_encode(['ok' => $rc === 0, 'action' => "scale $n", 'log' => $out]);
     break;
 
   case 'set-token':
-    $tok = trim($_REQUEST['token'] ?? '');
+    $raw = $_POST['token'] ?? '';
+    $tok = is_string($raw) ? trim($raw) : '';
     if ($tok === '') { echo json_encode(['ok'=>false,'error'=>'empty']); break; }
     // Shape-check the PAT: every GitHub token form (ghp_/gho_/ghs_/ghr_/github_pat_
     // + classic 40-char hex) is [A-Za-z0-9_] only. Rejecting anything else keeps a
@@ -69,43 +241,151 @@ switch ($action) {
     if (!preg_match('/^[A-Za-z0-9_]{20,255}$/', $tok)) {
       echo json_encode(['ok'=>false,'error'=>'that does not look like a GitHub token (expected letters, digits, and underscores only)']); break;
     }
-    @mkdir($CFGDIR, 0755, true);
-    file_put_contents("$CFGDIR/token", $tok);
-    chmod("$CFGDIR/token", 0600);
-    echo json_encode(['ok' => true, 'action' => 'set-token']);
+    $ok = write_secret("$CFGDIR/token", $tok);
+    echo json_encode(['ok' => $ok, 'action' => 'set-token', 'error' => $ok ? null : 'write failed']);
     break;
 
   case 'clear-token':
-    @unlink("$CFGDIR/token");
-    echo json_encode(['ok' => true, 'action' => 'clear-token']);
+    // The GitHub PAT is also the optional GHCR fallback. Remove the source and
+    // plugin-owned Docker auth under fleet.lock so a queued lifecycle action
+    // cannot recreate config.json from a pre-lock ACCESS_TOKEN snapshot.
+    [$out, $rc] = run(escapeshellarg($SCRIPT) . ' credential-clear-github-token');
+    $j = last_json($out);
+    if ($j !== '') echo $j;
+    else credential_response('clear-token', false,
+      $out !== '' ? $out : 'credential clear action failed', null,
+      ['token_removed'=>false,'host_auth_removed'=>false]);
+    break;
+
+  case 'set-gitlab-runner-token':
+    $raw = $_POST['token'] ?? '';
+    $tok = '';
+    // Require a runner created through GitLab's modern workflow. Registration-
+    // created glrtr- tokens can make `unregister` delete the shared runner entity
+    // instead of only this farm slot's manager, so they are intentionally refused.
+    $validation = gitlab_runner_token_validation($raw, $tok);
+    if (is_array($validation)) {
+      echo json_encode(['ok'=>false, 'error_code'=>$validation['code'], 'error'=>$validation['error']]); break;
+    }
+    $ok = write_secret("$CFGDIR/gitlab-runner-token", $tok);
+    $reconcile = $ok ? reconcile_active_gitlab($CFGDIR, $SCRIPT) : null;
+    credential_response('set-gitlab-runner-token', $ok, 'write failed', $reconcile);
+    break;
+
+  case 'clear-gitlab-runner-token':
+    $active = active_provider($CFGDIR) === 'gitlab';
+    $confirmStop = $_POST['confirm_stop'] ?? '';
+    if ($active && (!is_string($confirmStop) || $confirmStop !== '1')) {
+      echo json_encode([
+        'ok'=>false,
+        'action'=>'clear-gitlab-runner-token',
+        'confirmation_required'=>true,
+        'error'=>'Clearing the active GitLab runner token gracefully drains each manager before stopping and unregistering it; jobs still running after the configured timeout are forced to stop.'
+      ]);
+      break;
+    }
+    // The source token, mounted per-slot copies, manager unregister, and fleet
+    // teardown must be one fleet-locked transaction. Doing `stop` here and then
+    // unlinking from PHP leaves a gap in which an already-running reconciler can
+    // recreate config.toml from the bootstrap token. The engine also re-checks
+    // the active provider under the lock, so a concurrent Settings Apply cannot
+    // turn an unconfirmed inactive-token clear into a destructive fleet stop.
+    $confirmed = (is_string($confirmStop) && $confirmStop === '1') ? '1' : '0';
+    [$out, $rc] = run(escapeshellarg($SCRIPT) . ' credential-clear-gitlab-runner ' . escapeshellarg($confirmed));
+    $j = last_json($out);
+    if ($j !== '') echo $j;
+    else credential_response('clear-gitlab-runner-token', false,
+      $out !== '' ? $out : 'credential clear action failed', null,
+      ['token_removed'=>false,'fleet_stop_requested'=>$active,'fleet_stopped'=>false,'slot_configs_removed'=>false]);
+    break;
+
+  case 'set-gitlab-api-token':
+    $raw = $_POST['token'] ?? '';
+    $tok = is_string($raw) ? trim($raw) : '';
+    // GitLab.com PATs normally use glpat-, but self-managed instances may
+    // configure a different prefix. Accept the same narrow alphabet as the
+    // engine's curl-config path while rejecting whitespace, controls, quotes,
+    // backslashes, and newlines that could terminate or inject a directive.
+    if (!preg_match('/^[A-Za-z0-9_.@:+\/=~-]{8,512}$/D', $tok)) {
+      echo json_encode(['ok'=>false,'error'=>'expected an 8-512 character GitLab API token using only token-safe characters']); break;
+    }
+    $ok = write_secret("$CFGDIR/gitlab-api-token", $tok);
+    echo json_encode(['ok'=>$ok,'action'=>'set-gitlab-api-token','error'=>$ok ? null : 'write failed']);
+    break;
+
+  case 'clear-gitlab-api-token':
+    $ok = unlink_secret("$CFGDIR/gitlab-api-token");
+    credential_response('clear-gitlab-api-token', $ok, 'could not remove gitlab-api-token');
+    break;
+
+  case 'set-gitlab-ca':
+    $pem = normalize_pem_ca($_POST['ca'] ?? '');
+    if ($pem === false) { echo json_encode(['ok'=>false,'error'=>'expected one or more PEM CERTIFICATE blocks (private keys are not accepted)']); break; }
+    $ok = write_secret("$CFGDIR/gitlab-ca.crt", $pem);
+    $reconcile = $ok ? reconcile_active_gitlab($CFGDIR, $SCRIPT) : null;
+    credential_response('set-gitlab-ca', $ok, 'write failed', $reconcile);
+    break;
+
+  case 'clear-gitlab-ca':
+    $ok = unlink_secret("$CFGDIR/gitlab-ca.crt");
+    $reconcile = $ok ? reconcile_active_gitlab($CFGDIR, $SCRIPT) : null;
+    credential_response('clear-gitlab-ca', $ok, 'could not remove gitlab-ca.crt', $reconcile);
     break;
 
   case 'set-registry-token':
-    $tok = trim($_REQUEST['token'] ?? '');
+    $raw = $_POST['token'] ?? '';
+    if (!is_string($raw)) { echo json_encode(['ok'=>false,'error'=>'invalid registry token']); break; }
+    // Registry passwords are opaque: leading/trailing spaces may be meaningful,
+    // so never trim or normalize them. Keep flash writes bounded and reject ASCII
+    // controls (including NUL, tabs, CR/LF, and DEL) that cannot safely be treated
+    // as a single stored credential or redacted line-for-line in diagnostics.
+    if (strlen($raw) > 8192 || preg_match('/[\x00-\x1F\x7F]/', $raw)) {
+      echo json_encode(['ok'=>false,'error'=>'invalid or oversized registry token']); break;
+    }
+    $tok = $raw;
     if ($tok === '') { echo json_encode(['ok'=>false,'error'=>'empty']); break; }
-    @mkdir($CFGDIR, 0755, true);
-    file_put_contents("$CFGDIR/registry-token", $tok);
-    chmod("$CFGDIR/registry-token", 0600);
-    echo json_encode(['ok' => true, 'action' => 'set-registry-token']);
+    $ok = write_secret("$CFGDIR/registry-token", $tok);
+    $reconcile = $ok ? reconcile_active_gitlab($CFGDIR, $SCRIPT) : null;
+    credential_response('set-registry-token', $ok, 'write failed', $reconcile);
     break;
 
   case 'clear-registry-token':
-    @unlink("$CFGDIR/registry-token");
-    echo json_encode(['ok' => true, 'action' => 'clear-registry-token']);
+    // Serialize source-token removal, every derived Docker auth copy, and the
+    // active-GitLab reconcile decision with fleet mutations. Otherwise a drain
+    // that was already waiting on fleet.lock can repopulate config.json between
+    // PHP's independent unlink/scrub operations.
+    [$out, $rc] = run(escapeshellarg($SCRIPT) . ' credential-clear-registry-token');
+    $j = last_json($out);
+    if ($j !== '') echo $j;
+    else credential_response('clear-registry-token', false,
+      $out !== '' ? $out : 'credential clear action failed', null,
+      ['token_removed'=>false,'slot_auth_removed'=>false,'host_auth_removed'=>false]);
     break;
 
   case 'get-dockerfile':
-    $df = "$CFGDIR/Dockerfile";
-    if (!is_file($df)) $df = "/usr/local/emhttp/plugins/$PLUGIN/default.Dockerfile";
-    echo json_encode(['ok' => true, 'dockerfile' => is_file($df) ? file_get_contents($df) : '']);
+    $provider = active_provider($CFGDIR);
+    [$saved, $default] = dockerfile_paths($CFGDIR, $PLUGIN, $provider);
+    // Existing GitHub installs used an unsuffixed custom Dockerfile. Read it as
+    // a compatibility fallback, but all new saves go to Dockerfile.github.
+    $df = $saved;
+    if (!is_file($df) && $provider === 'github' && is_file("$CFGDIR/Dockerfile")) $df = "$CFGDIR/Dockerfile";
+    if (!is_file($df)) $df = $default;
+    echo json_encode(['ok'=>true,'provider'=>$provider,'path'=>$df,'saved'=>is_file($saved) || ($provider === 'github' && is_file("$CFGDIR/Dockerfile")),'dockerfile'=>is_file($df) ? file_get_contents($df) : '']);
     break;
 
   case 'save-dockerfile':
-    $content = $_REQUEST['dockerfile'] ?? '';
-    if (trim($content) === '') { echo json_encode(['ok'=>false,'error'=>'empty']); break; }
+    $content = $_POST['dockerfile'] ?? '';
+    if (!is_string($content) || trim($content) === '') { echo json_encode(['ok'=>false,'error'=>'empty']); break; }
+    if (strlen($content) > 2097152 || strpos($content, "\0") !== false) { echo json_encode(['ok'=>false,'error'=>'invalid or oversized Dockerfile']); break; }
+    $provider = active_provider($CFGDIR);
+    $expected = $_POST['provider'] ?? $provider;
+    if (!is_string($expected) || !in_array($expected, ['github','gitlab'], true) || $expected !== $provider) {
+      echo json_encode(['ok'=>false,'error'=>'active provider changed; reload the provider Dockerfile before saving','provider'=>$provider]); break;
+    }
+    [$df, $default] = dockerfile_paths($CFGDIR, $PLUGIN, $provider);
     @mkdir($CFGDIR, 0755, true);
-    file_put_contents("$CFGDIR/Dockerfile", $content);
-    echo json_encode(['ok' => true, 'action' => 'save-dockerfile']);
+    $ok = file_put_contents($df, $content, LOCK_EX) !== false;
+    echo json_encode(['ok'=>$ok,'action'=>'save-dockerfile','provider'=>$provider,'path'=>$df,'error'=>$ok ? null : 'write failed']);
     break;
 
   case 'build-image':
@@ -139,8 +419,8 @@ switch ($action) {
     break;
 
   case 'recycle':
-    $n = $_REQUEST['name'] ?? '';
-    if (!preg_match('/^ci-runner-[0-9]+$/', $n)) { echo json_encode(['ok'=>false,'error'=>'bad name']); break; }
+    $n = $_POST['name'] ?? '';
+    if (!is_string($n) || !preg_match('/^ci-runner-[0-9]+$/', $n)) { echo json_encode(['ok'=>false,'error'=>'bad name']); break; }
     [$out, $rc] = run_json(escapeshellarg($SCRIPT) . ' recycle ' . escapeshellarg($n));
     // cmd_recycle emits progress logs then its {ok,error?} verdict as the final
     // stdout line; pass it through so the specific reason (removed-not-recreated,
@@ -149,11 +429,34 @@ switch ($action) {
     echo $j !== '' ? $j : json_encode(['ok' => $rc === 0, 'action' => 'recycle']);
     break;
 
+  case 'force-forget-gitlab':
+    $n = $_POST['name'] ?? '';
+    $confirm = $_POST['confirm'] ?? '';
+    if (!is_string($n) || !preg_match('/^ci-runner-[0-9]+$/', $n)) {
+      echo json_encode(['ok'=>false,'error'=>'bad name']); break;
+    }
+    // This is the escape hatch for a permanently unreachable GitLab instance
+    // or revoked manager token. It interrupts the slot and deliberately leaves
+    // any remote manager record behind, so require an explicit second request.
+    if (!is_string($confirm) || !hash_equals('FORGET_LOCAL_GITLAB_MANAGER', $confirm)) {
+      echo json_encode(['ok'=>false,'confirmation_required'=>true,'error'=>'explicit local-forget confirmation required']); break;
+    }
+    [$out, $rc] = run(escapeshellarg($SCRIPT) . ' force-forget-gitlab ' . escapeshellarg($n));
+    echo json_encode([
+      'ok'=>$rc === 0,
+      'action'=>'force-forget-gitlab',
+      'name'=>$n,
+      'remote_manager_may_remain'=>true,
+      'error'=>$rc === 0 ? null : 'local cleanup failed; review the log and retry',
+      'log'=>$out,
+    ]);
+    break;
+
   case 'runner-log':
-    $n = $_REQUEST['name'] ?? '';
-    if (!preg_match('/^ci-runner-[0-9]+$/', $n)) { echo json_encode(['ok'=>false,'error'=>'bad name']); break; }
+    $n = $_POST['name'] ?? '';
+    if (!is_string($n) || !preg_match('/^ci-runner-[0-9]+$/', $n)) { echo json_encode(['ok'=>false,'error'=>'bad name']); break; }
     [$out, $rc] = run(escapeshellarg($SCRIPT) . ' logs-tail ' . escapeshellarg($n) . ' 150');
-    echo json_encode(['ok' => true, 'log' => $out]);
+    echo json_encode(['ok' => $rc === 0, 'log' => $out, 'error' => $rc === 0 ? null : 'runner is not an owned managed slot']);
     break;
 
   case 'image-info':
@@ -162,8 +465,9 @@ switch ($action) {
     break;
 
   case 'get-default-dockerfile':
-    $df = "/usr/local/emhttp/plugins/$PLUGIN/default.Dockerfile";
-    echo json_encode(['ok' => true, 'dockerfile' => is_file($df) ? file_get_contents($df) : '']);
+    $provider = active_provider($CFGDIR);
+    [$saved, $df] = dockerfile_paths($CFGDIR, $PLUGIN, $provider);
+    echo json_encode(['ok'=>true,'provider'=>$provider,'path'=>$df,'dockerfile'=>is_file($df) ? file_get_contents($df) : '']);
     break;
 
   case 'farm-log':

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -163,7 +163,8 @@ github_registry_credentials() {
 }
 
 github_build_args() {
-  local idx="$1" name="${2:-${NAME_PREFIX}-${idx}}" role="${CRF_CONTAINER_ROLE:-runner}"
+  local idx="$1"
+  local name="${2:-${NAME_PREFIX}-${idx}}" role="${CRF_CONTAINER_ROLE:-runner}"
   ARGS=(
     -d --restart=no
     --name "$name" --hostname "$name"

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -1,0 +1,365 @@
+#!/bin/bash
+# GitHub Actions provider adapter for CI Runner Farm.
+# Sourced by runner-farm.sh after configuration and common helpers are loaded.
+
+github_token_ready() { [ -n "$ACCESS_TOKEN" ]; }
+github_token_name()  { echo "GitHub token"; }
+github_builtin_image() { echo "$BUILTIN_IMAGE"; }
+github_validate_settings() { return 0; }
+github_strict_endpoint() { return 0; }
+github_imageupdate_pull() { return 1; }
+github_remote_image_host_pull_required() { return 0; }
+github_prepare_remote_image() { registry_login && host_docker_pull "$1"; }
+github_remote_image_update_allowed() { return 0; }
+github_stop_cleanup() { return 0; }
+github_docker_stopping_timeout() { echo 0; }
+github_docker_stopping() { return 0; }
+
+github_confgen() {
+  # Byte-for-byte the pre-provider fingerprint input/order. Existing GitHub
+  # containers must not become stale merely because provider support was added.
+  printf '%s\0' "$GH_SCOPE" "$GH_OWNER" "$GH_REPOS" "$RUNNER_GROUP" "$RUNNER_LABELS" \
+    "$EPHEMERAL" "$RUNNER_CPUS" "$RUNNER_MEMORY" "$WORK_TMPFS_SIZE" "$CACHE_MOUNTS" \
+    "$DIND" "$SHARE_DOCKER_SOCK" "$RUN_AS_ROOT" "$IMAGE_SOURCE" "$IMAGE" \
+    "$REGISTRY_SERVER" "$REGISTRY_USERNAME" "$SHARED_IMAGE_CACHE" "$MIRROR_PORT" \
+    "$NETWORK_ISOLATION" "$RUNNER_NETWORK" "$CACHE_ROOT" \
+    | sha256sum | cut -c1-12
+}
+
+github_runner_state() {
+  local c="$1" p
+  p="$(docker exec "$c" sh -c 'pgrep -x Runner.Worker >/dev/null 2>&1 && echo busy || { pgrep -x Runner.Listener >/dev/null 2>&1 && echo idle; }' 2>/dev/null)"
+  case "$p" in busy) echo busy; return;; idle) echo idle; return;; esac
+  case "$(docker logs --tail 15 "$c" 2>&1 | grep -iE 'Running job|Listening for Jobs|Job .* completed|error' | tail -1)" in
+    *"Running job"*)                      echo busy ;;
+    *"Listening for Jobs"*|*"completed"*) echo idle ;;
+    *[Ee]rror*)                           echo error ;;
+    *)                                    echo starting ;;
+  esac
+}
+
+github_scale_down_eligible() { ! runner_busy "$1"; }
+github_autoscale_counts() {
+  cur="$(current_count)" || return 1
+  busy="$(busy_count)" || return 1
+  idle=$((cur - busy))
+}
+
+github_repo_for_index() {
+  local idx="$1"
+  # shellcheck disable=SC2206  # GH_REPOS is deliberately space-separated.
+  local arr=($GH_REPOS); local n=${#arr[@]}
+  [ "$n" -eq 0 ] && { echo ""; return; }
+  echo "${arr[$(( (idx-1) % n ))]}"
+}
+
+# Long-lived PATs remain host-side; curl reads credentials from stdin so they do
+# not appear in /proc/<pid>/cmdline.
+gh_api() {
+  [ -n "$ACCESS_TOKEN" ] || return 1
+  printf 'header = "Authorization: Bearer %s"\n' "$ACCESS_TOKEN" \
+    | curl -fsSL -m 10 -X "$1" --config - \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com$2" 2>/dev/null
+}
+
+github_registration_token() {
+  local target="$1" path
+  case "$target" in
+    org:*)  path="/orgs/${target#org:}/actions/runners/registration-token" ;;
+    repo:*) path="/repos/${target#repo:}/actions/runners/registration-token" ;;
+    *) echo ""; return 1 ;;
+  esac
+  gh_api POST "$path" \
+    | grep -o '"token"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+    | sed 's/.*"\([^"]*\)"$/\1/'
+}
+
+# Prove that the long-lived PAT can mint a token for the replacement target
+# without retaining that short-lived token in Docker argv. A recycle can spend
+# many hours draining an old GitLab manager, so the real registration token is
+# minted only after removal; this probe keeps the pre-removal failure guard.
+github_replacement_preflight() {
+  local idx="$1" target repo probe
+  if [ "$GH_SCOPE" = org ]; then
+    target="org:$GH_OWNER"
+  else
+    repo="$(github_repo_for_index "$idx")"
+    [ -n "$repo" ] || { err "no GitHub repository configured for slot $idx"; return 1; }
+    target="repo:$repo"
+  fi
+  probe="$(github_registration_token "$target")"
+  [ -n "$probe" ] \
+    || { err "could not verify GitHub runner-registration permission for ${target#*:}"; return 1; }
+}
+
+github_deregister_runner_api() {
+  local c="$1" rname idx repo base id
+  [ -n "$ACCESS_TOKEN" ] && [ -n "$c" ] || return 0
+  rname="$(host)-${c}"
+  if [ "$GH_SCOPE" = "org" ]; then
+    base="/orgs/${GH_OWNER}"
+  else
+    idx="${c##*-}"; repo="$(github_repo_for_index "$idx")"
+    [ -n "$repo" ] || return 0
+    base="/repos/${repo}"
+  fi
+  id="$(gh_api GET "${base}/actions/runners?per_page=100" | awk -v want="$rname" '
+      /"id"[[:space:]]*:/   { if (match($0, /[0-9]+/)) cur = substr($0, RSTART, RLENGTH) }
+      /"name"[[:space:]]*:/ { s=$0; sub(/^[^:]*:[[:space:]]*"/, "", s); sub(/".*/, "", s); nm=s }
+      /"os"[[:space:]]*:/   { if (nm == want) { print cur; exit } }
+    ')"
+  [ -n "$id" ] || return 0
+  if gh_api DELETE "${base}/actions/runners/${id}" >/dev/null 2>&1; then
+    log "deregistered $rname from GitHub (id $id)"
+  else
+    log "warning: could not deregister $rname (id $id) from GitHub — a stale offline runner may linger"
+  fi
+}
+
+github_fetch_all() {
+  local suffix="$1" outdir="$2" maxpar="${3:-8}" timeout="${4:-10}"
+  local n=0 r
+  for r in $GH_REPOS; do
+    [ -n "$r" ] || continue
+    n=$((n+1))
+    printf 'header = "Authorization: Bearer %s"\n' "$ACCESS_TOKEN" \
+      | curl -s --max-time "$timeout" --config - \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${r}${suffix}" > "$outdir/$n" 2>/dev/null &
+    [ $((n % maxpar)) -eq 0 ] && wait
+  done
+  wait
+}
+
+github_public_repo_problem() {
+  [ "$GH_SCOPE" = "repo" ] || { echo ""; return; }
+  { [ "$DIND" = "true" ] || [ "$SHARE_DOCKER_SOCK" = "true" ]; } || { echo ""; return; }
+  [ -n "$ACCESS_TOKEN" ] || { echo ""; return; }
+  local cached; cached="$(security_cache_get)" && { printf '%s' "$cached"; return; }
+  local pub="" repo vis tmpd n=0
+  tmpd="$(mktemp -d 2>/dev/null)"
+  [ -n "$tmpd" ] || { echo ""; return; }
+  github_fetch_all "" "$tmpd" 8 5
+  for repo in $GH_REPOS; do
+    [ -n "$repo" ] || continue
+    n=$((n+1))
+    vis="$(grep -o '"visibility"[[:space:]]*:[[:space:]]*"[^"]*"' "$tmpd/$n" 2>/dev/null | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+    [ "$vis" = "public" ] && pub="$pub ${repo}"
+  done
+  rm -rf "$tmpd"
+  local msg=""
+  [ -n "$pub" ] && msg="PUBLIC repo(s) targeted while runners are privileged (DinD / host docker.sock):${pub}. Fork-PR code on a public repo would run as root on this server. Use trusted/private repos only, or an org runner-group restricted to private repos. See the Security section of the plugin README."
+  security_cache_put "$msg"
+  printf '%s' "$msg"
+}
+
+github_registry_credentials() {
+  if [ -z "$pass" ]; then
+    case "$REGISTRY_SERVER" in
+      ghcr.io|*.ghcr.io) pass="$ACCESS_TOKEN"; [ -z "$user" ] && user="$GH_OWNER" ;;
+    esac
+  fi
+}
+
+github_build_args() {
+  local idx="$1" name="${2:-${NAME_PREFIX}-${idx}}" role="${CRF_CONTAINER_ROLE:-runner}"
+  ARGS=(
+    -d --restart=no
+    --name "$name" --hostname "$name"
+    --pids-limit=4096
+    --label "${MANAGED_LABEL%=*}=true"
+    --label "net.unraid.ci-runner-farm.provider=github"
+    --label "net.unraid.ci-runner-farm.role=${role}"
+    --label "net.unraid.ci-runner-farm.index=${idx}"
+    --label "net.unraid.ci-runner-farm.confgen=$(crf_confgen)"
+    -e RUNNER_NAME="$(host)-${name}"
+    -e LABELS="$RUNNER_LABELS"
+    -e DISABLE_AUTO_UPDATE="true"
+    -e DISABLE_AUTOMATIC_DEREGISTRATION="true"
+    -e RUN_AS_ROOT="$RUN_AS_ROOT"
+    -e RUNNER_ALLOW_RUNASROOT="1"
+    -e RUNNER_WORKDIR="/_work"
+    -e npm_config_cache="/home/runner/.npm"
+  )
+  [ "$EPHEMERAL" = "true" ] && ARGS+=( -e EPHEMERAL="true" )
+  local m hostdir
+  for m in $CACHE_MOUNTS; do
+    [ -n "$m" ] || continue
+    hostdir="$(crf_safe_mount_subdir "${m%%:*}")" || { err "skipping unsafe cache mount '${m%%:*}'"; continue; }
+    ARGS+=( -v "$hostdir:${m#*:}" )
+  done
+  [ -n "$RUNNER_CPUS" ]   && ARGS+=( --cpus="$RUNNER_CPUS" )
+  [ -n "$RUNNER_MEMORY" ] && ARGS+=( --memory="$RUNNER_MEMORY" )
+  [ "$NETWORK_ISOLATION" != "off" ] && ARGS+=( --network "$RUNNER_NETWORK" )
+  if [ "$DIND" = "true" ]; then
+    ARGS+=( --privileged -e START_DOCKER_SERVICE=true )
+    mkdir -p "$CACHE_ROOT/docker/$name" "$CACHE_ROOT/dind-logs/$name"
+    ARGS+=( -v "$CACHE_ROOT/docker/$name:/var/lib/docker" )
+    ARGS+=( -v "$CACHE_ROOT/dind-daemon.json:/etc/docker/daemon.json:ro" )
+    ARGS+=( -v "$CACHE_ROOT/dind-logs/$name:/var/log/dind" )
+    [ "$SHARED_IMAGE_CACHE" = "true" ] && [ "$NETWORK_ISOLATION" = "off" ] && ARGS+=( --add-host "host.docker.internal:host-gateway" )
+  elif [ "$SHARE_DOCKER_SOCK" = "true" ]; then
+    ARGS+=( -v /var/run/docker.sock:/var/run/docker.sock )
+  fi
+  if [ -n "$WORK_TMPFS_SIZE" ]; then
+    ARGS+=( --tmpfs "/_work:rw,exec,size=${WORK_TMPFS_SIZE}" )
+  else
+    mkdir -p "$CACHE_ROOT/work/$name"
+    ARGS+=( -v "$CACHE_ROOT/work/$name:/_work" )
+  fi
+  local scope_target="" repo reg
+  if [ "$GH_SCOPE" = "org" ]; then
+    ARGS+=( -e RUNNER_SCOPE="org" -e ORG_NAME="$GH_OWNER" )
+    [ -n "$RUNNER_GROUP" ] && ARGS+=( -e RUNNER_GROUP="$RUNNER_GROUP" )
+    scope_target="org:$GH_OWNER"
+  else
+    repo="$(github_repo_for_index "$idx")"
+    ARGS+=( -e RUNNER_SCOPE="repo" -e REPO_URL="https://github.com/${repo}" )
+    scope_target="repo:$repo"
+  fi
+  if [ -n "$ACCESS_TOKEN" ] && [ "${NO_REGISTER:-0}" != "1" ]; then
+    reg="$(github_registration_token "$scope_target")"
+    [ -z "$reg" ] && { err "could not mint a runner registration token for ${scope_target#*:} (check the PAT's scope/permissions)"; return 1; }
+    ARGS+=( -e RUNNER_TOKEN="$reg" )
+  fi
+  ARGS+=( "$(effective_image)" )
+}
+
+github_start_one() {
+  local idx="$1" name="$2"
+  github_build_args "$idx" "$name" || { err "runner $name not started (registration-token error)"; return 1; }
+  log "starting $name (cpus=$RUNNER_CPUS mem=$RUNNER_MEMORY scope=$GH_SCOPE)"
+  docker run "${ARGS[@]}" >/dev/null
+}
+
+github_remove_runner() {
+  local c="$1" purge="${2:-true}" root failed=0
+  # GitHub rejects DELETE for an online/busy runner. Stop/remove first so its
+  # listener is offline, then delete the now-offline registration host-side.
+  # A failed stop/remove can leave the listener accepting or executing work.
+  # Never deregister it remotely or delete its Docker root underneath it.
+  provider_stop_remove_container "$c" || return 1
+  github_deregister_runner_api "$c" || failed=1
+  if [ "$purge" = true ]; then
+    root="$(crf_safe_cache_root)" || { err "refusing GitHub runner cleanup under unsafe CACHE_ROOT '$CACHE_ROOT'"; return 1; }
+    rm -rf "$root/docker/$c" 2>/dev/null || failed=1
+  fi
+  return "$failed"
+}
+
+github_queued_refresh() {
+  [ -z "$ACCESS_TOKEN" ] && [ -f "$TOKEN_FILE" ] && ACCESS_TOKEN="$(cat "$TOKEN_FILE" 2>/dev/null)"
+  [ -n "$ACCESS_TOKEN" ] || { echo "github $(date +%s) -1" > "$RUNDIR/queued.cache"; return 0; }
+  local total=0 got=0 r n body tmpd i=0
+  tmpd="$(mktemp -d 2>/dev/null)"
+  [ -n "$tmpd" ] || { echo "github $(date +%s) -1" > "$RUNDIR/queued.cache"; return 0; }
+  github_fetch_all "/actions/runs?status=queued&per_page=1" "$tmpd"
+  for r in $GH_REPOS; do
+    [ -n "$r" ] || continue
+    i=$((i+1)); body="$(cat "$tmpd/$i" 2>/dev/null)"
+    case "$body" in *'"total_count"'*) got=1 ;; esac
+    n="$(printf '%s' "$body" | grep -m1 -oE '"total_count":[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1)"
+    total=$(( total + ${n:-0} ))
+  done
+  rm -rf "$tmpd"
+  [ "$got" = "1" ] || total=-1
+  echo "github $(date +%s) $total" > "$RUNDIR/queued.cache"
+}
+
+github_stats_refresh() {
+  [ -z "$ACCESS_TOKEN" ] && [ -f "$TOKEN_FILE" ] && ACCESS_TOKEN="$(cat "$TOKEN_FILE" 2>/dev/null)"
+  [ -n "$ACCESS_TOKEN" ] || { echo "github $(date +%s) 0 0 0 0 -1" > "$RUNDIR/stats.cache"; return 0; }
+  local ok=0 fail=0 cancel=0 other=0 total got=0 r body c tmpd i=0
+  tmpd="$(mktemp -d 2>/dev/null)"
+  [ -n "$tmpd" ] || { echo "github $(date +%s) 0 0 0 0 -1" > "$RUNDIR/stats.cache"; return 0; }
+  github_fetch_all "/actions/runs?per_page=50" "$tmpd"
+  for r in $GH_REPOS; do
+    [ -n "$r" ] || continue
+    i=$((i+1)); body="$(cat "$tmpd/$i" 2>/dev/null)"
+    case "$body" in *'"workflow_runs"'*) got=1 ;; esac
+    while IFS= read -r c; do
+      case "$c" in
+        *'"success"'*) ok=$((ok+1)) ;;
+        *'"failure"'*|*'"timed_out"'*|*'"startup_failure"'*) fail=$((fail+1)) ;;
+        *'"cancelled"'*) cancel=$((cancel+1)) ;;
+        *null*) : ;;
+        ?*) other=$((other+1)) ;;
+      esac
+    done <<< "$(echo "$body" | grep -oE '"conclusion": ?(null|"[a-z_]+")')"
+  done
+  rm -rf "$tmpd"
+  if [ "$got" = "1" ]; then total=$((ok+fail+cancel+other)); else total=-1; fi
+  echo "github $(date +%s) $ok $fail $cancel $other $total" > "$RUNDIR/stats.cache"
+}
+
+github_usage_stat_target() { printf '%s\n' "$1"; }
+github_status_resources() { return 0; }
+
+# Populate cmd_usage_refresh's dynamically scoped provider-neutral output fields.
+github_usage_context() {
+  local c="$1" jline jenv jref
+  jline="$(docker logs --timestamps --tail 60 "$c" 2>&1 | grep 'Running job: ' | tail -1 | tr -d '\r')"
+  job="${jline##*Running job: }"
+  jstarted="$(echo "$jline" | awk '{print $1}' | grep -oE '^[0-9T:.Z-]+' | head -1)"; jstarted="${jstarted:-_}"
+  jenv="$(docker exec "$c" sh -c 'for p in /proc/[0-9]*/environ; do if tr "\0" "\n" < $p 2>/dev/null | grep -q "^GITHUB_REPOSITORY="; then tr "\0" "\n" < $p | grep -E "^GITHUB_(REPOSITORY|RUN_ID|REF_NAME)="; break; fi; done' 2>/dev/null)"
+  if [ -n "$jenv" ]; then
+    jrepo="$(echo "$jenv" | grep '^GITHUB_REPOSITORY=' | head -1 | cut -d= -f2)"
+    jrun="$(echo "$jenv" | grep '^GITHUB_RUN_ID=' | head -1 | cut -d= -f2 | grep -oE '^[0-9]+' | head -1)"; jrun="${jrun:-_}"
+    jref="$(echo "$jenv" | grep '^GITHUB_REF_NAME=' | head -1 | cut -d= -f2-)"
+    if echo "$jref" | grep -qE '^[0-9]+/merge$'; then jpr="${jref%%/merge*}"; else jbranch="$jref"; fi
+    project="$jrepo"; job_id="$jrun"
+    [ "$jrun" != _ ] && job_url="https://github.com/$jrepo/actions/runs/$jrun"
+    if [ "$jpr" != _ ]; then
+      ref="PR #$jpr"; ref_url="https://github.com/$jrepo/pull/$jpr"
+    else
+      ref="$jbranch"; [ -n "$jbranch" ] && ref_url="https://github.com/$jrepo/tree/$(urlencode "$jbranch")"
+    fi
+  fi
+}
+
+github_validate() {
+  check_cache_root || return 1
+  ensure_dirs
+  registry_login
+  local suffix name snapshot validation_id="" root
+  suffix="$(od -An -N6 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')"
+  printf '%s' "$suffix" | grep -qE '^[0-9a-f]{12}$' \
+    || { err "validate: could not create a random validation-container name"; return 1; }
+  name="${NAME_PREFIX}-validate-${suffix}"
+  # Dynamic scope lets github_build_args stamp a validation-specific ownership
+  # role without changing the ordinary runner contract.
+  local NO_REGISTER=1 CRF_CONTAINER_ROLE=validate
+  github_build_args 99 "$name" || return 1
+  local injected=() a eimg; eimg="$(effective_image)"
+  for a in "${ARGS[@]}"; do
+    [ "$a" = "$eimg" ] && injected+=( --entrypoint /bin/sh "$eimg" -c "sleep 30" ) || injected+=( "$a" )
+  done
+  log "validate: launching inert container to verify mounts/limits..."
+  local errf; errf="$(mktemp /tmp/crf-validate.XXXXXX)"
+  if ! docker run "${injected[@]}" >/dev/null 2>"$errf"; then
+    # docker run can leave a Created container on some failures. Remove it only
+    # when the complete labels resolve to an immutable ID owned by this attempt.
+    snapshot="$(owned_container_snapshot "$name" 99 github-validate 2>/dev/null || true)"
+    validation_id="${snapshot%%|*}"
+    [ -z "$validation_id" ] || docker rm -f "$validation_id" >/dev/null 2>&1 || true
+    err "docker run failed:"; cat "$errf" >&2; rm -f "$errf"; return 1
+  fi
+  rm -f "$errf"
+  snapshot="$(owned_container_snapshot "$name" 99 github-validate)" \
+    || { err "validate: created container failed its ownership check; leaving it untouched"; return 1; }
+  validation_id="${snapshot%%|*}"
+  echo "--- resource limits ---"
+  docker inspect -f 'cpus={{.HostConfig.NanoCpus}} mem={{.HostConfig.Memory}} pids={{.HostConfig.PidsLimit}}' "$validation_id"
+  echo "--- mounts ---"
+  docker inspect -f '{{range .Mounts}}{{.Source}} -> {{.Destination}}{{println}}{{end}}' "$validation_id"
+  echo "--- tmpfs ---"
+  docker inspect -f '{{json .HostConfig.Tmpfs}}' "$validation_id"
+  echo "--- docker.sock reachable inside container ---"
+  docker exec "$validation_id" sh -c '[ -S /var/run/docker.sock ] && echo "yes: docker.sock present" || echo "no socket"' 2>/dev/null
+  docker rm -f "$validation_id" >/dev/null 2>&1 \
+    || { err "validate: could not remove owned validation container $name"; return 1; }
+  root="$(crf_safe_cache_root)" || { err "validate: refusing cleanup under unsafe CACHE_ROOT"; return 1; }
+  rm -rf "$root/docker/$name" 2>/dev/null || true
+  log "validate: OK (container removed). Provisioning mechanics verified on this host."
+}

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/gitlab.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/gitlab.sh
@@ -742,7 +742,8 @@ gitlab_write_config() {
 }
 
 gitlab_build_manager_args() {
-  local idx="$1" name="${2:-${NAME_PREFIX}-${idx}}" dir sock sockdir socket_mount authdir slot_ca
+  local idx="$1"
+  local name="${2:-${NAME_PREFIX}-${idx}}" dir sock sockdir socket_mount authdir slot_ca
   gitlab_validate_settings || return 1
   gitlab_token_ready || { err "no valid GitLab glrt- runner token configured"; return 1; }
   gitlab_write_config "$idx" "$name" || { err "could not write GitLab config for $name"; return 1; }

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/gitlab.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/gitlab.sh
@@ -1,0 +1,1696 @@
+#!/bin/bash
+# GitLab CI/CD provider adapter for CI Runner Farm.
+# Uses persistent official Runner managers plus Docker-executor job containers.
+
+gitlab_token_ready() {
+  printf '%s' "$GITLAB_RUNNER_TOKEN" \
+    | grep -qE '^glrt-[A-Za-z0-9_.-]{10,507}$'
+}
+gitlab_token_name() { echo "GitLab runner authentication token"; }
+gitlab_builtin_image() { echo "$GITLAB_BUILTIN_IMAGE"; }
+
+# Runner 16.0 introduced manager-only unregister with system_id. Older clients
+# can route the shared glrt- token through DELETE /runners and delete the runner
+# entity used by every slot, so every mode requires a verified >=16 image.
+# Host-socket cleanup additionally relies on exact service container_labels,
+# fixed in 18.5.0. Cache successful image/requirement probes per CLI process.
+GITLAB_MANAGER_VERSION_VALIDATED_KEY="${GITLAB_MANAGER_VERSION_VALIDATED_KEY:-}"
+gitlab_validate_manager_version() {
+  local image="${1:-$GITLAB_RUNNER_IMAGE}" purpose="${2:-runtime}"
+  local output version major minor patch key
+  key="$image:$purpose:${DIND:-true}"
+  [ "$GITLAB_MANAGER_VERSION_VALIDATED_KEY" != "$key" ] || return 0
+
+  output="$(docker run --rm "$image" --version 2>&1)" \
+    || { err "could not execute GitLab Runner manager image $image --version"; return 1; }
+  version="$(printf '%s\n' "$output" \
+    | sed -nE 's/^[[:space:]]*Version:[[:space:]]*v?([0-9]{1,4})\.([0-9]{1,4})\.([0-9]{1,4})[[:space:]]*$/\1.\2.\3/p' \
+    | head -1)"
+  [ -n "$version" ] \
+    || { err "GitLab requires an official Runner image with a parseable stable version (minimum 16.0.0)"; return 1; }
+  IFS=. read -r major minor patch <<< "$version"
+  if (( 10#$major < 16 )); then
+    err "GitLab shared-manager lifecycle requires GitLab Runner 16.0.0 or newer for manager-only unregister; $image reports $version"
+    return 1
+  fi
+  if [ "$purpose" = runtime ] && [ "$DIND" != true ] \
+     && (( 10#$major < 18 || (10#$major == 18 && 10#$minor < 5) )); then
+    err "GitLab host-socket mode requires GitLab Runner 18.5.0 or newer; $image reports $version"
+    return 1
+  fi
+  GITLAB_MANAGER_VERSION_VALIDATED_KEY="$key"
+}
+
+gitlab_validate_host_socket_manager_version() {
+  gitlab_validate_manager_version "${1:-$GITLAB_RUNNER_IMAGE}" runtime
+}
+
+gitlab_shutdown_timeout() {
+  local timeout="${GITLAB_SHUTDOWN_TIMEOUT:-7200}"
+  case "$timeout" in ''|*[!0-9]*) timeout=7200 ;; esac
+  [ "$timeout" -ge 30 ] 2>/dev/null && [ "$timeout" -le 86400 ] 2>/dev/null || timeout=7200
+  printf '%s\n' "$timeout"
+}
+gitlab_docker_stopping_timeout() { gitlab_shutdown_timeout; }
+gitlab_docker_stopping() { provider_stop_container "$1"; }
+
+gitlab_confgen() {
+  # Hash the exact token values loaded after fleet.lock was acquired. Reading the
+  # files again here can pair a stale in-memory token with a freshly rotated file
+  # hash, incorrectly stamping a replacement as current.
+  printf '%s\0' gitlab "$GITLAB_URL" "$GITLAB_RUNNER_IMAGE" "$GITLAB_DIND_IMAGE" \
+    "$GITLAB_RUNNER_TOKEN" "$GITLAB_CA_FINGERPRINT" "$REGISTRY_TOKEN" \
+    "$RUNNER_CPUS" "$RUNNER_MEMORY" "$CACHE_MOUNTS" "$GITLAB_SHUTDOWN_TIMEOUT" \
+    "$GITLAB_ALLOWED_IMAGES" "$GITLAB_ALLOWED_SERVICES" "$GITLAB_PULL_POLICY" "$GITLAB_SHM_SIZE" \
+    "$DIND" "$SHARE_DOCKER_SOCK" "$IMAGE_SOURCE" "$IMAGE" \
+    "$REGISTRY_SERVER" "$REGISTRY_USERNAME" "$SHARED_IMAGE_CACHE" "$MIRROR_PORT" \
+    "$NETWORK_ISOLATION" "$RUNNER_NETWORK" "$CACHE_ROOT" \
+    | sha256sum | cut -c1-12
+}
+
+gitlab_url() {
+  local u="$GITLAB_URL"
+  while [ "${u%/}" != "$u" ]; do u="${u%/}"; done
+  printf '%s\n' "$u"
+}
+
+gitlab_validate_url() {
+  local url authority host port
+  url="$(gitlab_url)"
+  case "$url" in https://*) ;; *) err "GITLAB_URL must begin with https:// so reusable runner/API tokens are never sent in cleartext"; return 1 ;; esac
+  case "$url" in *[[:space:]\"\'\\]*|*@*|*\?*|*\#*) err "GITLAB_URL contains unsupported characters, credentials, a query, or a fragment"; return 1 ;; esac
+  authority="${url#https://}"; authority="${authority%%/*}"
+  [ -n "$authority" ] || { err "GITLAB_URL must include a host"; return 1; }
+  case "$authority" in *:*:*) err "GITLAB_URL authority must be a hostname or IPv4 address with an optional port"; return 1 ;; esac
+  host="$authority"; port=""
+  case "$authority" in *:*) host="${authority%:*}"; port="${authority##*:}" ;; esac
+  printf '%s' "$host" | grep -qE '^[A-Za-z0-9][A-Za-z0-9.-]*$' \
+    || { err "GITLAB_URL contains an invalid host"; return 1; }
+  if [ -n "$port" ]; then
+    case "$port" in *[!0-9]*) err "GITLAB_URL port must be numeric"; return 1 ;; esac
+    [ "$port" -ge 1 ] && [ "$port" -le 65535 ] || { err "GITLAB_URL port is out of range"; return 1; }
+  fi
+}
+
+gitlab_validate_image_patterns() {
+  local label="$1" raw="$2" item
+  local -a items=()
+  [ -z "$raw" ] && return 0
+  case "$raw" in *$'\n'*|*$'\r'*|*$'\t'*) err "$label must be a space-separated, single-line pattern list"; return 1 ;; esac
+  read -r -a items <<< "$raw"
+  [ "${#items[@]}" -gt 0 ] || { err "$label does not contain an image pattern"; return 1; }
+  for item in "${items[@]}"; do
+    printf '%s' "$item" | grep -qE '^[!A-Za-z0-9_./:@*?+-]+$' \
+      || { err "$label contains an unsupported image-pattern character"; return 1; }
+  done
+}
+
+gitlab_validate_cache_mounts() {
+  local m source dest rest seen=$'\n'
+  case "$CACHE_MOUNTS" in *$'\n'*|*$'\r'*|*$'\t'*) err "CACHE_MOUNTS must be a space-separated, single-line list"; return 1 ;; esac
+  for m in $CACHE_MOUNTS; do
+    case "$m" in *:*) ;; *) err "GitLab cache mount '$m' must use host-subdir:/absolute/container/path"; return 1 ;; esac
+    source="${m%%:*}"; rest="${m#*:}"; dest="$(gitlab_job_cache_destination "$rest")"
+    case "$rest" in *:*) err "GitLab cache mount '$m' contains an unsupported extra colon"; return 1 ;; esac
+    printf '%s' "$source" | grep -qE '^[A-Za-z0-9._+@/-]+$' \
+      || { err "GitLab cache mount '$m' has an unsafe host subdirectory"; return 1; }
+    case "/$source/" in *'/../'*|*'/./'*|*'//'*) err "GitLab cache mount '$m' has an unsafe host subdirectory"; return 1 ;; esac
+    printf '%s' "$dest" | grep -qE '^/[A-Za-z0-9._+@/-]+$' \
+      || { err "GitLab cache destination '$dest' must be a safe absolute Linux path"; return 1; }
+    case "$dest" in */../*|*/./*|*//*|*/) err "GitLab cache destination '$dest' must be lexically canonical"; return 1 ;; esac
+    case "$dest" in
+      /|/cache|/cache/*|/var/run/docker.sock|/var/run/docker.sock/*|/etc/gitlab-runner/certs/ca.crt|/etc/gitlab-runner/certs/ca.crt/*)
+        err "GitLab cache destination '$dest' conflicts with a Runner-managed mount"
+        return 1 ;;
+    esac
+    case "$seen" in *$'\n'"$dest"$'\n'*) err "duplicate GitLab cache destination: $dest"; return 1 ;; esac
+    seen="${seen}${dest}"$'\n'
+  done
+}
+
+gitlab_effective_pull_policy() {
+  case "$GITLAB_PULL_POLICY" in
+    auto) [ "$IMAGE_SOURCE" = "remote" ] && echo always || echo if-not-present ;;
+    *) printf '%s\n' "$GITLAB_PULL_POLICY" ;;
+  esac
+}
+
+gitlab_validate_settings() {
+  gitlab_validate_url || return 1
+  printf '%s' "$GITLAB_RUNNER_IMAGE" | grep -qE '^[A-Za-z0-9][A-Za-z0-9_./:@-]*$' \
+    || { err "GITLAB_RUNNER_IMAGE is not a safe Docker image reference"; return 1; }
+  case "$GITLAB_SHUTDOWN_TIMEOUT" in
+    ''|*[!0-9]*|0[0-9]*) err "GITLAB_SHUTDOWN_TIMEOUT must be a base-10 integer from 30 to 86400 seconds without leading zeros"; return 1 ;;
+  esac
+  [ "$GITLAB_SHUTDOWN_TIMEOUT" -ge 30 ] && [ "$GITLAB_SHUTDOWN_TIMEOUT" -le 86400 ] \
+    || { err "GITLAB_SHUTDOWN_TIMEOUT must be between 30 and 86400 seconds"; return 1; }
+  gitlab_validate_image_patterns GITLAB_ALLOWED_IMAGES "$GITLAB_ALLOWED_IMAGES" || return 1
+  gitlab_validate_image_patterns GITLAB_ALLOWED_SERVICES "$GITLAB_ALLOWED_SERVICES" || return 1
+  gitlab_validate_cache_mounts || return 1
+  case "$GITLAB_PULL_POLICY" in
+    auto|always|if-not-present) ;;
+    *) err "GITLAB_PULL_POLICY must be auto, always, or if-not-present"; return 1 ;;
+  esac
+  if [ "$GITLAB_PULL_POLICY" = always ] && [ "$IMAGE_SOURCE" != remote ]; then
+    err "GITLAB_PULL_POLICY=always requires a remote default job image; a locally built tag cannot be pulled for real jobs"
+    return 1
+  fi
+  case "$GITLAB_SHM_SIZE" in
+    ''|*[!0-9]*|0[0-9]*) err "GITLAB_SHM_SIZE must be a non-negative integer number of bytes"; return 1 ;;
+  esac
+  if [ "${#GITLAB_SHM_SIZE}" -gt 19 ] \
+     || { [ "${#GITLAB_SHM_SIZE}" -eq 19 ] && [[ "$GITLAB_SHM_SIZE" > 9223372036854775807 ]]; }; then
+    err "GITLAB_SHM_SIZE exceeds GitLab Runner's signed 64-bit byte limit"
+    return 1
+  fi
+  if [ "$DIND" != "true" ] && [ "$SHARE_DOCKER_SOCK" != "true" ]; then
+    err "GitLab's Docker executor needs DIND=true or an explicitly shared host docker.sock"
+    return 1
+  fi
+  if [ "$DIND" != "true" ] && [ "$NETWORK_ISOLATION" != "off" ]; then
+    err "GitLab host-socket mode cannot place Docker-executor job/helper/service networks on the manager's isolated bridge; use DIND=true or NETWORK_ISOLATION=off"
+    return 1
+  fi
+  if [ -n "$REGISTRY_SERVER" ] && ! gitlab_registry_authority >/dev/null 2>&1; then
+    err "REGISTRY_SERVER must be a hostname with an optional port (an https:// prefix is accepted; insecure HTTP is refused)"
+    return 1
+  fi
+  return 0
+}
+
+gitlab_strict_endpoint() { gitlab_url; }
+gitlab_registry_credentials() { return 0; }
+# The host daemon launches Docker-executor jobs only in explicit host-socket
+# mode. DinD job images must be authenticated, trusted, and pulled by the
+# private per-slot daemon instead (not prematurely by Unraid's Docker daemon).
+gitlab_remote_image_host_pull_required() { [ "$DIND" != "true" ]; }
+gitlab_prepare_remote_image() {
+  local image="$1" policy
+  [ "$DIND" != true ] || return 0
+  policy="$(gitlab_effective_pull_policy)"
+  case "$policy" in
+    always)
+      registry_login && host_docker_pull "$image" ;;
+    if-not-present)
+      docker image inspect "$image" >/dev/null 2>&1 \
+        || { registry_login && host_docker_pull "$image"; } ;;
+    *)
+      err "unsupported effective GitLab pull policy: $policy"; return 1 ;;
+  esac
+}
+gitlab_remote_image_update_allowed() {
+  [ "$DIND" != true ] && [ "$(gitlab_effective_pull_policy)" = always ]
+}
+
+gitlab_socket_path() {
+  local p
+  p="$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.socket" }}' "$1" 2>/dev/null)"
+  [ -n "$p" ] && printf '%s\n' "$p" || printf '%s\n' "$CACHE_ROOT/gitlab-sockets/$1/docker.sock"
+}
+
+gitlab_job_container() {
+  local c="$1" sock
+  sock="$(gitlab_socket_path "$c")"
+  if [ "$sock" = "/var/run/docker.sock" ]; then
+    docker ps -q \
+      --filter 'label=com.gitlab.gitlab-runner.managed=true' \
+      --filter 'label=com.gitlab.gitlab-runner.type=build' \
+      --filter "label=net.unraid.ci-runner-farm.slot=$c" 2>/dev/null | head -1
+    return
+  fi
+  docker --host "unix://$sock" ps -q \
+    --filter 'label=com.gitlab.gitlab-runner.managed=true' \
+    --filter 'label=com.gitlab.gitlab-runner.type=build' 2>/dev/null | head -1
+}
+
+# Enumerate every running build/helper/service owned by one slot. This is the
+# destructive-lifecycle guard, so inability to query the selected Docker daemon
+# is different from a positively empty result and must propagate non-zero.
+gitlab_running_executor_containers() {
+  local c="$1" sock
+  sock="$(gitlab_socket_path "$c")"
+  if [ "$sock" = "/var/run/docker.sock" ]; then
+    docker ps -q \
+      --filter 'label=com.gitlab.gitlab-runner.managed=true' \
+      --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' \
+      --filter "label=net.unraid.ci-runner-farm.slot=$c" 2>/dev/null
+    return
+  fi
+  docker --host "unix://$sock" ps -q \
+    --filter 'label=com.gitlab.gitlab-runner.managed=true' 2>/dev/null
+}
+
+gitlab_remove_host_jobs() {
+  local slot="${1:-}" jobs
+  if [ -n "$slot" ]; then
+    jobs="$(docker ps -aq \
+      --filter 'label=com.gitlab.gitlab-runner.managed=true' \
+      --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' \
+      --filter "label=net.unraid.ci-runner-farm.slot=$slot" 2>/dev/null)" \
+      || { err "could not enumerate host-socket GitLab jobs for $slot"; return 1; }
+  else
+    jobs="$(docker ps -aq \
+      --filter 'label=com.gitlab.gitlab-runner.managed=true' \
+      --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' \
+      --filter 'label=net.unraid.ci-runner-farm.slot' 2>/dev/null)" \
+      || { err "could not enumerate host-socket GitLab jobs"; return 1; }
+  fi
+  [ -z "$jobs" ] || docker rm -f $jobs >/dev/null 2>&1
+}
+
+gitlab_runner_state() {
+  local c="$1" st metrics job last
+  # The manager can be stopped while a host-socket or restarted DinD executor
+  # container is still alive (for example across a Docker-service interruption).
+  # Treat that as positively busy before consulting manager state so reconcile,
+  # autoscale, and ordinary Stop never destroy the surviving workload merely
+  # because its control process is currently exited.
+  if ! job="$(gitlab_job_container "$c")"; then
+    echo error
+    return
+  fi
+  [ -n "$job" ] && { echo busy; return; }
+  st="$(docker inspect -f '{{.State.Status}}' "$c" 2>/dev/null)"
+  [ "$st" = "running" ] || { case "$st" in created|restarting) echo starting ;; *) echo error ;; esac; return; }
+  metrics="$(docker exec "$c" sh -c 'wget -qO- http://127.0.0.1:9252/metrics 2>/dev/null || true' 2>/dev/null)"
+  printf '%s\n' "$metrics" | grep -Eq '^gitlab_runner_jobs(\{[^}]*\})?[[:space:]]+[1-9]' && { echo busy; return; }
+  last="$(docker logs --tail 30 "$c" 2>&1 | grep -iE 'Checking for jobs|Starting multi-runner|received job|job (succeeded|failed)|ERROR|FATAL' | tail -1 \
+    | tr '[:upper:]' '[:lower:]')"
+  case "$last" in
+    *"checking for jobs"*"received"*|*"received job"*) echo busy ;;
+    *error*|*fatal*) echo error ;;
+    *"checking for jobs"*|*"starting multi-runner"*|*"job succeeded"*|*"job failed"*) echo idle ;;
+    *) echo starting ;;
+  esac
+}
+
+gitlab_scale_down_eligible() { [ "$(runner_state "$1")" = idle ]; }
+gitlab_autoscale_counts() {
+  local c phase names
+  cur=0; busy=0; idle=0
+  names="$(owned_managed_names)" || return 1
+  for c in $names; do
+    [ -n "$c" ] || continue; cur=$((cur+1)); phase="$(runner_state "$c")" || return 1
+    case "$phase" in busy) busy=$((busy+1)) ;; idle) idle=$((idle+1)) ;; esac
+  done
+}
+
+gitlab_api_token_ready() {
+  [ "${#GITLAB_API_TOKEN}" -ge 8 ] && [ "${#GITLAB_API_TOKEN}" -le 512 ] \
+    && printf '%s' "$GITLAB_API_TOKEN" | grep -qE '^[A-Za-z0-9_.@:+/=~-]+$'
+}
+
+gitlab_api() {
+  local method="$1" path="$2" ca=()
+  gitlab_validate_url >/dev/null 2>&1 || return 1
+  gitlab_api_token_ready || return 1
+  [ -f "$GITLAB_CA_FILE" ] && ca=( --cacert "$GITLAB_CA_FILE" )
+  printf 'header = "PRIVATE-TOKEN: %s"\n' "$GITLAB_API_TOKEN" \
+    | curl -fsSL -g -m 12 -X "$method" --config - \
+      -H 'Accept: application/json' ${ca[@]+"${ca[@]}"} \
+      "$(gitlab_url)/api/v4${path}" 2>/dev/null
+}
+
+gitlab_api_capture() {
+  local path="$1" body="$2" headers="$3" ca=()
+  gitlab_validate_url >/dev/null 2>&1 || return 1
+  gitlab_api_token_ready || return 1
+  [ -f "$GITLAB_CA_FILE" ] && ca=( --cacert "$GITLAB_CA_FILE" )
+  printf 'header = "PRIVATE-TOKEN: %s"\n' "$GITLAB_API_TOKEN" \
+    | curl -fsSL -g -m 12 --config - -H 'Accept: application/json' \
+      ${ca[@]+"${ca[@]}"} -D "$headers" -o "$body" \
+      "$(gitlab_url)/api/v4${path}" 2>/dev/null
+}
+
+gitlab_public_repo_problem() {
+  { [ "$DIND" = "true" ] || [ "$SHARE_DOCKER_SOCK" = "true" ]; } || { echo ""; return; }
+  local cached; cached="$(security_cache_get)" && { printf '%s' "$cached"; return; }
+  local msg="" pub="" project body vis encoded
+  [ "$DIND" = true ] \
+    && msg="GitLab jobs control their privileged per-slot DinD daemon and can inspect or remove that slot's job, helper, and service containers. The slot limits ordinary Docker access but privileged DinD is not a security boundary against the Unraid host. Route only trusted projects/refs here and enforce tags/protected-runner policy in GitLab; monitored projects are telemetry only and do not define runner scope."
+  [ "$DIND" != "true" ] && [ "$SHARE_DOCKER_SOCK" = "true" ] \
+    && msg="GitLab host-socket mode gives every accepted job root-equivalent control of this Unraid host. Restrict the runner in GitLab to trusted, protected projects and refs; isolated DinD is the safer default."
+  if gitlab_api_token_ready && [ -n "$GITLAB_PROJECTS" ]; then
+    for project in $GITLAB_PROJECTS; do
+      [ -n "$project" ] || continue
+      encoded="$(urlencode "$project")"
+      body="$(gitlab_api GET "/projects/$encoded" 2>/dev/null)"
+      vis="$(printf '%s' "$body" | grep -o '"visibility"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+      [ "$vis" = public ] && pub="$pub $project"
+    done
+    [ -n "$pub" ] && msg="PUBLIC GitLab project(s) monitored while jobs can control a Docker daemon:${pub}. Untrusted merge-request code can control that slot's job, helper, and service containers; the privileged DinD sidecar is not a host security boundary. Use protected/trusted projects and runner policies. Host-socket mode directly exposes the Unraid Docker daemon. Monitored projects are advisory and do not define the runner's scope."
+  fi
+  security_cache_put "$msg"
+  printf '%s' "$msg"
+}
+
+gitlab_toml_string() {
+  local s="$1"
+  s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; s="${s//$'\n'/}"; s="${s//$'\r'/}"
+  printf '"%s"' "$s"
+}
+
+gitlab_toml_array() {
+  local raw="$1" item first=1
+  local -a items=()
+  read -r -a items <<< "$raw"
+  printf '['
+  for item in "${items[@]}"; do
+    [ "$first" -eq 1 ] || printf ', '
+    printf '%s' "$(gitlab_toml_string "$item")"
+    first=0
+  done
+  printf ']'
+}
+
+gitlab_slot_config_dir() { printf '%s/gitlab-runners/%s\n' "$CFGDIR" "$1"; }
+gitlab_socket_dir()      { printf '%s/gitlab-sockets/%s\n' "$CACHE_ROOT" "$1"; }
+gitlab_sidecar_name()    { printf '%s-dind\n' "$1"; }
+gitlab_job_cache_destination() { printf '%s\n' "$1"; }
+gitlab_slot_ca_file() { printf '%s/certs/gitlab-ca.crt\n' "$(gitlab_slot_config_dir "$1")"; }
+gitlab_unregister_marker() { printf '%s/.remote-unregister-complete\n' "$(gitlab_slot_config_dir "$1")"; }
+
+# Bind a successful remote manager deletion to the exact persisted config and
+# system ID that produced it. The marker lets a later local Docker-rm retry skip
+# a second, non-idempotent API call without ever applying to a rewritten manager.
+gitlab_unregister_identity() {
+  local dir="$1"
+  [ -s "$dir/config.toml" ] && [ -s "$dir/.runner_system_id" ] || return 1
+  { cat "$dir/config.toml"; printf '\0'; cat "$dir/.runner_system_id"; } \
+    | sha256sum | cut -d' ' -f1
+}
+
+gitlab_unregister_is_complete() {
+  local dir="$1" identity="$2" marker="$1/.remote-unregister-complete"
+  [ -s "$marker" ] && [ "$(cat "$marker" 2>/dev/null)" = "$identity" ]
+}
+
+gitlab_mark_unregister_complete() {
+  local dir="$1" identity="$2" marker="$1/.remote-unregister-complete" tmp
+  tmp="$marker.tmp"
+  ( umask 077; printf '%s\n' "$identity" > "$tmp" ) || return 1
+  chmod 600 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$marker"
+}
+
+gitlab_clear_unregister_complete() {
+  local dir="$1"
+  rm -f "$dir/.remote-unregister-complete" "$dir/.remote-unregister-complete.tmp"
+}
+
+# Each manager keeps the CA that was active when its URL/token config was
+# generated. Retirement must use that same trust snapshot even if Settings has
+# already replaced or removed the farm-wide CA while a stale manager drains.
+gitlab_snapshot_ca() {
+  local dir="$1" dest="$1/certs/gitlab-ca.crt" tmp="$1/certs/gitlab-ca.crt.tmp"
+  mkdir -p "$dir/certs" || return 1
+  chmod 700 "$dir/certs" 2>/dev/null || true
+  if [ "$GITLAB_CA_PRESENT" = true ]; then
+    [ "$GITLAB_CA_FINGERPRINT" != "!" ] || return 1
+    ( umask 077; printf '%s\n' "$GITLAB_CA_CONTENT" > "$tmp" ) || return 1
+    chmod 600 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+    mv "$tmp" "$dest" || { rm -f "$tmp"; return 1; }
+  else
+    rm -f "$dest" "$tmp" || return 1
+  fi
+}
+
+gitlab_ensure_system_id() {
+  local dir="$1" file="$1/.runner_system_id" tmp id
+  # GitLab Runner accepts exactly an s_/r_ prefix plus 12 alphanumeric
+  # characters. An arbitrary longer identifier is treated as missing and Runner
+  # silently generates a different one, defeating persistence across restarts.
+  if [ -e "$file" ] || [ -L "$file" ]; then
+    [ ! -L "$file" ] && [ -f "$file" ] && [ -s "$file" ] \
+      && grep -qE '^[sr]_[0-9A-Za-z]{12}$' "$file" 2>/dev/null \
+      || { err "refusing to replace an invalid persisted GitLab runner system ID in $dir"; return 1; }
+    chmod 600 "$file" 2>/dev/null \
+      || { err "could not protect persisted GitLab runner system ID in $dir"; return 1; }
+    return 0
+  fi
+  # Six random bytes produce the same 12-hex-character payload length used by
+  # Runner's stable system-ID contract, while remaining unique per farm slot.
+  id="r_$(od -An -N6 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')"
+  printf '%s' "$id" | grep -qE '^r_[a-f0-9]{12}$' \
+    || { err "could not generate a unique GitLab runner system ID"; return 1; }
+  tmp="$file.tmp"
+  ( umask 077; printf '%s\n' "$id" > "$tmp" ) || return 1
+  chmod 600 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$file"
+}
+
+# POST /runners/verify with a glrt- token is not read-only: GitLab ensures a
+# manager row for the supplied system ID. Use a dedicated persistent probe
+# identity and immediately unregister that exact manager through the official
+# >=16 client. If the process or network fails between those operations, keep
+# the protected probe config so the next attempt can re-verify (idempotently)
+# and finish manager-only cleanup before any fleet slot is retired.
+gitlab_probe_dir() { printf '%s/gitlab-token-probe\n' "$CFGDIR"; }
+gitlab_probe_name() { printf '%s\n' 'ci-runner-farm-token-probe'; }
+gitlab_probe_target() {
+  printf '%s\0' "$(gitlab_url)" "$GITLAB_RUNNER_TOKEN" "$GITLAB_CA_FINGERPRINT" \
+    | sha256sum | cut -d' ' -f1
+}
+
+gitlab_probe_scrub() {
+  local dir="$1"
+  rm -f "$dir/config.toml" "$dir/config.toml.tmp" \
+    "$dir/.target" "$dir/.target.tmp" \
+    "$dir/certs/gitlab-ca.crt" "$dir/certs/gitlab-ca.crt.tmp" || return 1
+  rmdir "$dir/certs" 2>/dev/null || true
+}
+
+gitlab_probe_write() {
+  local dir="$1" tmp="$1/config.toml.tmp" target_tmp="$1/.target.tmp"
+  local slot_ca="$1/certs/gitlab-ca.crt"
+  mkdir -p "$dir" "$dir/certs" || return 1
+  chmod 700 "$dir" "$dir/certs" 2>/dev/null || return 1
+  gitlab_ensure_system_id "$dir" || return 1
+  gitlab_snapshot_ca "$dir" || return 1
+  ( umask 077
+    {
+      echo 'concurrent = 1'
+      echo '[[runners]]'
+      printf '  name = %s\n' "$(gitlab_toml_string "$(gitlab_probe_name)")"
+      printf '  url = %s\n' "$(gitlab_toml_string "$(gitlab_url)")"
+      printf '  token = %s\n' "$(gitlab_toml_string "$GITLAB_RUNNER_TOKEN")"
+      echo '  executor = "docker"'
+      [ -f "$slot_ca" ] && echo '  tls-ca-file = "/etc/gitlab-runner/certs/gitlab-ca.crt"'
+    } > "$tmp"
+    printf '%s\n' "$(gitlab_probe_target)" > "$target_tmp"
+  ) || { rm -f "$tmp" "$target_tmp"; return 1; }
+  chmod 600 "$tmp" "$target_tmp" 2>/dev/null \
+    || { rm -f "$tmp" "$target_tmp"; return 1; }
+  mv "$tmp" "$dir/config.toml" && mv "$target_tmp" "$dir/.target"
+}
+
+# Echo only the HTTP status. Saved probe material is parsed from the restricted
+# TOML so interrupted cleanup remains possible even after Settings changes.
+gitlab_probe_verify_request() {
+  local dir="$1" url token system_id body code ca=()
+  url="$(sed -n 's/^[[:space:]]*url[[:space:]]*=[[:space:]]*"\([^"]*\)"[[:space:]]*$/\1/p' "$dir/config.toml" | head -1)"
+  token="$(sed -n 's/^[[:space:]]*token[[:space:]]*=[[:space:]]*"\(glrt-[A-Za-z0-9_.-]*\)"[[:space:]]*$/\1/p' "$dir/config.toml" | head -1)"
+  system_id="$(cat "$dir/.runner_system_id" 2>/dev/null)"
+  local GITLAB_URL="$url"
+  gitlab_validate_url >/dev/null 2>&1 || return 1
+  printf '%s' "$token" | grep -qE '^glrt-[A-Za-z0-9_.-]{10,507}$' || return 1
+  printf '%s' "$system_id" | grep -qE '^[sr]_[0-9A-Za-z]{12}$' || return 1
+  if grep -qE '^[[:space:]]*tls-ca-file[[:space:]]*=' "$dir/config.toml"; then
+    [ -s "$dir/certs/gitlab-ca.crt" ] || return 1
+    ca=( --cacert "$dir/certs/gitlab-ca.crt" )
+  fi
+  body="token=$(urlencode "$token")&system_id=$(urlencode "$system_id")"
+  code="$(printf '%s' "$body" \
+    | curl -sS -g -m 12 -X POST -o /dev/null -w '%{http_code}' \
+      -H 'Accept: application/json' \
+      -H 'Content-Type: application/x-www-form-urlencoded' \
+      --data-binary @- ${ca[@]+"${ca[@]}"} \
+      "$(gitlab_url)/api/v4/runners/verify" 2>/dev/null)" || return 1
+  printf '%s\n' "$code"
+}
+
+gitlab_probe_unregister() {
+  local dir="$1" image="$GITLAB_RUNNER_IMAGE" network tmpdir ca_source="" saved_url
+  docker image inspect "$image" >/dev/null 2>&1 \
+    || host_docker_pull "$image" >/dev/null 2>&1 \
+    || { err "could not obtain GitLab Runner image for token-probe cleanup"; return 1; }
+  gitlab_validate_manager_version "$image" unregister || return 1
+  [ "$NETWORK_ISOLATION" = off ] && network=bridge || network="$RUNNER_NETWORK"
+  printf '%s' "$network" | grep -qE '^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$' || return 1
+  if ! docker network inspect "$network" >/dev/null 2>&1; then
+    ensure_network \
+      || { err "GitLab token probe cannot create missing Docker network $network"; return 1; }
+  fi
+  if [ "$NETWORK_ISOLATION" = strict ]; then
+    saved_url="$(sed -n 's/^[[:space:]]*url[[:space:]]*=[[:space:]]*"\([^"]*\)"[[:space:]]*$/\1/p' "$dir/config.toml" | head -1)"
+    local CI_PROVIDER=gitlab GITLAB_URL="$saved_url"
+    firewall_prepare_replacement \
+      || { err "GitLab token probe cannot install its saved strict endpoint exception"; return 1; }
+  fi
+  tmpdir="$(mktemp -d "$RUNDIR/gitlab-token-probe.XXXXXX" 2>/dev/null)" || return 1
+  chmod 700 "$tmpdir" 2>/dev/null || { rm -rf "$tmpdir"; return 1; }
+  if ! ( umask 077; cp "$dir/config.toml" "$tmpdir/config.toml" \
+      && cp "$dir/.runner_system_id" "$tmpdir/.runner_system_id" ); then
+    rm -rf "$tmpdir"; return 1
+  fi
+  if grep -qE '^[[:space:]]*tls-ca-file[[:space:]]*=' "$tmpdir/config.toml"; then
+    ca_source="$dir/certs/gitlab-ca.crt"
+    [ -s "$ca_source" ] || { rm -rf "$tmpdir"; return 1; }
+    mkdir -p "$tmpdir/certs" \
+      && ( umask 077; cp "$ca_source" "$tmpdir/certs/gitlab-ca.crt" ) \
+      || { rm -rf "$tmpdir"; return 1; }
+  fi
+  chmod 600 "$tmpdir/config.toml" "$tmpdir/.runner_system_id" 2>/dev/null \
+    || { rm -rf "$tmpdir"; return 1; }
+  if [ -n "$ca_source" ]; then
+    chmod 600 "$tmpdir/certs/gitlab-ca.crt" 2>/dev/null \
+      || { rm -rf "$tmpdir"; return 1; }
+  fi
+  if ! docker run --rm --network "$network" -v "$tmpdir:/etc/gitlab-runner" "$image" \
+      unregister --name "$(gitlab_probe_name)" >/dev/null 2>&1; then
+    rm -rf "$tmpdir"
+    err "GitLab token probe manager could not be unregistered; protected retry material was retained"
+    return 1
+  fi
+  rm -rf "$tmpdir"
+}
+
+gitlab_recover_pending_probe() {
+  local dir old_target code
+  dir="$(gitlab_probe_dir)"
+  if [ ! -s "$dir/config.toml" ]; then
+    # The API call happens only after the complete config is atomically
+    # published. Partial temp files therefore cannot represent a remote manager.
+    rm -f "$dir/config.toml.tmp" "$dir/.target" "$dir/.target.tmp" \
+      "$dir/certs/gitlab-ca.crt.tmp" 2>/dev/null || return 1
+    return 0
+  fi
+  old_target="$(cat "$dir/.target" 2>/dev/null || true)"
+  code="$(gitlab_probe_verify_request "$dir")" \
+    || { err "GitLab token probe has an unknown remote state; retry with its saved URL/token/CA available"; return 1; }
+  [ "$code" = 200 ] \
+    || { err "GitLab cannot recover the pending token probe manager (HTTP ${code:-unknown}); restore its prior credential or remove that manager in GitLab"; return 1; }
+  gitlab_probe_unregister "$dir" || return 1
+  gitlab_probe_scrub "$dir" || { err "could not scrub completed GitLab token probe"; return 1; }
+  GITLAB_RECOVERED_PROBE_TARGET="$old_target"
+}
+
+gitlab_verify_manager_token() {
+  local name="$1" suffix dir current_target code fresh=0
+  case "$name" in "$NAME_PREFIX"-[0-9]*) suffix="${name#"$NAME_PREFIX"-}" ;; *) err "refusing unsafe GitLab verification slot: $name"; return 1 ;; esac
+  case "$suffix" in ''|*[!0-9]*) err "refusing unsafe GitLab verification slot: $name"; return 1 ;; esac
+  dir="$(gitlab_probe_dir)"
+  GITLAB_RECOVERED_PROBE_TARGET=""
+  gitlab_recover_pending_probe || return 1
+  gitlab_validate_url || return 1
+  gitlab_token_ready || { err "no valid GitLab glrt- runner token configured"; return 1; }
+  current_target="$(gitlab_probe_target)"
+  if [ "${GITLAB_TOKEN_PROBE_VALIDATED_TARGET:-}" = "$current_target" ]; then
+    return 0
+  fi
+  if [ -n "$GITLAB_RECOVERED_PROBE_TARGET" ] \
+     && [ "$GITLAB_RECOVERED_PROBE_TARGET" = "$current_target" ]; then
+    GITLAB_TOKEN_PROBE_VALIDATED_TARGET="$current_target"
+    log "verified GitLab runner authentication for $name and removed its temporary probe manager"
+    return 0
+  fi
+
+  gitlab_probe_write "$dir" || { err "could not persist the GitLab token probe identity"; return 1; }
+  fresh=1
+  if ! code="$(gitlab_probe_verify_request "$dir")"; then
+    err "GitLab token verification outcome is unknown; retry to complete exact probe-manager cleanup"
+    return 1
+  fi
+  if [ "$code" != 200 ]; then
+    if [ "$fresh" = 1 ] && [ "$code" = 403 ]; then
+      gitlab_probe_scrub "$dir" || true
+      err "GitLab rejected the runner token (HTTP 403)"
+    else
+      err "GitLab token verification failed (HTTP ${code:-unknown}); retry to complete probe-manager cleanup"
+    fi
+    return 1
+  fi
+  gitlab_probe_unregister "$dir" || return 1
+  gitlab_probe_scrub "$dir" || { err "could not scrub completed GitLab token probe"; return 1; }
+  GITLAB_TOKEN_PROBE_VALIDATED_TARGET="$current_target"
+  log "verified GitLab runner authentication for $name and removed its temporary probe manager"
+}
+
+gitlab_write_docker_auth() {
+  local name="$1" dir file auth authority
+  dir="$(gitlab_slot_config_dir "$name")/docker"; file="$dir/config.json"
+  mkdir -p "$dir" || return 1; chmod 700 "$dir" 2>/dev/null || true
+  # GitLab jobs and services may override a locally built default image. Keep
+  # configured registry auth available to every manager even in that case; the
+  # GitHub adapter retains its historical remote-default-only host login policy.
+  if [ -z "$REGISTRY_SERVER" ] || [ -z "$REGISTRY_USERNAME" ] || [ -z "$REGISTRY_TOKEN" ]; then
+    rm -f "$file" 2>/dev/null \
+      || { err "could not remove stale registry auth for $name"; return 1; }
+    return 0
+  fi
+  authority="$(gitlab_registry_authority)" \
+    || { err "registry server is not a safe hostname/port authority"; return 1; }
+  auth="$(printf '%s:%s' "$REGISTRY_USERNAME" "$REGISTRY_TOKEN" | base64 | tr -d '\r\n')"
+  ( umask 077; printf '{"auths":{"%s":{"auth":"%s"}}}\n' \
+      "$(printf '%s' "$authority" | json_escape)" "$(printf '%s' "$auth" | json_escape)" > "$file.tmp" ) || return 1
+  chmod 600 "$file.tmp" 2>/dev/null || { rm -f "$file.tmp"; return 1; }
+  mv "$file.tmp" "$file"
+}
+
+# Docker's registry trust directory is keyed by the exact registry authority
+# (hostname, plus a non-default port). Keep this parser deliberately narrower
+# than a general URL parser: its output becomes part of a DinD mount target.
+gitlab_registry_authority() {
+  local spec="$REGISTRY_SERVER" host port=""
+  case "$spec" in https://*) spec="${spec#https://}" ;; http://*) return 1 ;; *://*) return 1 ;; esac
+  spec="${spec%%/*}"
+  case "$spec" in ''|*[[:space:]\"\'\\]*|*@*|*,*|*\?*|*\#*|*:*:*) return 1 ;; esac
+  host="$spec"
+  case "$spec" in *:*) host="${spec%:*}"; port="${spec##*:}" ;; esac
+  printf '%s' "$host" | grep -qE '^[A-Za-z0-9][A-Za-z0-9.-]*$' || return 1
+  if [ -n "$port" ]; then
+    case "$port" in *[!0-9]*) return 1 ;; esac
+    [ "$port" -ge 1 ] && [ "$port" -le 65535 ] || return 1
+  fi
+  printf '%s\n' "$spec"
+}
+
+gitlab_write_config() {
+  local idx="$1" name="$2" dir tmp url token job_image socket_source executor_host pull_policy slot_ca
+  dir="$(gitlab_slot_config_dir "$name")"; tmp="$dir/config.toml.tmp"
+  slot_ca="$dir/certs/gitlab-ca.crt"
+  url="$(gitlab_url)"; token="$GITLAB_RUNNER_TOKEN"; job_image="$(effective_image)"
+  if [ "$DIND" = "true" ]; then
+    socket_source="/runner-services/docker.sock"
+    executor_host="unix:///runner-services/docker.sock"
+  else
+    socket_source="/var/run/docker.sock"
+    executor_host="unix:///var/run/docker.sock"
+  fi
+  pull_policy="$(gitlab_effective_pull_policy)"
+  mkdir -p "$dir" "$dir/certs" || return 1
+  chmod 700 "$dir" "$dir/certs" 2>/dev/null || true
+  gitlab_ensure_system_id "$dir" || return 1
+  gitlab_snapshot_ca "$dir" || return 1
+  local vols=() m hostdir dest i
+  mkdir -p "$CACHE_ROOT/gitlab-cache/$name" || return 1
+  vols+=( "$socket_source:/var/run/docker.sock" "$CACHE_ROOT/gitlab-cache/$name:/cache" )
+  # The helper image automatically installs a CA mounted at this documented
+  # path. User-selected job images receive the file too, but must install or
+  # explicitly use it themselves because their CA tooling is image-specific.
+  [ -f "$slot_ca" ] \
+    && vols+=( "$slot_ca:/etc/gitlab-runner/certs/ca.crt:ro" )
+  for m in $CACHE_MOUNTS; do
+    [ -n "$m" ] || continue
+    hostdir="$(crf_safe_mount_subdir "${m%%:*}")" \
+      || { err "refusing unsafe GitLab cache mount '${m%%:*}'"; return 1; }
+    dest="$(gitlab_job_cache_destination "${m#*:}")"
+    vols+=( "$hostdir:$dest" )
+  done
+  ( umask 077
+    {
+      echo 'concurrent = 1'
+      echo 'check_interval = 0'
+      printf 'shutdown_timeout = %s\n' "$GITLAB_SHUTDOWN_TIMEOUT"
+      echo 'listen_address = "127.0.0.1:9252"'
+      echo
+      echo '[[runners]]'
+      printf '  name = %s\n' "$(gitlab_toml_string "$(host)-$name")"
+      printf '  url = %s\n' "$(gitlab_toml_string "$url")"
+      printf '  token = %s\n' "$(gitlab_toml_string "$token")"
+      echo '  executor = "docker"'
+      echo '  limit = 1'
+      echo '  request_concurrency = 1'
+      echo '  environment = ["FF_NETWORK_PER_BUILD=1"]'
+      [ -f "$slot_ca" ] && echo '  tls-ca-file = "/etc/gitlab-runner/certs/gitlab-ca.crt"'
+      echo '  [runners.docker]'
+      printf '    host = %s\n' "$(gitlab_toml_string "$executor_host")"
+      echo '    tls_verify = false'
+      printf '    image = %s\n' "$(gitlab_toml_string "$job_image")"
+      printf '    pull_policy = %s\n' "$(gitlab_toml_string "$pull_policy")"
+      printf '    allowed_pull_policies = [%s]\n' "$(gitlab_toml_string "$pull_policy")"
+      [ -n "$GITLAB_ALLOWED_IMAGES" ] \
+        && printf '    allowed_images = %s\n' "$(gitlab_toml_array "$GITLAB_ALLOWED_IMAGES")"
+      [ -n "$GITLAB_ALLOWED_SERVICES" ] \
+        && printf '    allowed_services = %s\n' "$(gitlab_toml_array "$GITLAB_ALLOWED_SERVICES")"
+      echo '    privileged = false'
+      echo '    disable_entrypoint_overwrite = false'
+      echo '    oom_kill_disable = false'
+      echo '    disable_cache = false'
+      [ -n "$RUNNER_CPUS" ] && printf '    cpus = %s\n    service_cpus = %s\n' "$(gitlab_toml_string "$RUNNER_CPUS")" "$(gitlab_toml_string "$RUNNER_CPUS")"
+      [ -n "$RUNNER_MEMORY" ] && printf '    memory = %s\n    service_memory = %s\n' "$(gitlab_toml_string "$RUNNER_MEMORY")" "$(gitlab_toml_string "$RUNNER_MEMORY")"
+      printf '    shm_size = %s\n' "$GITLAB_SHM_SIZE"
+      printf '    volumes = ['
+      for ((i=0; i<${#vols[@]}; i++)); do
+        [ "$i" -gt 0 ] && printf ', '
+        printf '%s' "$(gitlab_toml_string "${vols[$i]}")"
+      done
+      echo ']'
+      echo '    [runners.docker.container_labels]'
+      echo '      "net.unraid.ci-runner-farm.provider" = "gitlab"'
+      printf '      "net.unraid.ci-runner-farm.slot" = %s\n' "$(gitlab_toml_string "$name")"
+    } > "$tmp"
+  ) || { rm -f "$tmp"; return 1; }
+  chmod 600 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  # A completed marker belongs to the manager represented by the previous live
+  # config. Clear it before publishing a replacement, even when all visible
+  # settings (and therefore the rendered TOML) happen to be identical.
+  gitlab_clear_unregister_complete "$dir" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$dir/config.toml"
+}
+
+gitlab_build_manager_args() {
+  local idx="$1" name="${2:-${NAME_PREFIX}-${idx}}" dir sock sockdir socket_mount authdir slot_ca
+  gitlab_validate_settings || return 1
+  gitlab_token_ready || { err "no valid GitLab glrt- runner token configured"; return 1; }
+  gitlab_write_config "$idx" "$name" || { err "could not write GitLab config for $name"; return 1; }
+  gitlab_write_docker_auth "$name" || { err "could not write registry auth for $name"; return 1; }
+  dir="$(gitlab_slot_config_dir "$name")"
+  slot_ca="$dir/certs/gitlab-ca.crt"
+  if [ "$DIND" = "true" ]; then
+    sockdir="$(gitlab_socket_dir "$name")"
+    sock="$sockdir/docker.sock"
+    socket_mount="$sockdir:/runner-services"
+  else
+    sock="/var/run/docker.sock"
+    socket_mount="/var/run/docker.sock:/var/run/docker.sock"
+  fi
+  ARGS=(
+    -d --restart=no --name "$name" --hostname "$name" --pids-limit=2048
+    --stop-signal SIGQUIT --stop-timeout "$GITLAB_SHUTDOWN_TIMEOUT"
+    --label "${MANAGED_LABEL%=*}=true"
+    --label "net.unraid.ci-runner-farm.provider=gitlab"
+    --label "net.unraid.ci-runner-farm.role=manager"
+    --label "net.unraid.ci-runner-farm.index=${idx}"
+    --label "net.unraid.ci-runner-farm.confgen=$(crf_confgen)"
+    --label "net.unraid.ci-runner-farm.socket=${sock}"
+    # Local process liveness only. A GitLab/network/CA outage must not make a
+    # healthy manager "unhealthy" and trigger destructive job reaping.
+    --health-cmd 'wget -qO- http://127.0.0.1:9252/metrics >/dev/null 2>&1'
+    --health-interval 30s --health-timeout 12s --health-retries 3 --health-start-period 30s
+    -v "$dir:/etc/gitlab-runner"
+    # Mount the directory in DinD mode, not the current socket inode. If the
+    # independently restarting sidecar recreates docker.sock, the manager sees
+    # the new file without needing its own container restart.
+    -v "$socket_mount"
+  )
+  [ -f "$slot_ca" ] && ARGS+=( -v "$slot_ca:/etc/gitlab-runner/certs/gitlab-ca.crt:ro" )
+  authdir="$dir/docker"
+  if [ -f "$authdir/config.json" ]; then
+    ARGS+=( -v "$authdir:/root/.docker:ro" -v "$authdir:/home/gitlab-runner/.docker:ro" )
+  fi
+  [ "$NETWORK_ISOLATION" != "off" ] && ARGS+=( --network "$RUNNER_NETWORK" )
+  ARGS+=( "$GITLAB_RUNNER_IMAGE" )
+}
+
+gitlab_build_args() { gitlab_build_manager_args "$@"; }
+
+gitlab_start_sidecar() {
+  local idx="$1" name="$2" side sockdir sock data m hostdir registry_authority slot_ca
+  side="$(gitlab_sidecar_name "$name")"
+  if [ "$DIND" != "true" ]; then
+    if docker inspect "$side" >/dev/null 2>&1; then
+      gitlab_sidecar_owned "$side" \
+        || { err "refusing to remove unowned container name collision: $side"; return 1; }
+      docker rm -f "$side" >/dev/null 2>&1 || return 1
+    fi
+    return 0
+  fi
+  sockdir="$(gitlab_socket_dir "$name")"; sock="$sockdir/docker.sock"; data="$CACHE_ROOT/docker/$name"
+  slot_ca="$(gitlab_slot_ca_file "$name")"
+  if docker inspect "$side" >/dev/null 2>&1; then
+    gitlab_sidecar_owned "$side" \
+      || { err "refusing to replace unowned container name collision: $side"; return 1; }
+    if docker ps --format '{{.Names}}' | grep -qx "$side" \
+       && [ "$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.confgen" }}' "$side" 2>/dev/null)" = "$(crf_confgen)" ] \
+       && [ "$(docker inspect -f '{{.Config.Image}}' "$side" 2>/dev/null)" = "$GITLAB_DIND_IMAGE" ] \
+       && on_expected_network "$side" \
+       && docker --host "unix://$sock" info >/dev/null 2>&1; then return 0; fi
+    local workloads
+    if docker ps --format '{{.Names}}' | grep -qx "$side"; then
+      if ! workloads="$(gitlab_running_executor_containers "$name")"; then
+        err "refusing to replace $side because its running executor workload cannot be enumerated"
+        return 1
+      fi
+      if [ -n "$workloads" ]; then
+        err "refusing to replace $side while GitLab executor containers are still running"
+        return 1
+      fi
+    fi
+    docker stop -t 30 "$side" >/dev/null 2>&1 || true
+    docker rm -f "$side" >/dev/null 2>&1 \
+      || { err "could not replace stale GitLab sidecar $side"; return 1; }
+  fi
+  mkdir -p "$sockdir" "$data" "$CACHE_ROOT/dind-logs/$name" || return 1
+  chmod 700 "$sockdir" 2>/dev/null || true
+  rm -f "$sock" 2>/dev/null || true
+  log "starting private GitLab Docker daemon $side"
+  local sargs=(
+    -d --restart=unless-stopped --name "$side" --hostname "$side" --privileged --pids-limit=4096
+    --label "net.unraid.ci-runner-farm.sidecar=true"
+    --label "net.unraid.ci-runner-farm.provider=gitlab"
+    --label "net.unraid.ci-runner-farm.role=dind"
+    --label "net.unraid.ci-runner-farm.index=${idx}"
+    --label "net.unraid.ci-runner-farm.confgen=$(crf_confgen)"
+    -e DOCKER_TLS_CERTDIR=
+    -v "$data:/var/lib/docker"
+    -v "$sockdir:/runner-services"
+    -v "$CACHE_ROOT/dind-daemon.json:/etc/docker/daemon.json:ro"
+    -v "$CACHE_ROOT/dind-logs/$name:/var/log/dind"
+    # The nested daemon must see bind sources at the same absolute paths used
+    # in config.toml. Expose only this slot's cache and explicitly configured
+    # shared cache directories—never the whole CACHE_ROOT or sibling slots.
+    -v "$CACHE_ROOT/gitlab-cache/$name:$CACHE_ROOT/gitlab-cache/$name"
+  )
+  if [ -f "$slot_ca" ]; then
+    # The nested daemon resolves config.toml bind sources in its own mount
+    # namespace, so mirror the host CA at the identical absolute path. Also
+    # teach dockerd to trust that CA for the explicitly configured registry;
+    # arbitrary image override registries remain operator-owned configuration.
+    sargs+=( --mount "type=bind,src=$slot_ca,dst=$slot_ca,readonly" )
+    registry_authority="$(gitlab_registry_authority 2>/dev/null || true)"
+    [ -n "$registry_authority" ] \
+      && sargs+=( --mount "type=bind,src=$slot_ca,dst=/etc/docker/certs.d/$registry_authority/ca.crt,readonly" )
+  fi
+  for m in $CACHE_MOUNTS; do
+    [ -n "$m" ] || continue
+    hostdir="$(crf_safe_mount_subdir "${m%%:*}")" || continue
+    sargs+=( -v "$hostdir:$hostdir" )
+  done
+  [ -n "$RUNNER_CPUS" ]   && sargs+=( --cpus="$RUNNER_CPUS" )
+  [ -n "$RUNNER_MEMORY" ] && sargs+=( --memory="$RUNNER_MEMORY" )
+  [ "$NETWORK_ISOLATION" != "off" ] && sargs+=( --network "$RUNNER_NETWORK" )
+  [ "$SHARED_IMAGE_CACHE" = "true" ] && [ "$NETWORK_ISOLATION" = "off" ] \
+    && sargs+=( --add-host "host.docker.internal:host-gateway" )
+  sargs+=( "$GITLAB_DIND_IMAGE" --host=unix:///runner-services/docker.sock )
+  docker run "${sargs[@]}" >/dev/null || return 1
+  local i
+  for i in $(seq 1 60); do
+    docker --host "unix://$sock" info >/dev/null 2>&1 && return 0
+    sleep 1
+  done
+  err "$side did not expose a healthy Docker socket"
+  docker logs --tail 40 "$side" >&2 2>/dev/null || true
+  gitlab_remove_sidecar "$name" false >/dev/null 2>&1 || true
+  return 1
+}
+
+gitlab_ensure_job_image() {
+  local name="$1" image sock dir host_id nested_id policy
+  image="$(effective_image)"
+  if [ "$DIND" = "true" ]; then sock="$(gitlab_socket_dir "$name")/docker.sock"; else sock="/var/run/docker.sock"; fi
+  policy="$(gitlab_effective_pull_policy)"
+  if [ "$IMAGE_SOURCE" = "remote" ] && [ -n "$IMAGE" ]; then
+    dir="$(gitlab_slot_config_dir "$name")/docker"
+    case "$policy" in
+      always) ;;
+      if-not-present)
+        docker --host "unix://$sock" image inspect "$image" >/dev/null 2>&1 && return 0 ;;
+      *) err "unsupported effective GitLab pull policy: $policy"; return 1 ;;
+    esac
+    if [ -f "$dir/config.json" ]; then
+      docker --config "$dir" --host "unix://$sock" pull "$image" >/dev/null
+    else
+      docker --host "unix://$sock" pull "$image" >/dev/null
+    fi
+  else
+    docker image inspect "$image" >/dev/null 2>&1 || { err "built-in GitLab job image '$image' is unavailable — build it on the Runner image tab"; return 1; }
+    host_id="$(docker image inspect -f '{{.Id}}' "$image" 2>/dev/null)"
+    nested_id="$(docker --host "unix://$sock" image inspect -f '{{.Id}}' "$image" 2>/dev/null)"
+    if [ "$DIND" = "true" ]; then
+      local load_builtin=false
+      case "$GITLAB_PULL_POLICY" in
+        # The upgrade-safe default keeps each private daemon synchronized with a
+        # newly rebuilt local image. Explicit policies retain their ordinary
+        # Docker meanings instead of overwriting an already cached image.
+        auto) [ "$host_id" != "$nested_id" ] && load_builtin=true ;;
+        always) load_builtin=true ;;
+        if-not-present) [ -z "$nested_id" ] && load_builtin=true ;;
+        *) err "unsupported GitLab pull policy: $GITLAB_PULL_POLICY"; return 1 ;;
+      esac
+      if [ "$load_builtin" = true ]; then
+        log "loading built-in GitLab job image into $name's private Docker daemon"
+        docker image save "$image" | docker --host "unix://$sock" image load >/dev/null || return 1
+      fi
+    fi
+  fi
+}
+
+gitlab_unregister_manager() {
+  local c="$1" dir image manager_name manager_network manager_networks network_count
+  local runner_entries manager_names manager_tokens
+  local identity marker tmpdir temp_config slot_ca ca_source="" unregister_ok=0
+  docker inspect "$c" >/dev/null 2>&1 || return 0
+  dir="$(gitlab_slot_config_dir "$c")"
+  [ -s "$dir/config.toml" ] \
+    || { log "warning: cannot unregister GitLab manager $c without its config.toml"; return 1; }
+  runner_entries="$(grep -cE '^[[:space:]]*\[\[runners\]\][[:space:]]*$' "$dir/config.toml" 2>/dev/null || true)"
+  manager_names="$(grep -cE '^[[:space:]]*name[[:space:]]*=' "$dir/config.toml" 2>/dev/null || true)"
+  manager_tokens="$(grep -cE '^[[:space:]]*token[[:space:]]*=' "$dir/config.toml" 2>/dev/null || true)"
+  [ "$runner_entries" = 1 ] && [ "$manager_names" = 1 ] && [ "$manager_tokens" = 1 ] \
+    || { log "warning: refusing to unregister $c: config.toml must contain exactly one runner manager"; return 1; }
+  # This farm supports only modern glrt- authentication tokens. That token form
+  # makes `unregister` call GitLab's manager-only endpoint with this directory's
+  # persisted system ID. Refuse older registration-created token forms because
+  # their unregister path can delete the shared runner entity used by every slot.
+  grep -qE '^[[:space:]]*token[[:space:]]*=[[:space:]]*"glrt-[A-Za-z0-9_.-]{10,507}"[[:space:]]*$' "$dir/config.toml" \
+    || { log "warning: refusing to unregister $c: config.toml does not contain a modern glrt- manager token"; return 1; }
+  # Select the one entry persisted for this slot. Read its saved name rather than
+  # recomputing from the current hostname, which may have changed since creation.
+  manager_name="$(sed -n 's/^[[:space:]]*name[[:space:]]*=[[:space:]]*"\([A-Za-z0-9_.-]*\)"[[:space:]]*$/\1/p' "$dir/config.toml" | head -1)"
+  [ -n "$manager_name" ] \
+    || { log "warning: refusing to unregister $c: config.toml has no safe manager name"; return 1; }
+  [ -s "$dir/.runner_system_id" ] \
+    && grep -qE '^[sr]_[0-9A-Za-z]{12}$' "$dir/.runner_system_id" 2>/dev/null \
+    || { log "warning: refusing to unregister $c without its persisted system ID"; return 1; }
+  # Retirement is called only after SIGQUIT has stopped the manager. Refusing a
+  # direct unregister of a live process prevents it from accepting another job
+  # between remote deletion and local container removal.
+  if docker inspect -f '{{.State.Running}}' "$c" 2>/dev/null | grep -qx true; then
+    log "warning: refusing to unregister GitLab manager $c while it is still running"
+    return 1
+  fi
+
+  identity="$(gitlab_unregister_identity "$dir")" \
+    || { log "warning: could not fingerprint persisted GitLab manager $c"; return 1; }
+  marker="$(gitlab_unregister_marker "$c")"
+  if gitlab_unregister_is_complete "$dir" "$identity"; then
+    log "GitLab manager $c was already unregistered remotely; retrying local cleanup"
+    return 0
+  fi
+
+  image="$(docker inspect -f '{{.Image}}' "$c" 2>/dev/null)"
+  [ -n "$image" ] || image="$(docker inspect -f '{{.Config.Image}}' "$c" 2>/dev/null)"
+  [ -n "$image" ] \
+    || { log "warning: cannot resolve the image for stopped GitLab manager $c"; return 1; }
+  gitlab_validate_manager_version "$image" unregister \
+    || { log "warning: refusing to unregister $c through an unverified/pre-16 Runner image; upgrade the manager or use the confirmed local Force forget action"; return 1; }
+
+  # Run the one-shot client in the stopped manager's actual network namespace
+  # policy. In strict mode that subnet is the one covered by the retained
+  # control-plane exception; the default bridge is equally explicit when
+  # isolation was off. Refuse ambiguous/manual multi-network attachments.
+  manager_networks="$(docker inspect -f '{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}' "$c" 2>/dev/null)" \
+    || { log "warning: cannot resolve the Docker network for stopped GitLab manager $c"; return 1; }
+  manager_networks="$(printf '%s\n' "$manager_networks" | sed '/^[[:space:]]*$/d')"
+  network_count="$(printf '%s\n' "$manager_networks" | grep -c . || true)"
+  [ "$network_count" = 1 ] \
+    || { log "warning: refusing to unregister $c from an ambiguous or missing Docker network attachment"; return 1; }
+  manager_network="$manager_networks"
+  printf '%s' "$manager_network" | grep -qE '^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$' \
+    || { log "warning: refusing unsafe Docker network name while unregistering $c"; return 1; }
+  docker network inspect "$manager_network" >/dev/null 2>&1 \
+    || { log "warning: stopped GitLab manager $c network $manager_network no longer exists"; return 1; }
+
+  # Never mount the live slot directory into `gitlab-runner unregister`: the
+  # official command rewrites config.toml after a successful API call. Work on a
+  # mode-restricted tmpfs copy so a later Docker-rm retry still has the exact old
+  # URL/token/system-ID material and can use the completion marker above.
+  tmpdir="$(mktemp -d "$RUNDIR/gitlab-unregister.XXXXXX" 2>/dev/null)" \
+    || { log "warning: could not create secure unregister workspace for $c"; return 1; }
+  chmod 700 "$tmpdir" 2>/dev/null || { rm -rf "$tmpdir"; return 1; }
+  temp_config="$tmpdir/config.toml"
+  if ! ( umask 077; cp "$dir/config.toml" "$temp_config" \
+      && cp "$dir/.runner_system_id" "$tmpdir/.runner_system_id" ); then
+    rm -rf "$tmpdir"
+    log "warning: could not copy persisted manager identity for $c"
+    return 1
+  fi
+  chmod 600 "$temp_config" "$tmpdir/.runner_system_id" 2>/dev/null \
+    || { rm -rf "$tmpdir"; return 1; }
+
+  # New slots always have an immutable per-slot snapshot. For legacy slots,
+  # fall back narrowly to the currently configured global CA. If that old TOML
+  # did not yet contain tls-ca-file, add it only to the disposable copy.
+  slot_ca="$(gitlab_slot_ca_file "$c")"
+  if [ -s "$slot_ca" ]; then
+    ca_source="$slot_ca"
+  elif [ -s "$GITLAB_CA_FILE" ]; then
+    ca_source="$GITLAB_CA_FILE"
+    log "warning: $c predates per-slot CA snapshots; using the current GitLab CA for unregister"
+  fi
+  if grep -qE '^[[:space:]]*tls-ca-file[[:space:]]*=' "$temp_config"; then
+    if [ -z "$ca_source" ]; then
+      rm -rf "$tmpdir"
+      log "warning: cannot unregister $c: its persisted TLS CA is unavailable"
+      return 1
+    fi
+  elif [ -n "$ca_source" ]; then
+    if ! awk '
+      !added && /^[[:space:]]*token[[:space:]]*=/ {
+        print
+        print "  tls-ca-file = \"/etc/gitlab-runner/certs/gitlab-ca.crt\""
+        added=1
+        next
+      }
+      { print }
+      END { if (!added) exit 1 }
+    ' "$temp_config" > "$temp_config.ca"; then
+      rm -rf "$tmpdir"
+      log "warning: could not add legacy CA trust to unregister copy for $c"
+      return 1
+    fi
+    chmod 600 "$temp_config.ca" 2>/dev/null \
+      && mv "$temp_config.ca" "$temp_config" \
+      || { rm -rf "$tmpdir"; return 1; }
+  fi
+  if [ -n "$ca_source" ]; then
+    mkdir -p "$tmpdir/certs" \
+      && chmod 700 "$tmpdir/certs" 2>/dev/null \
+      && ( umask 077; cp "$ca_source" "$tmpdir/certs/gitlab-ca.crt" ) \
+      && chmod 600 "$tmpdir/certs/gitlab-ca.crt" 2>/dev/null \
+      || { rm -rf "$tmpdir"; log "warning: could not stage TLS trust for unregistering $c"; return 1; }
+  fi
+
+  docker run --rm --network "$manager_network" -v "$tmpdir:/etc/gitlab-runner" "$image" \
+    unregister --name "$manager_name" >/dev/null 2>&1 && unregister_ok=1
+  rm -rf "$tmpdir"
+  if [ "$unregister_ok" -ne 1 ]; then
+    log "warning: could not unregister GitLab manager $c; its offline manager record may linger"
+    return 1
+  fi
+  if ! gitlab_mark_unregister_complete "$dir" "$identity"; then
+    log "warning: unregistered GitLab manager $c but could not persist local completion state"
+    return 1
+  fi
+  chmod 600 "$marker" 2>/dev/null || true
+  log "unregistered stopped GitLab manager $c"
+}
+
+# GitLab manager tokens are persistent, unlike GitHub's short-lived bootstrap
+# registration token. On an ordinary Docker/array restart with an unchanged
+# confgen, restart the same manager and system ID without remote unregister.
+gitlab_start_stopped() {
+  local c="$1" idx="$2" manager_id="${3:-}" current_id job side side_id i image dir
+  printf '%s' "$manager_id" | grep -qE '^[0-9a-f]{64}$' \
+    || { err "refusing to restart GitLab manager $c without a valid immutable container ID"; return 1; }
+  dir="$(gitlab_slot_config_dir "$c")"
+  # Once manager-only unregister succeeds, this exact local container must never
+  # resume polling. Its completion marker exists specifically so a failed Docker
+  # removal can retry local cleanup without contacting GitLab a second time.
+  if [ -e "$dir/.remote-unregister-complete" ] \
+     || [ -L "$dir/.remote-unregister-complete" ] \
+     || [ -e "$dir/.remote-unregister-complete.tmp" ] \
+     || [ -L "$dir/.remote-unregister-complete.tmp" ]; then
+    err "refusing to restart remotely unregistered GitLab manager $c; retry Stop to finish local cleanup"
+    return 1
+  fi
+  current_id="$(docker inspect -f '{{.Id}}' "$c" 2>/dev/null)" \
+    || { err "could not revalidate stopped GitLab manager identity for $c"; return 1; }
+  [ "$current_id" = "$manager_id" ] \
+    || { err "refusing to restart GitLab manager $c because its container identity changed"; return 1; }
+  # Validate the immutable image the stopped manager will actually execute. A
+  # mutable configured tag may have advanced or disappeared during the outage.
+  image="$(docker inspect -f '{{.Image}}' "$manager_id" 2>/dev/null)" \
+    || { err "could not resolve stopped GitLab manager image for $c"; return 1; }
+  [ -n "$image" ] \
+    || { err "could not resolve stopped GitLab manager image for $c"; return 1; }
+  gitlab_validate_manager_version "$image" runtime || return 1
+  side="$(gitlab_sidecar_name "$c")"
+  # A stopped manager can coexist with a surviving host-socket job or a live
+  # private daemon. Prove that endpoint idle before any stale sidecar is
+  # replaced. If an owned sidecar is stopped, starting that same immutable
+  # object is non-destructive and lets us inspect its persisted daemon state.
+  if [ "$DIND" = true ]; then
+    if docker inspect "$side" >/dev/null 2>&1; then
+      side_id="$(docker inspect -f '{{.Id}}' "$side" 2>/dev/null)" \
+        || { err "could not resolve private Docker sidecar identity for $c"; return 1; }
+      gitlab_sidecar_owned "$side_id" \
+        || { err "refusing unowned sidecar name collision: $side"; return 1; }
+      if ! docker ps --format '{{.Names}}' | grep -qx "$side"; then
+        docker start "$side_id" >/dev/null \
+          || { err "could not restart existing private Docker sidecar for $c"; return 1; }
+      fi
+      for i in $(seq 1 60); do
+        docker --host "unix://$(gitlab_socket_dir "$c")/docker.sock" info >/dev/null 2>&1 && break
+        sleep 1
+      done
+      docker --host "unix://$(gitlab_socket_dir "$c")/docker.sock" info >/dev/null 2>&1 \
+        || { err "cannot prove the existing private Docker daemon for $c is idle"; return 1; }
+      if ! job="$(gitlab_running_executor_containers "$c")"; then
+        err "refusing to restart GitLab manager $c because its executor workload cannot be enumerated"
+        return 1
+      fi
+    else
+      # With no private-daemon container there cannot be a running nested
+      # executor workload. start_sidecar can safely recreate the endpoint from
+      # the persisted data root before the manager resumes polling.
+      job=""
+    fi
+  elif ! job="$(gitlab_running_executor_containers "$c")"; then
+    err "refusing to restart GitLab manager $c because its host executor workload cannot be enumerated"
+    return 1
+  fi
+  if [ -n "$job" ]; then
+    err "refusing to restart GitLab manager $c while surviving executor container ${job%%$'\n'*} is still active"
+    return 1
+  fi
+  gitlab_start_sidecar "$idx" "$c" || return 1
+  gitlab_ensure_job_image "$c" \
+    || { err "could not prepare GitLab job image before restarting $c"; return 1; }
+  docker start "$manager_id" >/dev/null \
+    || { err "could not restart stopped GitLab manager $c"; return 1; }
+}
+
+gitlab_sidecar_owned() {
+  [ "$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.sidecar" }}' "$1" 2>/dev/null)" = true ] \
+    && [ "$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.provider" }}' "$1" 2>/dev/null)" = gitlab ] \
+    && [ "$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.role" }}' "$1" 2>/dev/null)" = dind ]
+}
+
+gitlab_manager_owned() {
+  [ "$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.managed" }}' "$1" 2>/dev/null)" = true ] \
+    && [ "$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.provider" }}' "$1" 2>/dev/null)" = gitlab ] \
+    && [ "$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.role" }}' "$1" 2>/dev/null)" = manager ]
+}
+
+gitlab_cleanup_orphan_sidecars() {
+  local side slot provider side_id workloads failed=0
+  for side in $(docker ps -a --filter 'label=net.unraid.ci-runner-farm.sidecar=true' --format '{{.Names}}' 2>/dev/null); do
+    [ -n "$side" ] || continue
+    gitlab_sidecar_owned "$side" || continue
+    slot="${side%-dind}"
+    provider="$(container_provider "$slot")"
+    if ! docker inspect "$slot" >/dev/null 2>&1 || [ "$provider" != gitlab ]; then
+      side_id="$(docker inspect -f '{{.Id}}' "$side" 2>/dev/null)" \
+        || { err "could not resolve orphaned sidecar identity for $side"; failed=1; continue; }
+      gitlab_sidecar_owned "$side_id" \
+        || { err "refusing orphan cleanup after sidecar ownership changed: $side"; failed=1; continue; }
+      if docker ps --format '{{.Names}}' | grep -qx "$side"; then
+        if ! workloads="$(gitlab_running_executor_containers "$slot")"; then
+          err "refusing to remove orphaned sidecar $side because its executor workload cannot be enumerated"
+          failed=1
+          continue
+        fi
+        if [ -n "$workloads" ]; then
+          err "refusing to remove orphaned sidecar $side while GitLab executor containers are still running"
+          failed=1
+          continue
+        fi
+      fi
+      log "removing orphaned privileged GitLab sidecar $side"
+      docker stop -t 30 "$side_id" >/dev/null 2>&1 || true
+      docker rm -f "$side_id" >/dev/null 2>&1 || failed=1
+    fi
+  done
+  return "$failed"
+}
+
+gitlab_remove_sidecar() {
+  local name="$1" purge="${2:-false}" side root
+  case "$name" in
+    "$NAME_PREFIX"-*) case "$name" in *[!A-Za-z0-9_.-]*) err "refusing unsafe GitLab slot name: $name"; return 1 ;; esac ;;
+    *) err "refusing unexpected GitLab slot name: $name"; return 1 ;;
+  esac
+  side="$(gitlab_sidecar_name "$name")"
+  if docker inspect "$side" >/dev/null 2>&1; then
+    gitlab_sidecar_owned "$side" \
+      || { err "refusing to remove unowned container name collision: $side"; return 1; }
+    docker stop -t 30 "$side" >/dev/null 2>&1 || true
+    docker rm -f "$side" >/dev/null 2>&1 || return 1
+  fi
+  if [ "$purge" = "true" ]; then
+    root="$(crf_safe_cache_root)" || { err "refusing GitLab slot purge under unsafe CACHE_ROOT '$CACHE_ROOT'"; return 1; }
+    rm -rf "$root/docker/$name" "$root/gitlab-sockets/$name" \
+      "$root/gitlab-cache/$name" 2>/dev/null || return 1
+  fi
+}
+
+gitlab_start_one() {
+  local idx="$1" name="$2" residue_status snapshot residue_id residue_provider residue_role names
+  docker image inspect "$GITLAB_RUNNER_IMAGE" >/dev/null 2>&1 \
+    || host_docker_pull "$GITLAB_RUNNER_IMAGE" >/dev/null \
+    || { err "could not pull GitLab Runner manager image $GITLAB_RUNNER_IMAGE"; return 1; }
+  gitlab_validate_host_socket_manager_version || return 1
+  # The verification transaction creates and removes a dedicated temporary
+  # manager identity; actual slot credentials are not rendered until that
+  # remote cleanup has succeeded.
+  gitlab_verify_manager_token "$name" || return 1
+  if ! gitlab_build_args "$idx" "$name"; then
+    gitlab_scrub_retired_slot_credentials "$name" >/dev/null 2>&1 \
+      || err "could not scrub unlaunched GitLab manager credentials for $name"
+    err "GitLab manager $name not started (configuration error)"
+    return 1
+  fi
+  if ! gitlab_start_sidecar "$idx" "$name"; then
+    gitlab_scrub_retired_slot_credentials "$name" >/dev/null 2>&1 || true
+    err "private Docker daemon for $name failed to start"
+    return 1
+  fi
+  if ! gitlab_ensure_job_image "$name"; then
+    gitlab_remove_sidecar "$name" false || true
+    gitlab_scrub_retired_slot_credentials "$name" >/dev/null 2>&1 || true
+    return 1
+  fi
+  log "starting GitLab manager $name (job cpus=$RUNNER_CPUS mem=$RUNNER_MEMORY url=$(gitlab_url))"
+  if ! docker run "${ARGS[@]}" >/dev/null; then
+    err "GitLab manager $name failed to start"
+    if docker inspect "$name" >/dev/null 2>&1; then
+      residue_status="$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || true)"
+      if [ "$residue_status" = created ]; then
+        snapshot="$(managed_runner_snapshot "$name" 2>/dev/null || true)"
+        IFS='|' read -r residue_id residue_provider residue_role _ <<< "$snapshot"
+        if printf '%s' "$residue_id" | grep -qE '^[0-9a-f]{64}$' \
+           && [ "$residue_provider" = gitlab ] \
+           && [ "$residue_role" = manager ] \
+           && docker rm "$residue_id" >/dev/null 2>&1; then
+          gitlab_remove_sidecar "$name" false || true
+          gitlab_scrub_retired_slot_credentials "$name" >/dev/null 2>&1 || true
+        else
+          err "retaining unverified Created residue $name and its protected identity for safe operator cleanup"
+        fi
+      else
+        err "retaining $name and its protected identity because it may have contacted GitLab before exiting"
+      fi
+    elif names="$(docker ps -a --format '{{.Names}}' 2>/dev/null)"; then
+      if printf '%s\n' "$names" | grep -qxF "$name"; then
+        err "retaining $name and its protected identity because Docker listed the name but its identity could not be inspected"
+      else
+        # A successful full-container enumeration is the only safe proof that
+        # a failed `docker run` never left a manager that could have registered.
+        gitlab_remove_sidecar "$name" false || true
+        gitlab_scrub_retired_slot_credentials "$name" >/dev/null 2>&1 || true
+      fi
+    else
+      err "retaining $name and its protected identity because Docker container state could not be enumerated"
+    fi
+    return 1
+  fi
+}
+
+# Successful retirement no longer needs reusable credentials or the CA/token
+# material that made manager-only unregister retryable. Scrub only after every
+# remote and local lifecycle step has succeeded; any earlier failure deliberately
+# leaves the complete slot identity intact. The stable system ID is non-secret and
+# survives so a later manager for this farm slot reuses the same machine identity.
+gitlab_scrub_retired_slot_credentials() {
+  local name="$1" dir
+  case "$name" in
+    "$NAME_PREFIX"-*) case "$name" in *[!A-Za-z0-9_.-]*) return 1 ;; esac ;;
+    *) return 1 ;;
+  esac
+  dir="$(gitlab_slot_config_dir "$name")"
+  rm -f \
+    "$dir/config.toml" "$dir/config.toml.tmp" "$dir/config.toml.ca" \
+    "$dir/docker/config.json" "$dir/docker/config.json.tmp" \
+    "$dir/.remote-unregister-complete" "$dir/.remote-unregister-complete.tmp" \
+    "$dir/certs/gitlab-ca.crt" "$dir/certs/gitlab-ca.crt.tmp" \
+    "$dir/.runner_system_id.tmp" \
+    || { err "could not scrub retired GitLab slot credentials for $name"; return 1; }
+  rmdir "$dir/docker" "$dir/certs" 2>/dev/null || true
+  log "scrubbed retired GitLab credentials for $name (system ID preserved)"
+}
+
+# Detect a slot whose Docker manager disappeared outside the normal retirement
+# transaction while its reusable token/system-ID pair still exists. Silently
+# deleting that pair would make exact manager-only unregister impossible and
+# leave an offline machine attached to the shared GitLab runner. A completion
+# marker proves the remote deletion already succeeded, in which case finishing
+# the interrupted local scrub is safe and idempotent.
+gitlab_assert_no_orphan_manager_configs() {
+  local dir name identity failed=0
+  # Verification can commit its disposable manager before an HTTP response is
+  # lost. Complete that exact saved transaction before any provider lifecycle
+  # continues, including a switch back to GitHub.
+  gitlab_recover_pending_probe || return 1
+  for dir in "$CFGDIR"/gitlab-runners/*; do
+    [ -d "$dir" ] || continue
+    [ -s "$dir/config.toml" ] || continue
+    name="${dir##*/}"
+    case "$name" in
+      "$NAME_PREFIX"-[0-9]*) ;;
+      *)
+        err "refusing to discard unexpected GitLab manager config directory: $dir"
+        failed=1
+        continue
+        ;;
+    esac
+    case "${name#"$NAME_PREFIX"-}" in
+      ''|*[!0-9]*)
+        err "refusing to discard unexpected GitLab manager config directory: $dir"
+        failed=1
+        continue
+        ;;
+    esac
+
+    if docker inspect "$name" >/dev/null 2>&1; then
+      gitlab_manager_owned "$name" \
+        || { err "unowned container $name collides with retained GitLab manager credentials"; failed=1; }
+      continue
+    fi
+
+    identity="$(gitlab_unregister_identity "$dir" 2>/dev/null || true)"
+    if [ -n "$identity" ] && gitlab_unregister_is_complete "$dir" "$identity"; then
+      gitlab_scrub_retired_slot_credentials "$name" || failed=1
+      continue
+    fi
+    err "GitLab manager $name is missing but its unregister credentials remain; retry cleanup after restoring it, or explicitly Force forget local manager in the Fleet UI"
+    failed=1
+  done
+  return "$failed"
+}
+
+gitlab_remove_runner() {
+  local c="$1" purge="${2:-true}" failed=0 job
+  # SIGQUIT stops accepting work and lets the current job finish. Only after the
+  # manager exits do we remove this one manager identity remotely; the shared
+  # runner entity and other slots remain intact.
+  if provider_stop_container "$c"; then
+    # A previously stopped manager may still have a live executor container.
+    # SIGQUIT on a running manager normally waits for this to disappear; after
+    # the stop completes, require that invariant before unregistering or taking
+    # down the slot daemon. The separately confirmed force-forget action is the
+    # only path allowed to interrupt such an orphaned workload deliberately.
+    if ! job="$(gitlab_running_executor_containers "$c")"; then
+      err "refusing to unregister GitLab manager $c because its executor workload cannot be enumerated"
+      return 1
+    fi
+    if [ -n "$job" ]; then
+      err "refusing to unregister GitLab manager $c while surviving executor container ${job%%$'\n'*} is still active"
+      return 1
+    fi
+    # A transient API/CA/network failure must not discard the only persisted
+    # config/system-ID pair that can retry exact manager removal. Keep the now-
+    # stopped manager and sidecar intact; provider switch/recycle/Stop reports
+    # failure and can be retried without orphaning a remote manager record.
+    gitlab_unregister_manager "$c" || return 1
+  elif docker inspect "$c" >/dev/null 2>&1; then
+    # Never tear down the daemon/jobs underneath a manager that failed to stop.
+    return 1
+  else
+    log "warning: $c disappeared before its GitLab manager identity could be unregistered"
+    failed=1
+  fi
+  provider_remove_container "$c" || failed=1
+  gitlab_remove_host_jobs "$c" || failed=1
+  gitlab_remove_sidecar "$c" "$purge" || failed=1
+  [ "$failed" -eq 0 ] || return 1
+  gitlab_scrub_retired_slot_credentials "$c"
+}
+
+# Break-glass local cleanup after the normal manager-only unregister path has
+# repeatedly failed. This deliberately never contacts GitLab: the operator must
+# remove any lingering offline manager in GitLab's UI. Keep the stable system ID
+# so a partially completed cleanup is retryable and diagnostics retain the one
+# non-secret piece of remote identity.
+gitlab_force_forget_local() {
+  local c="$1" suffix dir side manager_id="" side_id="" failed=0 root
+  case "$c" in
+    "$NAME_PREFIX"-*) suffix="${c#"$NAME_PREFIX"-}" ;;
+    *) err "refusing unexpected GitLab slot name: $c"; return 1 ;;
+  esac
+  case "$suffix" in ''|*[!0-9]*) err "refusing unsafe GitLab slot name: $c"; return 1 ;; esac
+
+  side="$(gitlab_sidecar_name "$c")"
+  if docker inspect "$c" >/dev/null 2>&1; then
+    manager_id="$(docker inspect -f '{{.Id}}' "$c" 2>/dev/null)" \
+      || { err "could not resolve GitLab manager identity for $c"; return 1; }
+    gitlab_manager_owned "$manager_id" \
+      || { err "refusing to force-forget unowned manager name collision: $c"; return 1; }
+  fi
+  if docker inspect "$side" >/dev/null 2>&1; then
+    side_id="$(docker inspect -f '{{.Id}}' "$side" 2>/dev/null)" \
+      || { err "could not resolve GitLab sidecar identity for $side"; return 1; }
+    gitlab_sidecar_owned "$side_id" \
+      || { err "refusing to force-forget unowned sidecar name collision: $side"; return 1; }
+  fi
+
+  # Stop new work first, then remove every plugin-labelled build/helper/service
+  # container for this slot before taking down its private daemon.
+  if [ -n "$manager_id" ]; then
+    docker rm -f "$manager_id" >/dev/null 2>&1 \
+      || { err "could not force-remove GitLab manager $c"; return 1; }
+  fi
+  gitlab_remove_host_jobs "$c" || failed=1
+  if [ -n "$side_id" ]; then
+    docker rm -f "$side_id" >/dev/null 2>&1 || failed=1
+  fi
+  [ "$failed" -eq 0 ] \
+    || { err "local force-forget cleanup for $c is incomplete; retry the action"; return 1; }
+
+  root="$(crf_safe_cache_root)" \
+    || { err "refusing force-forget cache cleanup under unsafe CACHE_ROOT '$CACHE_ROOT'"; return 1; }
+  rm -rf "$root/docker/$c" "$root/gitlab-sockets/$c" "$root/gitlab-cache/$c" \
+    || { err "could not purge local Docker/cache state for $c; retry the action"; return 1; }
+
+  dir="$(gitlab_slot_config_dir "$c")"
+  rm -f \
+    "$dir/config.toml" "$dir/config.toml.tmp" "$dir/config.toml.ca" \
+    "$dir/docker/config.json" "$dir/docker/config.json.tmp" \
+    "$dir/.remote-unregister-complete" "$dir/.remote-unregister-complete.tmp" \
+    "$dir/certs/gitlab-ca.crt" "$dir/certs/gitlab-ca.crt.tmp" \
+    "$dir/.runner_system_id.tmp" \
+    || { err "could not scrub local GitLab credentials for $c; retry the action"; return 1; }
+  log "WARNING: force-forgot local GitLab slot $c without unregistering it; its remote manager may remain in GitLab"
+}
+
+# Side-effect-free break-glass preflight. The common engine calls this before it
+# stops fleet-wide workers so a stale UI request or fixed-name collision cannot
+# perturb healthy capacity. The destructive function repeats the ownership
+# checks and binds removals to immutable IDs to close the race after preflight.
+gitlab_force_forget_target_ready() {
+  local name="$1" suffix dir side manager_id side_id seen=0
+  case "$name" in "$NAME_PREFIX"-[0-9]*) suffix="${name#"$NAME_PREFIX"-}" ;; *) return 1 ;; esac
+  case "$suffix" in ''|*[!0-9]*) return 1 ;; esac
+  dir="$(gitlab_slot_config_dir "$name")"; side="$(gitlab_sidecar_name "$name")"
+  if docker inspect "$name" >/dev/null 2>&1; then
+    manager_id="$(docker inspect -f '{{.Id}}' "$name" 2>/dev/null)" || return 1
+    gitlab_manager_owned "$manager_id" \
+      || { err "refusing to force-forget unowned manager name collision: $name"; return 1; }
+    seen=1
+  fi
+  if docker inspect "$side" >/dev/null 2>&1; then
+    side_id="$(docker inspect -f '{{.Id}}' "$side" 2>/dev/null)" || return 1
+    gitlab_sidecar_owned "$side_id" \
+      || { err "refusing to force-forget unowned sidecar name collision: $side"; return 1; }
+    seen=1
+  fi
+  [ -s "$dir/config.toml" ] && seen=1
+  [ -s "$dir/.remote-unregister-complete" ] && seen=1
+  [ -s "$dir/.runner_system_id" ] \
+    && grep -qE '^[sr]_[0-9A-Za-z]{12}$' "$dir/.runner_system_id" 2>/dev/null \
+    || { err "refusing local forget without the slot's persisted GitLab system ID"; return 1; }
+  [ "$seen" -eq 1 ] \
+    || { err "no retryable local GitLab manager identity exists for $name"; return 1; }
+}
+
+gitlab_stop_cleanup() { gitlab_remove_host_jobs; }
+
+gitlab_imageupdate_pull() {
+  local changed=1 before after
+  before="$(image_id "$GITLAB_RUNNER_IMAGE")"
+  host_docker_pull "$GITLAB_RUNNER_IMAGE" >/dev/null 2>&1
+  after="$(image_id "$GITLAB_RUNNER_IMAGE")"
+  if [ -n "$after" ] && [ "$before" != "$after" ]; then
+    changed=0; log "image-update: GitLab manager $GITLAB_RUNNER_IMAGE ${before:-none} -> $after"
+  fi
+  if [ "$DIND" = true ]; then
+    before="$(image_id "$GITLAB_DIND_IMAGE")"
+    host_docker_pull "$GITLAB_DIND_IMAGE" >/dev/null 2>&1
+    after="$(image_id "$GITLAB_DIND_IMAGE")"
+    if [ -n "$after" ] && [ "$before" != "$after" ]; then
+      changed=0; log "image-update: GitLab DinD $GITLAB_DIND_IMAGE ${before:-none} -> $after"
+    fi
+  fi
+  return "$changed"
+}
+
+gitlab_queued_refresh() {
+  [ -z "$GITLAB_API_TOKEN" ] && [ -f "$GITLAB_API_TOKEN_FILE" ] && GITLAB_API_TOKEN="$(cat "$GITLAB_API_TOKEN_FILE" 2>/dev/null || true)"
+  if ! gitlab_api_token_ready || [ -z "$GITLAB_PROJECTS" ]; then
+    echo "gitlab $(date +%s) -1" > "$RUNDIR/queued.cache"; return 0
+  fi
+  local total=0 got=0 failed=0 project encoded tmpd body headers n
+  tmpd="$(mktemp -d 2>/dev/null)"
+  [ -n "$tmpd" ] || { echo "gitlab $(date +%s) -1" > "$RUNDIR/queued.cache"; return 0; }
+  for project in $GITLAB_PROJECTS; do
+    [ -n "$project" ] || continue
+    encoded="$(urlencode "$project")"; body="$tmpd/body"; headers="$tmpd/headers"
+    : > "$body"; : > "$headers"
+    if gitlab_api_capture "/projects/$encoded/jobs?scope%5B%5D=pending&per_page=1" "$body" "$headers"; then
+      got=1
+      n="$(awk -F': *' 'tolower($1)=="x-total" {gsub(/\r/,"",$2); print $2; exit}' "$headers")"
+      case "$n" in ''|*[!0-9]*) grep -qE '^\[[[:space:]]*\]$' "$body" && n=0 || n=1 ;; esac
+      total=$((total + ${n:-0}))
+    else
+      failed=1
+    fi
+  done
+  rm -rf "$tmpd"
+  [ "$got" = 1 ] && [ "$failed" = 0 ] || total=-1
+  echo "gitlab $(date +%s) $total" > "$RUNDIR/queued.cache"
+}
+
+gitlab_stats_refresh() {
+  [ -z "$GITLAB_API_TOKEN" ] && [ -f "$GITLAB_API_TOKEN_FILE" ] && GITLAB_API_TOKEN="$(cat "$GITLAB_API_TOKEN_FILE" 2>/dev/null || true)"
+  if ! gitlab_api_token_ready || [ -z "$GITLAB_PROJECTS" ]; then
+    echo "gitlab $(date +%s) 0 0 0 0 -1" > "$RUNDIR/stats.cache"; return 0
+  fi
+  local ok=0 fail=0 cancel=0 other=0 total got=0 failed=0 project encoded body status
+  for project in $GITLAB_PROJECTS; do
+    [ -n "$project" ] || continue
+    encoded="$(urlencode "$project")"
+    if body="$(gitlab_api GET "/projects/$encoded/jobs?per_page=50&order_by=id&sort=desc")"; then
+      got=1
+      while IFS= read -r status; do
+        case "$status" in
+          success) ok=$((ok+1)) ;;
+          failed) fail=$((fail+1)) ;;
+          canceled) cancel=$((cancel+1)) ;;
+          running|pending|created|preparing|waiting_for_resource|waiting_for_callback|canceling|manual|scheduled) : ;;
+          ?*) other=$((other+1)) ;;
+        esac
+      # Split only API array peers, then anchor at each top-level job object.
+      # Unanchored id/status matching also counts nested pipeline/runner status
+      # fields and can triple the dashboard totals.
+      done <<< "$(printf '%s' "$body" | tr -d '\r\n' | sed 's/},{/}\
+{/g' \
+        | grep -oE '^\[?\{[[:space:]]*"id"[[:space:]]*:[[:space:]]*[0-9]+[[:space:]]*,[[:space:]]*"status"[[:space:]]*:[[:space:]]*"[a-z_]+"' \
+        | sed 's/.*"\([a-z_]*\)"$/\1/')"
+    else
+      failed=1
+    fi
+  done
+  if [ "$got" = 1 ] && [ "$failed" = 0 ]; then total=$((ok+fail+cancel+other)); else total=-1; fi
+  echo "gitlab $(date +%s) $ok $fail $cancel $other $total" > "$RUNDIR/stats.cache"
+}
+
+gitlab_usage_stat_target() {
+  local c="$1"
+  [ "$(gitlab_socket_path "$c")" = /var/run/docker.sock ] && echo _ || gitlab_sidecar_name "$c"
+}
+
+gitlab_status_resources() {
+  local c="$1" inspraw="$2" side_row side_state side_cpus side_mem
+  side_row="$(printf '%s\n' "$inspraw" | grep -m1 -E "^/?$(gitlab_sidecar_name "$c")\|")"
+  if [ -n "$side_row" ]; then
+    IFS='|' read -r _ side_state side_cpus side_mem _ _ <<< "$side_row"
+    cpus="$side_cpus"; mem="$side_mem"
+  else
+    [ -n "$RUNNER_CPUS" ] && cpus="$(awk -v n="$RUNNER_CPUS" 'BEGIN{printf "%.0f", n*1000000000}')"
+    [ -n "$RUNNER_MEMORY" ] && mem="$(memory_limit_bytes "$RUNNER_MEMORY")"
+  fi
+}
+
+gitlab_usage_context() {
+  local c="$1" jcid jsock jmeta jenv project_from_url
+  jcid="$(gitlab_job_container "$c")"; jsock="$(gitlab_socket_path "$c")"
+  if [ -n "$jcid" ]; then
+    jmeta="$(docker --host "unix://$jsock" inspect -f '{{index .Config.Labels "com.gitlab.gitlab-runner.job.id"}}{{println}}{{index .Config.Labels "com.gitlab.gitlab-runner.job.url"}}{{println}}{{index .Config.Labels "com.gitlab.gitlab-runner.job.ref"}}{{println}}{{.State.StartedAt}}' "$jcid" 2>/dev/null)"
+    job_id="$(printf '%s\n' "$jmeta" | sed -n '1p' | grep -oE '^[0-9]+$' | head -1)"; job_id="${job_id:-_}"
+    job_url="$(printf '%s\n' "$jmeta" | sed -n '2p')"
+    ref="$(printf '%s\n' "$jmeta" | sed -n '3p')"
+    jstarted="$(printf '%s\n' "$jmeta" | sed -n '4p' | grep -oE '^[0-9T:.Z+-]+' | head -1)"; jstarted="${jstarted:-_}"
+    jenv="$(docker --host "unix://$jsock" inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$jcid" 2>/dev/null \
+      | grep -E '^CI_(JOB_NAME|PROJECT_PATH)=')"
+    job="$(printf '%s\n' "$jenv" | grep '^CI_JOB_NAME=' | head -1 | cut -d= -f2-)"
+    project="$(printf '%s\n' "$jenv" | grep '^CI_PROJECT_PATH=' | head -1 | cut -d= -f2-)"
+    if [ -z "$project" ] && [ -n "$job_url" ]; then
+      project_from_url="${job_url#$(gitlab_url)/}"
+      project="${project_from_url%/-/jobs/*}"
+    fi
+    [ -z "$job" ] && [ "$job_id" != _ ] && job="GitLab job #$job_id"
+    [ -n "$project" ] && [ -n "$ref" ] && ref_url="$(gitlab_url)/$project/-/tree/$(urlencode "$ref")"
+  fi
+}
+
+# `gitlab-runner list` is the parse/schema fallback for official images that do
+# not expose a lint command.  A zero exit code is insufficient: Runner has
+# historically reported schema problems as diagnostics while still listing the
+# file.  Also require the exact generated manager and Docker executor so an empty
+# or silently skipped config cannot pass validation.
+gitlab_list_output_valid() {
+  local expected_name="$1" output="$2" plain
+  # The official image colorizes key/value fields even without a TTY. Remove
+  # only ANSI SGR sequences before matching diagnostics and Executor=docker.
+  plain="$(printf '%s\n' "$output" | sed $'s/\033\\[[0-9;]*m//g')"
+  if grep -Eiq \
+    "jsonschema:|there might be a problem with your config|created missing unique system id|couldn.t save new system id|(^|[[:space:]])(FATAL|ERROR|PANIC)(:|[[:space:]])|failed to (load|decode|parse)|warning:.*(config|schema|unknown|unsupported|invalid)" \
+    <<< "$plain"; then
+    return 1
+  fi
+  grep -Fq -- "$expected_name" <<< "$plain" || return 1
+  grep -Eq 'Executor[[:space:]]*=[[:space:]]*docker([[:space:]]|$)' <<< "$plain"
+}
+
+gitlab_validate() {
+  gitlab_validate_settings || return 1
+  docker image inspect "$GITLAB_RUNNER_IMAGE" >/dev/null 2>&1 \
+    || host_docker_pull "$GITLAB_RUNNER_IMAGE" >/dev/null \
+    || { err "validate: cannot pull GitLab manager image $GITLAB_RUNNER_IMAGE"; return 1; }
+  gitlab_validate_host_socket_manager_version || return 1
+  local existing_managed
+  existing_managed="$(managed_names)" \
+    || { err "validate: could not enumerate the managed fleet"; return 1; }
+  if [ -n "$existing_managed" ]; then
+    # Validation may run before recycling one member of a live mixed fleet. Add
+    # current endpoints/rules without clearing the policy that still protects
+    # busy managers on the previous provider configuration.
+    provision_base || return 1
+    firewall_prepare_replacement || return 1
+  else
+    provision_preflight || return 1
+  fi
+  local suffix name idx=99 dir sock image side manager_ca=() job_args=() slot_ca validation_cfgroot
+  suffix="$(od -An -N6 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')"
+  printf '%s' "$suffix" | grep -qE '^[a-f0-9]{12}$' \
+    || { err "validate: could not allocate a unique validation name"; return 1; }
+  name="${NAME_PREFIX}-validate-$suffix"
+  side="$(gitlab_sidecar_name "$name")"
+  if docker inspect "$name" >/dev/null 2>&1 \
+     || docker inspect "${name}-job" >/dev/null 2>&1; then
+    err "validate: refusing unexpected random-name container collision for $name"
+    return 1
+  fi
+  if docker inspect "$side" >/dev/null 2>&1; then
+    gitlab_sidecar_owned "$side" \
+      || { err "validate: refusing unowned container name collision: $side"; return 1; }
+    gitlab_remove_sidecar "$name" false || return 1
+  fi
+  image="$(effective_image)"
+  if [ "$IMAGE_SOURCE" = remote ]; then
+    if gitlab_remote_image_host_pull_required; then
+      gitlab_prepare_remote_image "$image" >/dev/null 2>&1 \
+        || { err "validate: cannot prepare job image $image under the selected pull policy"; return 1; }
+    fi
+  else
+    docker image inspect "$image" >/dev/null 2>&1 || { err "validate: built-in GitLab job image $image is unavailable"; return 1; }
+  fi
+  validation_cfgroot="$(mktemp -d "$RUNDIR/gitlab-validate-config.XXXXXX" 2>/dev/null)" \
+    || { err "validate: could not create a temporary manager-config directory"; return 1; }
+  chmod 700 "$validation_cfgroot" 2>/dev/null \
+    || { rm -rf -- "$validation_cfgroot"; return 1; }
+  # Dynamic scope redirects gitlab_slot_config_dir and every called adapter
+  # helper to tmpfs. Validate must never write its dummy token/system ID to the
+  # persistent flash configuration tree, even if the process is interrupted.
+  local CFGDIR="$validation_cfgroot"
+  local GITLAB_RUNNER_TOKEN="glrt-validationtoken000000000000"
+  gitlab_write_config "$idx" "$name" \
+    || { err "validate: could not render GitLab config.toml"; rm -rf -- "$validation_cfgroot"; return 1; }
+  gitlab_write_docker_auth "$name" \
+    || { err "validate: could not render registry auth"; rm -rf -- "$validation_cfgroot"; return 1; }
+  dir="$(gitlab_slot_config_dir "$name")"
+  slot_ca="$dir/certs/gitlab-ca.crt"
+  [ -f "$slot_ca" ] && manager_ca=( -v "$slot_ca:/etc/gitlab-runner/certs/gitlab-ca.crt:ro" )
+  if docker run --rm "$GITLAB_RUNNER_IMAGE" --help 2>&1 | grep -qE '(^|[[:space:]])lint([[:space:]]|$)'; then
+    if ! docker run --rm -v "$dir:/etc/gitlab-runner" ${manager_ca[@]+"${manager_ca[@]}"} "$GITLAB_RUNNER_IMAGE" \
+        lint --config /etc/gitlab-runner/config.toml >/dev/null 2>&1; then
+      err "validate: gitlab-runner lint rejected the generated config.toml"
+      rm -rf -- "$validation_cfgroot" 2>/dev/null || true
+      return 1
+    fi
+  else
+    # Current official images may not expose `lint`. `list` still runs the same
+    # TOML decoder; inspect its diagnostics as well as its exit status because
+    # some schema/config warnings historically returned zero.
+    local list_output list_rc=0 expected_name
+    expected_name="$(host)-$name"
+    list_output="$(docker run --rm -v "$dir:/etc/gitlab-runner" ${manager_ca[@]+"${manager_ca[@]}"} \
+      "$GITLAB_RUNNER_IMAGE" list 2>&1)" || list_rc=$?
+    if [ "$list_rc" -ne 0 ] || ! gitlab_list_output_valid "$expected_name" "$list_output"; then
+      err "validate: the official GitLab Runner image rejected, warned about, or did not list the generated Docker runner config.toml"
+      rm -rf -- "$validation_cfgroot" 2>/dev/null || true
+      return 1
+    fi
+  fi
+  gitlab_start_sidecar "$idx" "$name" || { rm -rf -- "$validation_cfgroot" 2>/dev/null || true; return 1; }
+  gitlab_ensure_job_image "$name" || { gitlab_remove_sidecar "$name" true; rm -rf -- "$validation_cfgroot" 2>/dev/null || true; return 1; }
+  [ "$DIND" = true ] && sock="$(gitlab_socket_dir "$name")/docker.sock" || sock="/var/run/docker.sock"
+  job_args=( --host "unix://$sock" run --rm --name "${name}-job" --pids-limit=2048
+    --label "net.unraid.ci-runner-farm.provider=gitlab"
+    --label "net.unraid.ci-runner-farm.slot=$name"
+    --label "net.unraid.ci-runner-farm.role=validate-job" )
+  [ -n "$RUNNER_CPUS" ] && job_args+=( --cpus="$RUNNER_CPUS" )
+  [ -n "$RUNNER_MEMORY" ] && job_args+=( --memory="$RUNNER_MEMORY" )
+  job_args+=( -v "$CACHE_ROOT/gitlab-cache/$name:/cache" "$image" /bin/sh -c 'test -d /cache && printf "GitLab Docker-executor job image OK\n"' )
+  log "validate: parsing generated GitLab TOML and launching an inert Docker-executor job container..."
+  if ! docker "${job_args[@]}"; then
+    err "validate: the GitLab job image could not run through the selected Docker endpoint"
+    gitlab_remove_sidecar "$name" true; rm -rf -- "$validation_cfgroot" 2>/dev/null || true
+    return 1
+  fi
+  gitlab_remove_sidecar "$name" true \
+    || { err "validate: could not remove the temporary GitLab sidecar/data"; rm -rf -- "$validation_cfgroot" 2>/dev/null || true; return 1; }
+  rm -rf -- "$validation_cfgroot" "$CACHE_ROOT/gitlab-cache/$name" 2>/dev/null || true
+  log "validate: OK (generated config parsed; temporary manager data, DinD daemon, and job container removed)."
+}

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/gitlab.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/gitlab.sh
@@ -58,7 +58,9 @@ gitlab_confgen() {
   # Hash the exact token values loaded after fleet.lock was acquired. Reading the
   # files again here can pair a stale in-memory token with a freshly rotated file
   # hash, incorrectly stamping a replacement as current.
-  printf '%s\0' gitlab "$GITLAB_URL" "$GITLAB_RUNNER_IMAGE" "$GITLAB_DIND_IMAGE" \
+  # Keep a runtime-schema salt in the fingerprint so security-sensitive argv
+  # changes also retire sidecars created by an older plugin build.
+  printf '%s\0' gitlab-dind-unix-only-v2 "$GITLAB_URL" "$GITLAB_RUNNER_IMAGE" "$GITLAB_DIND_IMAGE" \
     "$GITLAB_RUNNER_TOKEN" "$GITLAB_CA_FINGERPRINT" "$REGISTRY_TOKEN" \
     "$RUNNER_CPUS" "$RUNNER_MEMORY" "$CACHE_MOUNTS" "$GITLAB_SHUTDOWN_TIMEOUT" \
     "$GITLAB_ALLOWED_IMAGES" "$GITLAB_ALLOWED_SERVICES" "$GITLAB_PULL_POLICY" "$GITLAB_SHM_SIZE" \
@@ -862,7 +864,10 @@ gitlab_start_sidecar() {
   [ "$NETWORK_ISOLATION" != "off" ] && sargs+=( --network "$RUNNER_NETWORK" )
   [ "$SHARED_IMAGE_CACHE" = "true" ] && [ "$NETWORK_ISOLATION" = "off" ] \
     && sargs+=( --add-host "host.docker.internal:host-gateway" )
-  sargs+=( "$GITLAB_DIND_IMAGE" --host=unix:///runner-services/docker.sock )
+  # docker:dind's stock entrypoint adds an unauthenticated TCP listener when
+  # its first argument is an option. Pass `dockerd` explicitly so the entrypoint
+  # retains PID cleanup/init/iptables setup without injecting any TCP listener.
+  sargs+=( "$GITLAB_DIND_IMAGE" dockerd --host=unix:///runner-services/docker.sock )
   docker run "${sargs[@]}" >/dev/null || return 1
   local i
   for i in $(seq 1 60); do

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# CI Runner Farm - manage GitHub Actions self-hosted BUILD runners as Docker
+# CI Runner Farm - manage GitHub Actions or GitLab CI runners as Docker
 # containers on Unraid. Multiple concurrent runners, container-only (no VM),
 # warm shared caches on a fast pool, resource-capped so builds coexist with
 # the host and the other workloads.
@@ -13,29 +13,43 @@
 #   status           human-readable fleet table
 #   status-json      machine-readable status for the web UI
 #   logs <i>         tail logs for runner i
-#   validate         dry-provision one container (no GitHub token needed) to
-#                    prove mounts/limits/image on this box, then remove it
+#   validate         dry-provision the selected provider to prove its generated
+#                    config, mounts, limits, and image, then remove it
 #   prune-cache      clear the shared cache root
 ###############################################################################
 set -uo pipefail
 
 PLUGIN="ci-runner-farm"
-CFGDIR="/boot/config/plugins/${PLUGIN}"
+CFGDIR="${CRF_CFGDIR:-/boot/config/plugins/${PLUGIN}}"
 # Ephemeral runtime caches/locks live on tmpfs, not the USB flash (they are
 # rewritten every 60-300s while a settings tab is open — a flash-wear antipattern).
-RUNDIR="/var/local/emhttp/${PLUGIN}"
+RUNDIR="${CRF_RUNDIR:-/var/local/emhttp/${PLUGIN}}"
 mkdir -p "$RUNDIR" 2>/dev/null || RUNDIR="$CFGDIR"
+HOST_DOCKER_CONFIG="$RUNDIR/docker-auth"
 CFG="${CFGDIR}/${PLUGIN}.cfg"
 TOKEN_FILE="${CFGDIR}/token"
+GITLAB_RUNNER_TOKEN_FILE="${CFGDIR}/gitlab-runner-token"
+GITLAB_API_TOKEN_FILE="${CFGDIR}/gitlab-api-token"
+GITLAB_CA_FILE="${CFGDIR}/gitlab-ca.crt"
 REGISTRY_TOKEN_FILE="${CFGDIR}/registry-token"
 MANAGED_LABEL="net.unraid.ci-runner-farm.managed=true"
 NAME_PREFIX="ci-runner"
 
 # ---- defaults (overridden by ci-runner-farm.cfg) ---------------------------
+CI_PROVIDER="github"                  # github | gitlab (one active provider per farm)
 GH_SCOPE="repo"                       # repo | org
 GH_OWNER="unraid"
 GH_REPOS="unraid/repo-a unraid/repo-b"
 RUNNER_GROUP=""
+GITLAB_URL="https://gitlab.com"       # GitLab.com or a self-managed base URL
+GITLAB_RUNNER_IMAGE="gitlab/gitlab-runner:alpine" # official persistent manager image
+GITLAB_PROJECTS=""                    # optional space-separated paths for advisory API telemetry
+GITLAB_SHUTDOWN_TIMEOUT="7200"        # graceful SIGQUIT drain before Docker force-stops a manager
+GITLAB_ALLOWED_IMAGES=""              # optional space-separated Docker image patterns; empty = GitLab default (all)
+GITLAB_ALLOWED_SERVICES=""            # optional space-separated service-image patterns; empty = GitLab default (all)
+GITLAB_PULL_POLICY="auto"             # auto | always | if-not-present; auto preserves built-in/remote behavior
+GITLAB_SHM_SIZE="0"                   # job/service /dev/shm size in bytes; 0 = Docker default
+GITLAB_DIND_IMAGE="docker:27-dind"    # private executor daemon; deliberately not user-configurable yet
 RUNNER_COUNT=4
 RUNNER_LABELS="self-hosted,unraid,build"
 RUNNER_CPUS=""                        # per-runner CPU cap; empty = uncapped (CFS time-shares fairly)
@@ -43,13 +57,16 @@ RUNNER_MEMORY="16g"                   # per-runner memory cap (kept: memory isn'
 CACHE_ROOT="/mnt/cache/github-runner" # must be a dedicated SUBDIR under a pool/disk, never a bare mount root (see crf_safe_cache_root)
 WORK_TMPFS_SIZE="8g"                  # empty => bind workdir to pool instead of RAM
 IMAGE_SOURCE="builtin"                # builtin = run the locally-built image; remote = pull IMAGE from a registry
-BUILTIN_IMAGE="ci-runner-farm-runner:latest"  # tag produced by the in-plugin image builder (build-image)
+BUILTIN_IMAGE="ci-runner-farm-runner:latest"  # legacy/GitHub tag produced by build-image
+GITLAB_BUILTIN_IMAGE="ci-runner-farm-gitlab-job:latest" # GitLab default job-image tag
 IMAGE=""                              # remote image ref, used when IMAGE_SOURCE=remote (e.g. ghcr.io/org/img:tag)
 EPHEMERAL="false"                     # true => runner deregisters after each job
 RUN_AS_ROOT="false"                   # false => jobs run as non-root 'runner' (sudo+docker groups), like
                                       # GitHub-hosted runners. true => jobs run as root (legacy).
 ACCESS_TOKEN=""                       # GitHub PAT (repo scope; +admin:org for org; +read:packages if reused for private GHCR). Stays host-side:
                                       # runners get a short-lived registration token, never the PAT itself.
+GITLAB_RUNNER_TOKEN=""                # reusable glrt- auth token; written into mode-0600 per-slot config.toml
+GITLAB_API_TOKEN=""                   # optional read_api token, host-side telemetry only
 SHARE_DOCKER_SOCK="false"             # mount host docker.sock for service containers (ignored when DIND=true).
                                       # Off by default: it gives jobs root-equivalent host access — opt in only
                                       # for trusted/private repos. DIND=true (the default) supersedes it anyway.
@@ -80,7 +97,7 @@ REGISTRY_TOKEN=""                      # registry password/token (loaded from re
 RUNNER_UID="1001"                     # uid of the image's 'runner' user (myoung34/github-runner)
 RUNNER_GID="121"                      # gid of the 'runner' group
 CACHE_MOUNTS="pnpm-store:/home/runner/.local/share/pnpm/store npm:/home/runner/.npm yarn:/home/runner/.cache/yarn ms-playwright:/home/runner/.cache/ms-playwright"
-# ---- autoscaling (queue-aware): fleet floats between MIN and MAX ------------
+# ---- autoscaling (live runner state; provider API queue is display-only) -----
 AUTOSCALE="false"                     # true => a daemon grows/shrinks the fleet by demand
 AUTOSCALE_MIN="2"                     # never go below this many runners
 AUTOSCALE_MAX="16"                    # never go above this many
@@ -99,7 +116,9 @@ DASHBOARD_WIDGET_ENABLE="true"       # show the Main->Dashboard status tile (rea
 # ----------------------------------------------------------------------------
 
 # Allowlist of keys the settings page may set. load_cfg only ever assigns these.
-CFG_KEYS="GH_SCOPE GH_OWNER GH_REPOS RUNNER_GROUP RUNNER_COUNT RUNNER_LABELS \
+CFG_KEYS="CI_PROVIDER GH_SCOPE GH_OWNER GH_REPOS RUNNER_GROUP GITLAB_URL GITLAB_RUNNER_IMAGE GITLAB_PROJECTS GITLAB_SHUTDOWN_TIMEOUT \
+GITLAB_ALLOWED_IMAGES GITLAB_ALLOWED_SERVICES GITLAB_PULL_POLICY GITLAB_SHM_SIZE \
+RUNNER_COUNT RUNNER_LABELS \
 RUNNER_CPUS RUNNER_MEMORY CACHE_ROOT WORK_TMPFS_SIZE IMAGE_SOURCE IMAGE EPHEMERAL \
 RUN_AS_ROOT REGISTRY_SERVER REGISTRY_USERNAME CACHE_MOUNTS SHARE_DOCKER_SOCK DIND \
 SHARED_IMAGE_CACHE NETWORK_ISOLATION RUNNER_NETWORK MIRROR_PORT AUTOSCALE AUTOSCALE_MIN \
@@ -127,13 +146,54 @@ load_cfg() {
 }
 
 load_cfg
-[ -z "$ACCESS_TOKEN" ] && [ -f "$TOKEN_FILE" ] && ACCESS_TOKEN="$(cat "$TOKEN_FILE" 2>/dev/null)"
-[ -z "$REGISTRY_TOKEN" ] && [ -f "$REGISTRY_TOKEN_FILE" ] && REGISTRY_TOKEN="$(cat "$REGISTRY_TOKEN_FILE" 2>/dev/null)"
+[ "$CI_PROVIDER" = "gitlab" ] || CI_PROVIDER="github"
+read_secret_file() {
+  [ -f "$1" ] && cat "$1" 2>/dev/null || true
+}
+reload_secret_files() {
+  # A successful GitLab verification is reusable only within one immutable
+  # locked snapshot. Any explicit reload invalidates that process-local cache.
+  GITLAB_TOKEN_PROBE_VALIDATED_TARGET=""
+  ACCESS_TOKEN="$(read_secret_file "$TOKEN_FILE")"
+  GITLAB_RUNNER_TOKEN="$(read_secret_file "$GITLAB_RUNNER_TOKEN_FILE")"
+  GITLAB_API_TOKEN="$(read_secret_file "$GITLAB_API_TOKEN_FILE")"
+  REGISTRY_TOKEN="$(read_secret_file "$REGISTRY_TOKEN_FILE")"
+  # Treat the CA fingerprint as part of the same runtime snapshot. confgen must
+  # never combine locked token/config values with a second, live read of a CA
+  # file that may have been atomically replaced after fleet.lock was acquired.
+  GITLAB_CA_PRESENT=false
+  GITLAB_CA_CONTENT=""
+  GITLAB_CA_FINGERPRINT="_"
+  if [ -f "$GITLAB_CA_FILE" ]; then
+    GITLAB_CA_CONTENT="$(cat "$GITLAB_CA_FILE" 2>/dev/null)" \
+      || { GITLAB_CA_FINGERPRINT="!"; return 1; }
+    GITLAB_CA_PRESENT=true
+    GITLAB_CA_FINGERPRINT="$(printf '%s' "$GITLAB_CA_CONTENT" | sha256sum 2>/dev/null | cut -c1-12)"
+    [ -n "$GITLAB_CA_FINGERPRINT" ] || { GITLAB_CA_FINGERPRINT="!"; return 1; }
+  fi
+  return 0
+}
+reload_secret_files
+
+# Re-read the complete mutable runtime snapshot only after fleet.lock is held.
+# Every CLI process loads cfg/secrets before dispatch, so a process queued behind
+# a credential-clear action could otherwise resume with an old in-memory token
+# and recreate the derived per-slot config that was just scrubbed. Normalize the
+# provider on every reload too: long-running daemons re-read the web-written cfg
+# repeatedly, not only through the one-time startup normalization above.
+reload_locked_snapshot() {
+  load_cfg
+  [ "$CI_PROVIDER" = "gitlab" ] || CI_PROVIDER="github"
+  reload_secret_files || { err "could not take a consistent credential/CA snapshot"; return 1; }
+}
 # PID files live on tmpfs (RUNDIR), not flash: they're pure per-boot runtime state,
 # so this both spares the USB stick and means a stale PID can't survive a reboot to
 # later match an unrelated reused PID that autoscale_stop would then kill.
 AUTOSCALE_PID="${RUNDIR}/autoscale.pid"
 IMAGEUPDATE_PID="${RUNDIR}/imageupdate.pid"
+BOOT_AUTOSTART_PID="${RUNDIR}/boot-autostart.pid"
+RECONCILE_PID="${RUNDIR}/reconcile.pid"
+IMAGEUPDATE_PENDING="${RUNDIR}/imageupdate.pending"
 SECURITY_CACHE="${RUNDIR}/security-warn.cache"   # cached public-repo warning (TTL below), so the
 SECURITY_TTL="300"                               # UI's 5s status poll never hammers the GitHub API
 
@@ -141,33 +201,139 @@ log()  { echo "[ci-runner-farm] $*"; }
 err()  { echo "[ci-runner-farm] ERROR: $*" >&2; }
 host() { hostname -s; }
 
-managed_names() {
-  docker ps -a --filter "label=${MANAGED_LABEL}" --format '{{.Names}}' | sort -V
+# Provider implementations live in adapters. CI_PROVIDER is normalized to the
+# two allowlisted names above, so dynamic dispatch cannot resolve an arbitrary
+# function. The files contain definitions only and are safe in source-only tests.
+PROVIDER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/providers"
+for provider_file in "$PROVIDER_DIR/github.sh" "$PROVIDER_DIR/gitlab.sh"; do
+  [ -r "$provider_file" ] || { err "provider adapter missing: $provider_file"; exit 1; }
+  # shellcheck source=/dev/null
+  . "$provider_file" || { err "could not load provider adapter: $provider_file"; exit 1; }
+done
+unset provider_file
+
+provider_call() { "${CI_PROVIDER}_$1" "${@:2}"; }
+
+# Provider helpers. Existing containers predate provider labels, so an absent
+# label always means GitHub; this keeps upgrades and mixed-fleet reconciliation
+# safe while new GitLab managers are introduced one idle slot at a time.
+container_provider() {
+  local p
+  p="$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.provider" }}' "$1" 2>/dev/null)"
+  [ "$p" = "gitlab" ] && echo gitlab || echo github
 }
 
-current_count() { managed_names | grep -c . ; }
+# Resolve one container name to a single immutable Docker ID and validate the
+# complete ownership contract from that same inspect result. Destructive UI
+# actions must never infer ownership from a ci-runner-N-shaped name: a foreign
+# container can legitimately collide with that predictable namespace.
+#
+# Contract "runner" accepts current fully-labelled GitHub/GitLab slots. The
+# managed+index-only GitHub form is the narrow upgrade path for containers made
+# by releases that predate provider/role labels; the plugin-owned managed label
+# is still mandatory, so an ordinary unlabeled collision is never treated as
+# GitHub. Contract "github-validate" is strict because validation containers are
+# created by this version and have no legacy form.
+owned_container_snapshot() {
+  local name="$1" expected_index="$2" contract="$3"
+  local raw id managed provider role index confgen actual
+  case "$name" in ''|*[!A-Za-z0-9_.-]*) err "unsafe container name: $name"; return 1 ;; esac
+  raw="$(docker inspect -f '{{.Id}}|{{ index .Config.Labels "net.unraid.ci-runner-farm.managed" }}|{{ index .Config.Labels "net.unraid.ci-runner-farm.provider" }}|{{ index .Config.Labels "net.unraid.ci-runner-farm.role" }}|{{ index .Config.Labels "net.unraid.ci-runner-farm.index" }}|{{ index .Config.Labels "net.unraid.ci-runner-farm.confgen" }}|{{.Name}}' "$name" 2>/dev/null)" \
+    || { err "container not found: $name"; return 1; }
+  IFS='|' read -r id managed provider role index confgen actual <<< "$raw"
+  [ "$managed" = "<no value>" ] && managed=""
+  [ "$provider" = "<no value>" ] && provider=""
+  [ "$role" = "<no value>" ] && role=""
+  [ "$index" = "<no value>" ] && index=""
+  [ "$confgen" = "<no value>" ] && confgen=""
+  printf '%s' "$id" | grep -qE '^[0-9a-f]{64}$' \
+    || { err "refusing $name: Docker returned an invalid immutable container ID"; return 1; }
+  [ "$actual" = "/$name" ] \
+    || { err "refusing $name: inspected container name does not match"; return 1; }
+  [ "$managed" = true ] \
+    || { err "refusing unowned container name collision: $name"; return 1; }
+  [ "$index" = "$expected_index" ] \
+    || { err "refusing $name: managed slot index label does not match its name"; return 1; }
+  case "$confgen" in *[!A-Za-z0-9._-]*) err "refusing $name: invalid config-generation label"; return 1 ;; esac
 
-# is a runner actively running a job? (last meaningful log line)
-# Single busy/idle/starting/error predicate shared by the autoscaler (scale-down
-# safety) and the UI status, so the two can never disagree. Deterministic: ask the
-# runner which agent process is live (Runner.Worker = running a job, Runner.Listener
-# = idle-waiting) in one docker exec, matching the image's own healthcheck, with a
-# log-tail fallback for non-standard images or the brief gap between agent processes.
-runner_state() {
-  local c="$1" p
-  p="$(docker exec "$c" sh -c 'pgrep -x Runner.Worker >/dev/null 2>&1 && echo busy || { pgrep -x Runner.Listener >/dev/null 2>&1 && echo idle; }' 2>/dev/null)"
-  case "$p" in busy) echo busy; return;; idle) echo idle; return;; esac
-  case "$(docker logs --tail 15 "$c" 2>&1 | grep -iE 'Running job|Listening for Jobs|Job .* completed|error' | tail -1)" in
-    *"Running job"*)                      echo busy ;;
-    *"Listening for Jobs"*|*"completed"*) echo idle ;;
-    *[Ee]rror*)                           echo error ;;
-    *)                                    echo starting ;;
+  case "$contract:$provider:$role" in
+    runner:github:runner|runner:gitlab:manager|github-validate:github:validate) ;;
+    # Upgrade compatibility for the existing GitHub adapter, which historically
+    # stamped managed+index but had no provider/role labels.
+    runner::) provider=github; role=runner ;;
+    *) err "refusing $name: provider/role ownership labels do not match a $contract container"; return 1 ;;
   esac
+  printf '%s|%s|%s|%s|%s\n' "$id" "$provider" "$role" "$index" "$confgen"
+}
+
+managed_runner_snapshot() {
+  local name="$1" index
+  echo "$name" | grep -qE "^${NAME_PREFIX}-[0-9]+$" \
+    || { err "unsafe runner slot name: $name"; return 1; }
+  index="${name##*-}"
+  owned_container_snapshot "$name" "$index" runner
+}
+
+provider_token_ready() { provider_call token_ready; }
+provider_token_name()  { provider_call token_name; }
+builtin_image()        { provider_call builtin_image; }
+provider_validate_settings() { provider_call validate_settings; }
+provider_public_problem() { provider_call public_repo_problem; }
+provider_registry_credentials() { provider_call registry_credentials; }
+provider_strict_endpoint() { provider_call strict_endpoint; }
+provider_imageupdate_pull() { provider_call imageupdate_pull; }
+provider_remote_image_host_pull_required() { provider_call remote_image_host_pull_required; }
+provider_prepare_remote_image() { provider_call prepare_remote_image "$@"; }
+provider_remote_image_update_allowed() { provider_call remote_image_update_allowed; }
+
+container_docker_stopping_timeout() {
+  local provider
+  provider="$(container_provider "$1")"
+  "${provider}_docker_stopping_timeout" "$1"
+}
+container_docker_stopping() {
+  local provider
+  provider="$(container_provider "$1")"
+  "${provider}_docker_stopping" "$1"
+}
+
+managed_names() {
+  # Validation containers intentionally carry the managed ownership label too,
+  # but they are not fleet slots and their random suffix is not a runner index.
+  # Keep every lifecycle loop scoped to canonical numeric slot names.
+  local listed
+  listed="$(docker ps -a --filter "label=${MANAGED_LABEL}" --format '{{.Names}}')" \
+    || { err "could not enumerate managed runner containers"; return 1; }
+  printf '%s\n' "$listed" \
+    | awk -v prefix="${NAME_PREFIX}-" 'index($0,prefix)==1 && substr($0,length(prefix)+1) ~ /^[0-9]+$/ {print}' \
+    | sort -V
+}
+
+owned_managed_names() {
+  local names c
+  names="$(managed_names)" || return 1
+  for c in $names; do
+    managed_runner_snapshot "$c" >/dev/null || return 1
+  done
+  printf '%s\n' "$names"
+}
+
+current_count() {
+  local names
+  names="$(owned_managed_names)" || return 1
+  printf '%s\n' "$names" | awk 'NF { n++ } END { print n+0 }'
+}
+
+runner_state() {
+  local c="$1" provider
+  provider="$(container_provider "$c")"
+  "${provider}_runner_state" "$c"
 }
 runner_busy() { [ "$(runner_state "$1")" = busy ]; }
 busy_count() {
-  local b=0 c
-  for c in $(managed_names); do [ -n "$c" ] && runner_busy "$c" && b=$((b+1)); done
+  local b=0 c names
+  names="$(managed_names)" || return 1
+  for c in $names; do [ -n "$c" ] && runner_busy "$c" && b=$((b+1)); done
   echo "$b"
 }
 
@@ -180,23 +346,24 @@ busy_count() {
 # change and migrate them onto the new config as they go idle. IMPORTANT: whenever you
 # add a setting that build_args bakes into the container, add it here too.
 crf_confgen() {
-  printf '%s\0' "$GH_SCOPE" "$GH_OWNER" "$GH_REPOS" "$RUNNER_GROUP" "$RUNNER_LABELS" \
-    "$EPHEMERAL" "$RUNNER_CPUS" "$RUNNER_MEMORY" "$WORK_TMPFS_SIZE" "$CACHE_MOUNTS" \
-    "$DIND" "$SHARE_DOCKER_SOCK" "$RUN_AS_ROOT" "$IMAGE_SOURCE" "$IMAGE" \
-    "$REGISTRY_SERVER" "$REGISTRY_USERNAME" "$SHARED_IMAGE_CACHE" "$MIRROR_PORT" \
-    "$NETWORK_ISOLATION" "$RUNNER_NETWORK" "$CACHE_ROOT" \
-    | sha256sum | cut -c1-12
+  provider_call confgen
 }
-# The config fingerprint a running runner was created with ('' for runners created before
+# The config fingerprint a managed runner was created with ('' for runners created before
 # this feature existed — they read as stale and migrate on the next reconcile).
 runner_confgen() { docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.confgen" }}' "$1" 2>/dev/null; }
-# How many RUNNING runners predate the current baked config (drives the drain loop and the
-# UI "migrating" indicator).
+# How many running or stopped managed runners predate the current baked config.
+# A fail-closed unregister deliberately leaves a stopped manager; it must remain
+# visible to the drain instead of letting reconciliation advance through the fleet.
 count_stale_runners() {
-  local cur c n=0; cur="$(crf_confgen)"
-  for c in $(docker ps --filter "label=${MANAGED_LABEL}" --format '{{.Names}}'); do
+  local cur c names snapshot id provider role index gen n=0
+  cur="$(crf_confgen)" || { err "could not calculate the current runner configuration"; return 1; }
+  [ -n "$cur" ] || { err "current runner configuration fingerprint is empty"; return 1; }
+  names="$(managed_names)" || return 1
+  for c in $names; do
     [ -n "$c" ] || continue
-    [ "$(runner_confgen "$c")" = "$cur" ] || n=$((n+1))
+    snapshot="$(managed_runner_snapshot "$c")" || return 1
+    IFS='|' read -r id provider role index gen <<< "$snapshot"
+    [ "$gen" = "$cur" ] || n=$((n+1))
   done
   echo "$n"
 }
@@ -208,17 +375,27 @@ autoscale_floor() { local f="$AUTOSCALE_MIN"; [ "$f" -gt "$AUTOSCALE_MAX" ] && f
 # remove up to $1 IDLE runners (highest index first), never below the effective
 # floor (MIN clamped to MAX), never busy ones
 scale_down_idle() {
-  local want="$1" removed=0 c floor
+  local want="$1" removed=0 c floor provider failed=0 names snapshot id role index gen count
   floor="$(autoscale_floor)"
-  for c in $(managed_names | sort -rV); do
+  names="$(managed_names)" || return 1
+  for c in $(printf '%s\n' "$names" | sort -rV); do
     [ "$removed" -ge "$want" ] && break
-    [ "$(current_count)" -le "$floor" ] && break
-    if ! runner_busy "$c"; then
+    count="$(current_count)" || return 1
+    [ "$count" -le "$floor" ] && break
+    snapshot="$(managed_runner_snapshot "$c")" || return 1
+    IFS='|' read -r id provider role index gen <<< "$snapshot"
+    if "${provider}_scale_down_eligible" "$c"; then
       log "autoscale: removing idle $c"
-      remove_runner "$c"
-      removed=$((removed+1))
+      if remove_runner "$c" true "$id" "$provider"; then
+        removed=$((removed+1))
+      else
+        err "autoscale: failed to remove idle $c; preserving later slots"
+        failed=1
+        break
+      fi
     fi
   done
+  return "$failed"
 }
 
 # Remove managed runners that can no longer service jobs, so the grow step below
@@ -240,11 +417,58 @@ scale_down_idle() {
 # empty => treated as fine, so this is a safe no-op until the new image ships).
 # Caches/DinD roots persist as bind mounts across the recycle.
 reap_dead_runners() {
-  local c st health
-  for c in $(managed_names); do
+  local c st health provider sock side phase job_container failf failcount
+  local names sidecars snapshot id role index gen failed=0
+  names="$(managed_names)" || return 1
+  for c in $names; do
     [ -n "$c" ] || continue
-    st="$(docker inspect -f '{{.State.Status}}' "$c" 2>/dev/null)"
-    health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$c" 2>/dev/null)"
+    snapshot="$(managed_runner_snapshot "$c")" || { failed=1; continue; }
+    IFS='|' read -r id provider role index gen <<< "$snapshot"
+    st="$(docker inspect -f '{{.State.Status}}' "$id" 2>/dev/null)" \
+      || { err "autoscale: could not inspect state for owned runner $c"; failed=1; continue; }
+    health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$id" 2>/dev/null)" \
+      || { err "autoscale: could not inspect health for owned runner $c"; failed=1; continue; }
+    if [ "$provider" = "gitlab" ]; then
+      # A positively identified executor job always wins over manager/sidecar
+      # health. Never destroy a job because its control plane or daemon probe is
+      # transiently unavailable.
+      if ! job_container="$(gitlab_job_container "$c")"; then
+        log "autoscale: retaining $c because its GitLab executor state could not be enumerated"
+        failed=1
+        continue
+      fi
+      [ -n "$job_container" ] && { log "autoscale: retaining $c while GitLab job $job_container is active"; continue; }
+      if [ "$st" = "running" ]; then
+        phase="$(gitlab_runner_state "$c")"
+        [ "$phase" = busy ] && { log "autoscale: retaining positively busy GitLab manager $c"; continue; }
+      fi
+    fi
+    if [ "$provider" = "gitlab" ] && [ "$st" = "running" ]; then
+      sock="$(gitlab_socket_path "$c")"
+      if [ "$sock" != "/var/run/docker.sock" ]; then
+        side="$(gitlab_sidecar_name "$c")"
+        sidecars="$(docker ps --format '{{.Names}}')" \
+          || { err "autoscale: could not enumerate GitLab sidecars for owned runner $c"; failed=1; continue; }
+        if ! printf '%s\n' "$sidecars" | grep -qx "$side" \
+           || ! docker --host "unix://$sock" info >/dev/null 2>&1; then
+          # A single nested-daemon probe can fail during dockerd GC or host I/O.
+          # Require two consecutive fleet evaluations before destructive repair;
+          # positively detected jobs/busy metrics were already protected above.
+          failf="$RUNDIR/gitlab-sidecar-fail.$c"; failcount=0
+          [ -f "$failf" ] && read -r failcount < "$failf"
+          case "$failcount" in ''|*[!0-9]*) failcount=0 ;; esac
+          failcount=$((failcount+1)); printf '%s\n' "$failcount" > "$failf"
+          if [ "$failcount" -lt 2 ]; then
+            log "autoscale: deferring repair of $c after first private Docker daemon probe failure"
+            continue
+          fi
+          log "autoscale: reaping GitLab manager $c because its private Docker daemon is unavailable"
+          st=dead
+        else
+          rm -f "$RUNDIR/gitlab-sidecar-fail.$c" 2>/dev/null || true
+        fi
+      fi
+    fi
     case "$st" in
       exited|dead)
         log "autoscale: reaping dead runner $c (state=$st)" ;;
@@ -253,17 +477,28 @@ reap_dead_runners() {
         log "autoscale: reaping unhealthy runner $c (disconnected; health=$health)" ;;
       *) continue ;;
     esac
-    deregister_runner_api "$c"
-    docker rm -f "$c" >/dev/null 2>&1
+    if remove_runner "$c" true "$id" "$provider"; then
+      rm -f "$RUNDIR/gitlab-sidecar-fail.$c" 2>/dev/null || true
+    else
+      log "autoscale: failed to remove dead runner $c; will retry"
+      failed=1
+    fi
   done
+  return "$failed"
 }
 
 # one autoscaling evaluation: keep AUTOSCALE_MIN_IDLE warm runners, within [MIN,MAX]
 autoscale_tick() {
   [ "$AUTOSCALE" = "true" ] || return 0
-  reap_dead_runners        # drop dead containers first so idle accounting is real
-  local cur busy idle statef over target
-  cur=$(current_count); busy=$(busy_count); idle=$((cur - busy))
+  reap_dead_runners || return 1  # drop dead containers first so idle accounting is real
+  local cur=0 busy=0 idle=0 statef over target
+  # GitHub retains its original cur-busy semantics; GitLab counts only explicit
+  # idle managers so disconnected/starting slots are not phantom headroom.
+  provider_call autoscale_counts \
+    || { err "autoscale: could not enumerate and inspect the managed fleet"; return 1; }
+  case "$cur:$busy:$idle" in
+    *[!0-9:]*) err "autoscale: provider returned invalid fleet counts"; return 1 ;;
+  esac
   statef="${RUNDIR}/autoscale.state"; over=0
   [ -f "$statef" ] && over=$(cat "$statef" 2>/dev/null || echo 0)
 
@@ -288,7 +523,8 @@ autoscale_tick() {
     over=$(( over + 1 )); echo "$over" > "$statef"
     if [ "$over" -ge "$AUTOSCALE_IDLE_GRACE" ]; then
       log "autoscale: idle=$idle/$cur high for $over checks -> shrink by $AUTOSCALE_STEP"
-      scale_down_idle "$AUTOSCALE_STEP"; echo 0 > "$statef"
+      scale_down_idle "$AUTOSCALE_STEP" || return 1
+      echo 0 > "$statef"
     fi
   else
     echo 0 > "$statef"
@@ -313,7 +549,7 @@ autoscale_daemon() {
   log "autoscale daemon up (min=$AUTOSCALE_MIN max=$AUTOSCALE_MAX buffer=$AUTOSCALE_MIN_IDLE step=$AUTOSCALE_STEP every ${AUTOSCALE_INTERVAL}s)"
   while true; do
     load_cfg
-    [ -z "$ACCESS_TOKEN" ] && [ -f "$TOKEN_FILE" ] && ACCESS_TOKEN="$(cat "$TOKEN_FILE" 2>/dev/null)"
+    reload_secret_files
     [ "$AUTOSCALE" = "true" ] || { log "autoscale disabled -> daemon exit"; rm -f "$AUTOSCALE_PID"; break; }
     with_fleet_lock try autoscale_tick
     sleep "${AUTOSCALE_INTERVAL:-30}"
@@ -322,15 +558,35 @@ autoscale_daemon() {
 
 autoscale_start() {
   [ "$AUTOSCALE" = "true" ] || return 0
-  autoscale_stop
+  autoscale_stop || return 1
   nohup "$0" autoscale-daemon >>"${RUNDIR}/autoscale.log" 2>&1 &
   echo $! > "$AUTOSCALE_PID"
   log "autoscale daemon started (pid $(cat "$AUTOSCALE_PID"))"
 }
+stop_worker_group() {
+  local label="$1" pidfile="$2" pattern="$3" pids i
+  pids="$(pgrep -f "$pattern" 2>/dev/null || true)"
+  if [ -n "$pids" ]; then
+    # pgrep returns numeric PIDs only. Target the live command line rather than a
+    # stale PID file that could have been recycled for an unrelated process.
+    kill $pids 2>/dev/null || true
+    for i in $(seq 1 20); do
+      pgrep -f "$pattern" >/dev/null 2>&1 || break
+      sleep 0.1
+    done
+  fi
+  rm -f "$pidfile" 2>/dev/null || {
+    err "could not remove $label PID file"
+    return 1
+  }
+  if pgrep -f "$pattern" >/dev/null 2>&1; then
+    err "$label worker is still running"
+    return 1
+  fi
+}
+
 autoscale_stop() {
-  [ -f "$AUTOSCALE_PID" ] && kill "$(cat "$AUTOSCALE_PID")" 2>/dev/null
-  rm -f "$AUTOSCALE_PID"
-  pkill -f "runner-farm.sh autoscale-daemon" 2>/dev/null || true
+  stop_worker_group "autoscale" "$AUTOSCALE_PID" '[r]unner-farm.sh autoscale-daemon'
 }
 autoscale_status() {
   if [ -f "$AUTOSCALE_PID" ] && kill -0 "$(cat "$AUTOSCALE_PID" 2>/dev/null)" 2>/dev/null; then
@@ -357,16 +613,24 @@ image_id() { docker image inspect --format '{{.Id}}' "$1" 2>/dev/null; }
 imageupdate_pull() {
   local changed=1 before after img
   img="$(effective_image)"
-  if [ "$IMAGE_SOURCE" = "remote" ] && [ -n "$IMAGE" ]; then
-    registry_login
+  provider_imageupdate_pull && changed=0
+  if [ "$IMAGE_SOURCE" = "remote" ] && [ -n "$IMAGE" ] \
+     && provider_remote_image_host_pull_required \
+     && provider_remote_image_update_allowed; then
     before="$(image_id "$img")"
-    docker pull "$img" >/dev/null 2>&1
+    provider_prepare_remote_image "$img" >/dev/null 2>&1 \
+      || { err "image-update: provider image preparation failed"; return 1; }
     after="$(image_id "$img")"
     if [ -n "$after" ] && [ "$before" != "$after" ]; then
       changed=0; log "image-update: $img ${before:-none} -> $after"
     fi
-  else
+  elif [ "$IMAGE_SOURCE" != "remote" ] || [ -z "$IMAGE" ]; then
     log "image-update: image source is builtin ($img) — nothing to pull; rebuild via build-image to update"
+  else
+    # GitLab DinD refreshes through the slot daemon. Explicit host-socket
+    # An explicit if-not-present policy likewise prohibits this scheduled host pull.
+    rm -f "$HOST_DOCKER_CONFIG/config.json" 2>/dev/null || true
+    log "image-update: provider job-image pull policy does not permit a scheduled host pull"
   fi
   # keep the shared pull-through mirror image current too (recreate in place if it moved)
   if [ "$SHARED_IMAGE_CACHE" = "true" ] && [ "$DIND" = "true" ]; then
@@ -375,7 +639,8 @@ imageupdate_pull() {
     after="$(image_id registry:2)"
     if [ -n "$after" ] && [ "$before" != "$after" ]; then
       log "image-update: mirror image registry:2 changed -> recreating $MIRROR_NAME"
-      docker rm -f "$MIRROR_NAME" >/dev/null 2>&1; ensure_mirror
+      mirror_remove_owned || return 1
+      ensure_mirror || return 1
     fi
   fi
   return $changed
@@ -385,7 +650,7 @@ imageupdate_pull() {
 # freshly-pulled image. Never interrupts a running job. If it stays busy past
 # IMAGE_DRAIN_TIMEOUT, leave it on the old image — the next cycle retries.
 drain_and_recreate() {
-  local c="$1" waited=0 idx limit
+  local c="$1" waited=0 limit all_names
   limit="${IMAGE_DRAIN_TIMEOUT:-3600}"
   # Wait for the runner to finish its job WITHOUT holding the fleet lock across the
   # (up to IMAGE_DRAIN_TIMEOUT — hours) idle-wait. fd 8 is the fleet mutex, held by our
@@ -400,34 +665,87 @@ drain_and_recreate() {
     flock -u 8 2>/dev/null                 # release the fleet lock while idle-waiting
     sleep 15; waited=$((waited+15))
     flock -w 20 8 2>/dev/null || { log "image-update: fleet busy elsewhere — deferring $c to next cycle"; return 1; }
+    # Another action may have changed provider settings or removed a credential
+    # while this drain deliberately released fleet.lock. Resume only from the
+    # snapshot that exists after the lock was reacquired.
+    reload_locked_snapshot || return 1
   done
   # Re-holding the lock here. If the runner vanished while we were unlocked (the
   # operator hit Stop/Recycle mid-drain), do NOT recreate it — never resurrect a
   # runner the operator just removed.
-  docker ps -a --format '{{.Names}}' | grep -qx "$c" || { log "image-update: $c no longer present — skipping recreate"; return 0; }
-  idx="$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.index" }}' "$c" 2>/dev/null)"
-  [ -z "$idx" ] && idx="${c##*-}"
-  log "image-update: $c idle -> recreating on new image"
-  remove_runner "$c"
-  start_one "$idx"
+  all_names="$(docker ps -a --format '{{.Names}}')" \
+    || { err "image-update: could not enumerate Docker containers after reacquiring the fleet lock"; return 1; }
+  printf '%s\n' "$all_names" | grep -qx "$c" \
+    || { log "image-update: $c no longer present — skipping recreate"; return 0; }
+  log "image-update: $c idle -> validating and recycling onto the current provider image"
+  if ! cmd_recycle "$c" >/dev/null; then
+    log "image-update: validated recycle of $c failed; existing capacity was preserved when possible"
+    return 1
+  fi
 }
 
 # Roll the whole fleet onto the new image, one runner at a time so capacity stays
 # up while each drains. Re-reads managed_names each loop (recreated names persist).
 imageupdate_rollover() {
-  local c
-  for c in $(managed_names); do
-    [ -n "$c" ] && drain_and_recreate "$c"
+  local retry_only="${1:-false}" c names failed=0 pending_tmp final_count
+  pending_tmp="${IMAGEUPDATE_PENDING}.tmp.$$"
+  : > "$pending_tmp" || { err "image-update: cannot persist rollover retry state"; return 1; }
+  if [ "$retry_only" = true ]; then
+    names="$([ -f "$IMAGEUPDATE_PENDING" ] && cat "$IMAGEUPDATE_PENDING")"
+  else
+    if ! names="$(managed_names)"; then
+      rm -f "$pending_tmp"
+      err "image-update: could not enumerate the managed fleet before rollover"
+      return 1
+    fi
+  fi
+  for c in $names; do
+    [ -n "$c" ] || continue
+    # A manual Stop/Recycle may have removed a previously pending slot. Do not
+    # resurrect it merely because an older image-update pass recorded its name.
+    docker inspect "$c" >/dev/null 2>&1 || continue
+    if [ "$failed" -ne 0 ]; then
+      # Stop at the first unsafe slot. Preserve every unattempted name so this
+      # pass cannot drain the rest of the fleet after one fail-closed recycle.
+      printf '%s\n' "$c" >> "$pending_tmp"
+      continue
+    fi
+    if ! drain_and_recreate "$c"; then
+      printf '%s\n' "$c" >> "$pending_tmp"
+      failed=1
+    fi
   done
-  log "image-update: rollover complete ($(managed_names | wc -l) runner(s) on $(effective_image))"
+  if [ -s "$pending_tmp" ]; then
+    if ! mv "$pending_tmp" "$IMAGEUPDATE_PENDING"; then
+      rm -f "$pending_tmp"
+      err "image-update: could not publish rollover retry state"
+      return 1
+    fi
+    log "image-update: rollover incomplete; $(grep -c . "$IMAGEUPDATE_PENDING") slot(s) will retry next cycle"
+  else
+    final_count="$(current_count)" || {
+      rm -f "$pending_tmp"
+      err "image-update: rollover finished but the managed fleet could not be verified"
+      return 1
+    }
+    rm -f "$pending_tmp" "$IMAGEUPDATE_PENDING"
+    log "image-update: rollover complete ($final_count runner(s) on $(effective_image))"
+  fi
+  return "$failed"
 }
 
-# one update evaluation: pull, and roll only if the runner image actually changed
+# One update evaluation. A digest change starts a full roll; any slot that could
+# not drain or replace is persisted by name and retried on later ticks even though
+# the local image tag has already advanced and a subsequent pull is unchanged.
 imageupdate_tick() {
   [ "$IMAGE_AUTOUPDATE" = "true" ] || return 0
-  imageupdate_pull || return 0   # nonzero = image unchanged this cycle
-  log "image-update: new runner image detected -> draining + recreating fleet"
-  imageupdate_rollover
+  if imageupdate_pull; then
+    log "image-update: a provider runtime/job image changed -> draining + recreating fleet"
+    imageupdate_rollover false
+  elif [ -s "$IMAGEUPDATE_PENDING" ]; then
+    log "image-update: retrying the slots left on an older provider image"
+    imageupdate_rollover true
+  fi
 }
 
 # long-running loop; re-reads config each tick so UI changes apply live
@@ -436,8 +754,7 @@ imageupdate_daemon() {
   log "image-update daemon up (every ${IMAGE_AUTOUPDATE_INTERVAL}s, drain-timeout ${IMAGE_DRAIN_TIMEOUT}s)"
   while true; do
     load_cfg
-    [ -z "$ACCESS_TOKEN" ] && [ -f "$TOKEN_FILE" ] && ACCESS_TOKEN="$(cat "$TOKEN_FILE" 2>/dev/null)"
-    [ -z "$REGISTRY_TOKEN" ] && [ -f "$REGISTRY_TOKEN_FILE" ] && REGISTRY_TOKEN="$(cat "$REGISTRY_TOKEN_FILE" 2>/dev/null)"
+    reload_secret_files
     [ "$IMAGE_AUTOUPDATE" = "true" ] || { log "image auto-update disabled -> daemon exit"; rm -f "$IMAGEUPDATE_PID"; break; }
     with_fleet_lock try imageupdate_tick
     sleep "${IMAGE_AUTOUPDATE_INTERVAL:-1800}"
@@ -446,29 +763,18 @@ imageupdate_daemon() {
 
 imageupdate_start() {
   [ "$IMAGE_AUTOUPDATE" = "true" ] || return 0
-  imageupdate_stop
+  imageupdate_stop || return 1
   nohup "$0" imageupdate-daemon >>"${RUNDIR}/imageupdate.log" 2>&1 &
   echo $! > "$IMAGEUPDATE_PID"
   log "image-update daemon started (pid $(cat "$IMAGEUPDATE_PID"))"
 }
 imageupdate_stop() {
-  [ -f "$IMAGEUPDATE_PID" ] && kill "$(cat "$IMAGEUPDATE_PID")" 2>/dev/null
-  rm -f "$IMAGEUPDATE_PID"
-  pkill -f "runner-farm.sh imageupdate-daemon" 2>/dev/null || true
+  stop_worker_group "image-update" "$IMAGEUPDATE_PID" '[r]unner-farm.sh imageupdate-daemon'
 }
 imageupdate_status() {
   if [ -f "$IMAGEUPDATE_PID" ] && kill -0 "$(cat "$IMAGEUPDATE_PID" 2>/dev/null)" 2>/dev/null; then
     echo "running (pid $(cat "$IMAGEUPDATE_PID"))"
   else echo "stopped"; fi
-}
-
-repo_for_index() {
-  # round-robin assign a target repo to runner index (repo scope, multi-repo)
-  local idx="$1"
-  # shellcheck disable=SC2206  # GH_REPOS is a deliberately space-separated list
-  local arr=($GH_REPOS); local n=${#arr[@]}
-  [ "$n" -eq 0 ] && { echo ""; return; }
-  echo "${arr[$(( (idx-1) % n ))]}"
 }
 
 # Inspect CACHE_ROOT and describe any problem that would break the fleet (empty
@@ -479,8 +785,33 @@ repo_for_index() {
 #     Docker data root lands here, and overlay2 cannot run on FUSE, so buildx
 #     and 'services:' jobs die with "mount overlay ... invalid argument".
 cache_root_problem() {
-  local line fstype target
-  line=$(df -PT "$CACHE_ROOT" 2>/dev/null | awk 'NR==2')
+  local root probe resolved line fstype target
+  # A valid cache leaf need not exist before the first Start/Validate. Resolve
+  # the guarded path first, then ask df about its nearest existing ancestor.
+  # Using the canonical path (and canonicalizing the ancestor again) means an
+  # existing symlink cannot redirect this probe outside the safe root between
+  # the shape check and df. If the configured pool is not mounted yet, the walk
+  # reaches /mnt and df reports rootfs, so the existing hard failure is retained.
+  root="$(crf_safe_cache_root 2>/dev/null)" || {
+    echo "CACHE_ROOT ($CACHE_ROOT) is unsafe — point it at a dedicated subdirectory under /mnt/<pool>."
+    return
+  }
+  probe="$root"
+  while [ ! -e "$probe" ] && [ "$probe" != "/" ]; do
+    probe="${probe%/*}"
+    [ -n "$probe" ] || probe="/"
+  done
+  resolved="$(realpath -e -- "$probe" 2>/dev/null)" || {
+    echo "CACHE_ROOT ($CACHE_ROOT) could not be resolved to a stable existing pool path."
+    return
+  }
+  case "$root" in
+    "$resolved"|"$resolved"/*) probe="$resolved" ;;
+    *)
+      echo "CACHE_ROOT ($CACHE_ROOT) changed while it was being checked; retry after verifying the path."
+      return ;;
+  esac
+  line=$(df -PT -- "$probe" 2>/dev/null | awk 'NR==2')
   fstype=$(echo "$line" | awk '{print $2}')
   target=$(echo "$line" | awk '{print $NF}')
   case "$fstype" in
@@ -524,31 +855,31 @@ check_cache_root() {
 
 # Thin GitHub REST helper: gh_api METHOD PATH -> response body on stdout (empty on
 # failure). Requires ACCESS_TOKEN. Used for the token + deregistration calls below.
-gh_api() {
-  [ -n "$ACCESS_TOKEN" ] || return 1
-  # Pass the bearer token via --config on stdin so the PAT never appears in argv
-  # (/proc/<pid>/cmdline is world-readable), unlike a -H flag on the command line.
-  printf 'header = "Authorization: Bearer %s"\n' "$ACCESS_TOKEN" \
-    | curl -fsSL -m 10 -X "$1" --config - \
-      -H "Accept: application/vnd.github+json" \
-      "https://api.github.com$2" 2>/dev/null
+# GitLab API telemetry is deliberately separate from the reusable runner
+# authentication token. The optional read_api token never enters a container or
+# argv: like the GitHub PAT, curl reads its header from stdin. Callers use this
+# only for the operator-configured GITLAB_PROJECTS list; runner polling itself
+# works without it.
+# Capture both body and response headers. GitLab's pagination X-Total header is
+# the only efficient way to count all pending jobs without downloading an
+# arbitrary number of pages.
+# RFC 3986 percent encoding for GitLab project paths. Implemented locally so
+# the runtime does not depend on jq/Python/PHP being available in PATH.
+urlencode() {
+  local LC_ALL=C s="$1" out="" c hex
+  while [ -n "$s" ]; do
+    c="${s:0:1}"; s="${s:1}"
+    case "$c" in
+      [A-Za-z0-9.~_-]) out+="$c" ;;
+      *) printf -v hex '%02X' "'$c"; out+="%$hex" ;;
+    esac
+  done
+  printf '%s' "$out"
 }
 
 # Mint a runner registration token for a scope. $1 = "org:<name>" or
 # "repo:<owner/repo>". Echoes the token (empty on failure). GitHub's
 # registration-token endpoint returns {"token":"...","expires_at":"..."}.
-registration_token() {
-  local target="$1" path
-  case "$target" in
-    org:*)  path="/orgs/${target#org:}/actions/runners/registration-token" ;;
-    repo:*) path="/repos/${target#repo:}/actions/runners/registration-token" ;;
-    *) echo ""; return 1 ;;
-  esac
-  gh_api POST "$path" \
-    | grep -o '"token"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
-    | sed 's/.*"\([^"]*\)"$/\1/'
-}
-
 # Deregister a runner from GitHub host-side, by name, using the PAT. This replaces
 # the base image's in-container SIGTERM deregister (we disable it via
 # DISABLE_AUTOMATIC_DEREGISTRATION) — that path re-mints from ACCESS_TOKEN and so
@@ -557,35 +888,9 @@ registration_token() {
 # Best-effort: a busy runner can't be deleted (GitHub 422) and a leftover offline
 # entry is harmless — the next Start re-registers the same name with --replace.
 deregister_runner_api() {
-  local c="$1" rname idx repo base id
-  [ -n "$ACCESS_TOKEN" ] && [ -n "$c" ] || return 0
-  rname="$(host)-${c}"                          # matches RUNNER_NAME set in build_args
-  if [ "$GH_SCOPE" = "org" ]; then
-    base="/orgs/${GH_OWNER}"
-  else
-    idx="${c##*-}"; repo="$(repo_for_index "$idx")"
-    [ -n "$repo" ] || return 0
-    base="/repos/${repo}"
-  fi
-  # Resolve name -> id from the (pretty-printed, multi-line) runners list. Track the
-  # last-seen id and name, and emit only at a runner-only key ("os") — label objects
-  # carry "id"+"name" too but never "os", and a runner's own id/name precede its
-  # labels, so at the "os" line cur/nm still hold the runner's values. Robust to the
-  # API's whitespace/line formatting (a single-line grep pair is not).
-  id="$(gh_api GET "${base}/actions/runners?per_page=100" | awk -v want="$rname" '
-      /"id"[[:space:]]*:/   { if (match($0, /[0-9]+/)) cur = substr($0, RSTART, RLENGTH) }
-      /"name"[[:space:]]*:/ { s=$0; sub(/^[^:]*:[[:space:]]*"/, "", s); sub(/".*/, "", s); nm=s }
-      /"os"[[:space:]]*:/   { if (nm == want) { print cur; exit } }
-    ')"
-  [ -n "$id" ] || return 0
-  # Best-effort (all callers force-remove the container regardless), but surface a
-  # DELETE failure in the fleet log so a lingering "offline" registration on GitHub
-  # isn't completely silent — recycle/scale-down otherwise report only success.
-  if gh_api DELETE "${base}/actions/runners/${id}" >/dev/null 2>&1; then
-    log "deregistered $rname from GitHub (id $id)"
-  else
-    log "warning: could not deregister $rname (id $id) from GitHub — a stale offline runner may linger"
-  fi
+  local c="$1" provider
+  provider="$(container_provider "$c")"
+  "${provider}_deregister_runner_api" "$c"
 }
 
 # Fetch one GitHub REST endpoint for EVERY repo in GH_REPOS concurrently, writing each
@@ -596,25 +901,6 @@ deregister_runner_api() {
 # list can't spawn hundreds of simultaneous curls or trip GitHub's concurrent-request
 # secondary limit. Callers re-walk GH_REPOS with the SAME skip-empty rule so file <n>
 # lines up with the right repo. Requires $ACCESS_TOKEN in scope.
-gh_fetch_all() {
-  local suffix="$1" outdir="$2" maxpar="${3:-8}" timeout="${4:-10}"
-  local n=0 r
-  for r in $GH_REPOS; do
-    [ -n "$r" ] || continue
-    n=$((n+1))
-    # PAT via --config on stdin so it never lands in argv (/proc/<pid>/cmdline is
-    # world-readable and reachable from a broken-out privileged runner) — same
-    # hardening as gh_api. printf is a shell builtin (no argv exposure) and the whole
-    # printf|curl pipeline is backgrounded as a unit, so each curl gets its own stdin.
-    printf 'header = "Authorization: Bearer %s"\n' "$ACCESS_TOKEN" \
-      | curl -s --max-time "$timeout" --config - \
-        -H "Accept: application/vnd.github+json" \
-        "https://api.github.com/repos/${r}${suffix}" > "$outdir/$n" 2>/dev/null &
-    [ $((n % maxpar)) -eq 0 ] && wait
-  done
-  wait
-}
-
 # The single biggest footgun: pointing privileged runners at a PUBLIC repo. A
 # fork PR on a public repo runs attacker-controlled code, and here that code runs
 # in a --privileged DinD container (or with the host docker.sock mounted) — i.e.
@@ -625,57 +911,57 @@ gh_fetch_all() {
 # for repo scope; org scope should use a runner group restricted to private repos.
 # Result is cached with a TTL (SECURITY_TTL) so the UI's 5s status poll doesn't
 # hit the GitHub API on every refresh.
+security_cache_get() {
+  [ -f "$SECURITY_CACHE" ] || return 1
+  local age first
+  age=$(( $(date +%s) - $(stat -c %Y "$SECURITY_CACHE" 2>/dev/null || echo 0) ))
+  [ "$age" -ge 0 ] && [ "$age" -lt "$SECURITY_TTL" ] || return 1
+  first="$(head -1 "$SECURITY_CACHE" 2>/dev/null)"
+  case "$first" in
+    github|gitlab) [ "$first" = "$CI_PROVIDER" ] || return 1; tail -n +2 "$SECURITY_CACHE" ;;
+    *) [ "$CI_PROVIDER" = github ] || return 1; cat "$SECURITY_CACHE" ;; # pre-provider cache
+  esac
+}
+
+security_cache_put() {
+  { printf '%s\n' "$CI_PROVIDER"; printf '%s' "$1"; } > "$SECURITY_CACHE" 2>/dev/null || true
+}
+
 public_repo_problem() {
-  [ "$GH_SCOPE" = "repo" ] || { echo ""; return; }
-  { [ "$DIND" = "true" ] || [ "$SHARE_DOCKER_SOCK" = "true" ]; } || { echo ""; return; }
-  [ -n "$ACCESS_TOKEN" ] || { echo ""; return; }   # can't query without a token
-  if [ -f "$SECURITY_CACHE" ]; then
-    local age; age=$(( $(date +%s) - $(stat -c %Y "$SECURITY_CACHE" 2>/dev/null || echo 0) ))
-    [ "$age" -ge 0 ] && [ "$age" -lt "$SECURITY_TTL" ] && { cat "$SECURITY_CACHE"; return; }
-  fi
-  local pub="" repo vis tmpd n=0
-  tmpd="$(mktemp -d 2>/dev/null)"
-  [ -n "$tmpd" ] || { echo ""; return; }   # transient temp failure: don't cache, retry next call
-  # One concurrent visibility probe per repo (see gh_fetch_all). GitHub's repo API
-  # returns "visibility":"public|private|internal"; a 404 (a repo the PAT can't see)
-  # returns a JSON error body with no "visibility" field, so it reads as unknown and is
-  # not flagged — the same outcome the old per-repo `curl -f` gave.
-  gh_fetch_all "" "$tmpd" 8 5
-  for repo in $GH_REPOS; do
-    [ -n "$repo" ] || continue
-    n=$((n+1))
-    vis="$(grep -o '"visibility"[[:space:]]*:[[:space:]]*"[^"]*"' "$tmpd/$n" 2>/dev/null | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
-    [ "$vis" = "public" ] && pub="$pub ${repo}"
-  done
-  rm -rf "$tmpd"
-  local msg=""
-  [ -n "$pub" ] && msg="PUBLIC repo(s) targeted while runners are privileged (DinD / host docker.sock):${pub}. Fork-PR code on a public repo would run as root on this server. Use trusted/private repos only, or an org runner-group restricted to private repos. See the Security section of the plugin README."
-  printf '%s' "$msg" > "$SECURITY_CACHE" 2>/dev/null || true
-  printf '%s' "$msg"
+  provider_public_problem
 }
 
 # docker login on the HOST so it can pull a private runner IMAGE (e.g. a private
 # GHCR image). No-op unless server+username+token are all configured.
 registry_login() {
-  [ "$IMAGE_SOURCE" = "remote" ] || return 0
-  [ -n "$REGISTRY_SERVER" ] || return 0
-  local user="$REGISTRY_USERNAME" pass="$REGISTRY_TOKEN"
-  # GHCR fallback: reuse the GitHub PAT (ACCESS_TOKEN) when no dedicated registry
-  # token is set, so a private GHCR image pulls without configuring a second
-  # token. Requires the PAT to carry the read:packages scope. Username can be
-  # anything for GHCR PAT auth; default to the org/owner.
-  if [ -z "$pass" ]; then
-    case "$REGISTRY_SERVER" in
-      ghcr.io|*.ghcr.io) pass="$ACCESS_TOKEN"; [ -z "$user" ] && user="$GH_OWNER" ;;
-    esac
+  if [ "$IMAGE_SOURCE" != remote ] || [ -z "$REGISTRY_SERVER" ]; then
+    rm -f "$HOST_DOCKER_CONFIG/config.json" 2>/dev/null || true
+    return 0
   fi
-  [ -n "$user" ] && [ -n "$pass" ] || return 0
-  if printf '%s' "$pass" | docker login -u "$user" --password-stdin -- "$REGISTRY_SERVER" >/dev/null 2>&1; then
+  local user="$REGISTRY_USERNAME" pass="$REGISTRY_TOKEN"
+  provider_registry_credentials
+  mkdir -p "$HOST_DOCKER_CONFIG" || return 1
+  chmod 700 "$HOST_DOCKER_CONFIG" 2>/dev/null || true
+  if [ -z "$user" ] || [ -z "$pass" ]; then
+    rm -f "$HOST_DOCKER_CONFIG/config.json" 2>/dev/null || true
+    return 0
+  fi
+  if printf '%s' "$pass" | docker --config "$HOST_DOCKER_CONFIG" login -u "$user" --password-stdin -- "$REGISTRY_SERVER" >/dev/null 2>&1; then
+    chmod 600 "$HOST_DOCKER_CONFIG/config.json" 2>/dev/null || true
     log "registry: logged in to $REGISTRY_SERVER as $user"
   else
+    # Never retain the previously working credential after a failed rotation;
+    # later pulls must fail closed instead of silently using stale cached auth.
+    rm -f "$HOST_DOCKER_CONFIG/config.json" 2>/dev/null || true
     err "registry: docker login to $REGISTRY_SERVER failed (check server/username/token; GHCR needs read:packages on the PAT)"
     return 1
   fi
+}
+
+host_docker_pull() {
+  mkdir -p "$HOST_DOCKER_CONFIG" || return 1
+  chmod 700 "$HOST_DOCKER_CONFIG" 2>/dev/null || true
+  docker --config "$HOST_DOCKER_CONFIG" pull "$1"
 }
 
 ensure_dirs() {
@@ -702,16 +988,30 @@ ensure_dirs() {
 # on). Docker isolates user-defined bridges from each other, so runners here can't
 # reach your OTHER Unraid containers. Docker auto-allocates the subnet; strict mode
 # reads it back for the egress rules. No-op (and never created) when isolation=off.
+network_owned() {
+  [ "$(docker network inspect -f '{{ index .Labels "net.unraid.ci-runner-farm" }}' "$1" 2>/dev/null)" = 1 ]
+}
+
 ensure_network() {
   [ "$NETWORK_ISOLATION" = "off" ] && return 0
-  docker network inspect "$RUNNER_NETWORK" >/dev/null 2>&1 && return 0
+  if docker network inspect "$RUNNER_NETWORK" >/dev/null 2>&1; then
+    if network_owned "$RUNNER_NETWORK"; then
+      return 0
+    fi
+    if [ "$NETWORK_ISOLATION" = strict ]; then
+      err "strict isolation refuses unowned pre-existing network $RUNNER_NETWORK; remove/rename the collision or select an owned runner network"
+      return 1
+    fi
+    log "warning: using pre-existing unowned network $RUNNER_NETWORK; it will be preserved on Stop"
+    return 0
+  fi
   log "creating isolated runner network $RUNNER_NETWORK"
   # Label our networks so they're identifiable as plugin-created. (RUNNER_NETWORK
   # defaults to the plugin-specific 'ci-runner-net'; a foreign network deliberately
   # pointed at by a hand-edited RUNNER_NETWORK is not verified here to preserve
   # upgrade compatibility with pre-label networks — see docs on isolation caveats.)
   docker network create --driver bridge --label net.unraid.ci-runner-farm=1 "$RUNNER_NETWORK" >/dev/null \
-    || err "could not create network $RUNNER_NETWORK"
+    || { err "could not create network $RUNNER_NETWORK"; return 1; }
 }
 
 # Does container $1 sit on the network the CURRENT isolation mode expects? Used to
@@ -733,22 +1033,87 @@ on_expected_network() {
 # ($MIRROR_NAME:5000) over that bridge — so it keeps working even in strict mode,
 # where host access is blocked. Otherwise it's published on the host ($MIRROR_PORT)
 # and reached via host.docker.internal (the legacy path).
+mirror_labelled_id() {
+  local id="$1"
+  [ -n "$id" ] \
+    && [ "$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.resource" }}' "$id" 2>/dev/null)" = true ] \
+    && [ "$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.role" }}' "$id" 2>/dev/null)" = mirror ]
+}
+
+# v1.8 and earlier created this plugin-specific mirror without ownership labels.
+# Keep upgrades working, but recognize that legacy object only by a complete
+# immutable provenance tuple: exact name, official image/config, and the exact
+# plugin cache bind source. A merely colliding name never authorizes deletion.
+mirror_legacy_owned_id() {
+  local id="$1" name image source expected env
+  [ -n "$id" ] || return 1
+  name="$(docker inspect -f '{{.Name}}' "$id" 2>/dev/null)" || return 1
+  image="$(docker inspect -f '{{.Config.Image}}' "$id" 2>/dev/null)" || return 1
+  source="$(docker inspect -f '{{range .Mounts}}{{if eq .Destination "/var/lib/registry"}}{{.Source}}{{end}}{{end}}' "$id" 2>/dev/null)" || return 1
+  env="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$id" 2>/dev/null)" || return 1
+  expected="$CACHE_ROOT/registry-mirror"
+  [ "$name" = "/$MIRROR_NAME" ] \
+    && [ "$image" = registry:2 ] \
+    && [ "$source" = "$expected" ] \
+    && printf '%s\n' "$env" | grep -qx 'REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io'
+}
+
+mirror_owned_id() {
+  mirror_labelled_id "$1" || mirror_legacy_owned_id "$1"
+}
+
+mirror_resolve_owned_id() {
+  local id
+  id="$(docker inspect -f '{{.Id}}' "$MIRROR_NAME" 2>/dev/null)" || return 1
+  mirror_owned_id "$id" || {
+    err "refusing fixed-name collision: $MIRROR_NAME is not owned by CI Runner Farm"
+    return 1
+  }
+  if ! mirror_labelled_id "$id"; then
+    log "recognized legacy CI Runner Farm mirror by its exact image/cache provenance; it will be recreated with ownership labels on the next mirror refresh" >&2
+  fi
+  printf '%s\n' "$id"
+}
+
+# Delete the immutable object we inspected, never a name that another actor could
+# reuse between the ownership check and Docker rm.
+mirror_remove_owned() {
+  local id
+  if ! docker inspect "$MIRROR_NAME" >/dev/null 2>&1; then return 0; fi
+  id="$(mirror_resolve_owned_id)" || return 1
+  docker rm -f "$id" >/dev/null 2>&1 \
+    || { err "could not remove owned shared image cache $MIRROR_NAME"; return 1; }
+  if docker inspect "$id" >/dev/null 2>&1; then
+    err "owned shared image cache $MIRROR_NAME still exists after removal"
+    return 1
+  fi
+}
+
 ensure_mirror() {
   [ "$SHARED_IMAGE_CACHE" = "true" ] && [ "$DIND" = "true" ] || return 0
-  mkdir -p "$CACHE_ROOT/registry-mirror"
+  mkdir -p "$CACHE_ROOT/registry-mirror" \
+    || { err "could not create shared image cache directory under $CACHE_ROOT"; return 1; }
+  local existing_id=""
+  if docker inspect "$MIRROR_NAME" >/dev/null 2>&1; then
+    existing_id="$(mirror_resolve_owned_id)" || return 1
+  fi
   # If the mirror is up but on the wrong network for the current mode (operator
   # switched NETWORK_ISOLATION without a full Stop/Start), drop it so it's recreated
   # below on the right network — otherwise runners can't reach it by name and strict's
   # firewall keys off its stale IP. Its cache is on the pool volume, so this is cheap.
-  if docker ps -a --format '{{.Names}}' | grep -qx "$MIRROR_NAME" && ! on_expected_network "$MIRROR_NAME"; then
+  if [ -n "$existing_id" ] && ! on_expected_network "$existing_id"; then
     log "network mode changed -> recreating shared image cache ($MIRROR_NAME)"
-    docker rm -f "$MIRROR_NAME" >/dev/null 2>&1
+    mirror_remove_owned || return 1
+    existing_id=""
   fi
   if ! docker ps --format '{{.Names}}' | grep -qx "$MIRROR_NAME"; then
-    docker rm -f "$MIRROR_NAME" >/dev/null 2>&1
+    if [ -n "$existing_id" ]; then
+      mirror_remove_owned || return 1
+      existing_id=""
+    fi
     local netargs=()
     if [ "$NETWORK_ISOLATION" != "off" ]; then
-      ensure_network
+      ensure_network || return 1
       netargs=( --network "$RUNNER_NETWORK" )
       log "starting shared image cache ($MIRROR_NAME) on $RUNNER_NETWORK"
     else
@@ -772,12 +1137,17 @@ ensure_mirror() {
     # an image-pull failure, etc. were otherwise lost, leaving only a generic message.
     local mout
     if ! mout="$(docker run -d --restart=unless-stopped --name "$MIRROR_NAME" \
+        --label net.unraid.ci-runner-farm.resource=true \
+        --label net.unraid.ci-runner-farm.role=mirror \
         "${netargs[@]}" \
         -v "$CACHE_ROOT/registry-mirror:/var/lib/registry" \
         -e REGISTRY_PROXY_REMOTEURL="https://registry-1.docker.io" \
         registry:2 2>&1)"; then
       err "could not start $MIRROR_NAME: ${mout##*: }"
-      docker rm -f "$MIRROR_NAME" >/dev/null 2>&1   # clear the Created residue so the next cycle retries clean
+      # A failed run can leave a Created residue. The labels above make that
+      # residue safe to clear through the same immutable-ID ownership check.
+      mirror_remove_owned >/dev/null 2>&1 || true
+      return 1
     fi
   fi
 }
@@ -806,8 +1176,9 @@ write_dind_config() {
 # still allowing the internet (GitHub, package registries) and the shared mirror.
 # We drive Docker's DOCKER-USER chain (the supported hook for user rules on
 # forwarded container traffic). Rules are scoped to the runner network's subnet, so
-# nothing else on the box is affected. Best-effort: a missing iptables or chain
-# just means egress isn't restricted (logged), never a failed Start.
+# nothing else on the box is affected. Strict means fail closed: inability to
+# inspect or install any required rule aborts Start/reconcile before a manager is
+# allowed to accept work.
 
 # Remove every rule we previously added (matched by our comment tag), highest line
 # number first so deletes don't renumber out from under us. Covers BOTH chains we
@@ -815,221 +1186,348 @@ write_dind_config() {
 # Idempotent.
 firewall_clear() {
   command -v iptables >/dev/null 2>&1 || return 0
-  local chain n
+  local chain n listing failed=0
   for chain in DOCKER-USER INPUT; do
-    for n in $(iptables -w -L "$chain" --line-numbers -n 2>/dev/null \
+    if ! listing="$(iptables -w -L "$chain" --line-numbers -n 2>/dev/null)"; then
+      err "could not enumerate $chain while removing CI Runner Farm firewall rules"
+      failed=1
+      continue
+    fi
+    for n in $(printf '%s\n' "$listing" \
                | awk -v t="$FW_TAG" 'index($0,t){print $1}' | sort -rn); do
-      iptables -w -D "$chain" "$n" 2>/dev/null || true
+      if ! iptables -w -D "$chain" "$n" 2>/dev/null; then
+        err "could not remove CI Runner Farm firewall rule $chain line $n"
+        failed=1
+      fi
+    done
+  done
+  return "$failed"
+}
+
+# Idempotently add one rule at the head of a chain. `iptables -C` distinguishes
+# an already-present rule from one that needs insertion; a failed insertion is a
+# hard error in strict mode even if a later rule would happen to succeed.
+firewall_ensure_rule() {
+  local chain="$1"; shift
+  if iptables -w -C "$chain" "$@" >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! iptables -w -I "$chain" 1 "$@" >/dev/null 2>&1; then
+    err "strict isolation: could not install required $chain firewall rule"
+    return 1
+  fi
+}
+
+firewall_delete_exact_rule() {
+  local chain="$1"; shift
+  if ! iptables -w -D "$chain" "$@" >/dev/null 2>&1; then
+    err "strict isolation: could not retire temporary $chain fail-closed guard"
+    return 1
+  fi
+}
+
+# Insert an ordered rule while building an authoritative policy from scratch.
+firewall_insert_rule() {
+  local chain="$1" position="$2"; shift 2
+  if ! iptables -w -I "$chain" "$position" "$@" >/dev/null 2>&1; then
+    err "strict isolation: could not install required $chain firewall rule at position $position"
+    return 1
+  fi
+}
+
+# Resolve the two explicitly configured control-plane endpoints that may
+# legitimately live on a private/LAN address. Strict mode otherwise drops every
+# RFC1918/CGNAT destination. Output is "IPv4 port label" and is consumed only as
+# validated iptables arguments; arbitrary URLs never reach the shell command.
+configured_strict_endpoints() {
+  local kind spec hostport host port ip
+  for kind in provider registry; do
+    if [ "$kind" = provider ]; then
+      spec="$(provider_strict_endpoint)"; [ -n "$spec" ] || continue
+      spec="${spec#https://}"; port=443; kind="$CI_PROVIDER"
+    else
+      # GitLab jobs/services may override a built-in default image, so their
+      # explicitly configured registry still needs its narrow LAN exception.
+      # Preserve GitHub's historical remote-default-only registry behavior.
+      [ -n "$REGISTRY_SERVER" ] \
+        && { [ "$CI_PROVIDER" = gitlab ] || [ "$IMAGE_SOURCE" = remote ]; } \
+        || continue
+      spec="$REGISTRY_SERVER"
+      case "$spec" in http://*) port=80 ;; *) port=443 ;; esac
+      spec="${spec#https://}"; spec="${spec#http://}"
+    fi
+    hostport="${spec%%/*}"; host="$hostport"
+    # IPv4/hostname endpoints cover Unraid's iptables-based strict mode. IPv6
+    # destinations are outside this plugin's existing IPv4 firewall contract.
+    case "$hostport" in
+      *:*:*) continue ;;
+      *:*) host="${hostport%:*}"; port="${hostport##*:}" ;;
+    esac
+    printf '%s' "$host" | grep -qE '^[A-Za-z0-9][A-Za-z0-9.-]*$' || continue
+    case "$port" in ''|*[!0-9]*) continue ;; esac
+    [ "$port" -ge 1 ] && [ "$port" -le 65535 ] || continue
+    {
+      getent ahostsv4 "$host" 2>/dev/null | awk '{print $1}'
+      getent hosts "$host" 2>/dev/null | awk '{print $1}'
+    } | grep -E '^[0-9]+(\.[0-9]+){3}$' | sort -u | while read -r ip; do
+      [ -n "$ip" ] && printf '%s %s %s\n' "$ip" "$port" "$kind"
     done
   done
 }
 
-# Install the egress rules for strict mode. Reads the runner network's subnet and
-# the mirror's IP back from docker (no pinned subnet -> no collisions). RETURN =
-# "leave DOCKER-USER, let Docker's normal ACCEPT handle it"; public destinations
-# match none of the DROPs and fall through, so internet egress still works.
-firewall_apply() {
-  [ "$NETWORK_ISOLATION" = "strict" ] || return 0
-  command -v iptables >/dev/null 2>&1 || { err "strict isolation needs iptables — egress NOT restricted"; return 0; }
-  docker network inspect "$RUNNER_NETWORK" >/dev/null 2>&1 || { err "strict isolation: $RUNNER_NETWORK missing — egress NOT restricted"; return 0; }
-  local s gw mip i=1
+# Add the COMPLETE policy for the current runner subnet without deleting tagged
+# rules for an old subnet or endpoint.  This is used while a mixed/stale fleet is
+# draining: a runner still attached to the old network must remain protected and
+# able to reach its old control plane, while its replacement needs the current
+# network, mirror and endpoint policy immediately.  All allows are inserted after
+# the drops below, so they finish above both the new and any pre-existing drops.
+# Exact -C checks make the operation idempotent across repeated Start/reconcile
+# cycles.
+firewall_allow_current_policy() {
+  [ "$NETWORK_ISOLATION" = strict ] || return 0
+  command -v iptables >/dev/null 2>&1 \
+    || { err "strict isolation needs iptables — egress NOT restricted"; return 1; }
+  docker network inspect "$RUNNER_NETWORK" >/dev/null 2>&1 \
+    || { err "strict isolation: $RUNNER_NETWORK missing — egress NOT restricted"; return 1; }
+  local s gw mip epip epport eplabel
   s="$(docker network inspect -f '{{range .IPAM.Config}}{{.Subnet}}{{end}}' "$RUNNER_NETWORK" 2>/dev/null)"
   gw="$(docker network inspect -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' "$RUNNER_NETWORK" 2>/dev/null)"
-  [ -n "$s" ] || { err "strict isolation: could not resolve $RUNNER_NETWORK subnet — egress NOT restricted"; return 0; }
+  [ -n "$s" ] || { err "strict isolation: could not resolve $RUNNER_NETWORK subnet — egress NOT restricted"; return 1; }
   mip="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$MIRROR_NAME" 2>/dev/null)"
-  firewall_clear
+
+  # Install a broad temporary egress guard before touching a live subnet. If any
+  # later insert fails, the guard remains and the operation fails closed (jobs
+  # lose egress instead of gaining LAN/host access). Exact current allows are
+  # inserted at the head and the guard is retired only after the whole policy is
+  # present. INPUT's broad drop is itself the final host-protection rule.
+  firewall_ensure_rule DOCKER-USER -s "$s" -j DROP -m comment --comment "$FW_TAG:install-guard" || return 1
+  firewall_ensure_rule INPUT -s "$s" -j DROP -m comment --comment "$FW_TAG:in-drop" || return 1
+
+  # Specific drops first. Later -I 1 allows are guaranteed to precede them.
+  firewall_ensure_rule DOCKER-USER -s "$s" -d 100.64.0.0/10 -j DROP -m comment --comment "$FW_TAG:cgnat" || return 1
+  firewall_ensure_rule DOCKER-USER -s "$s" -d 192.168.0.0/16 -j DROP -m comment --comment "$FW_TAG:lan192" || return 1
+  firewall_ensure_rule DOCKER-USER -s "$s" -d 172.16.0.0/12 -j DROP -m comment --comment "$FW_TAG:lan172" || return 1
+  firewall_ensure_rule DOCKER-USER -s "$s" -d 10.0.0.0/8 -j DROP -m comment --comment "$FW_TAG:lan10" || return 1
+  if [ -n "$gw" ]; then
+    firewall_ensure_rule DOCKER-USER -s "$s" -d "$gw" -j DROP -m comment --comment "$FW_TAG:host" || return 1
+  fi
+  while read -r epip epport eplabel; do
+    [ -n "$epip" ] || continue
+    firewall_ensure_rule DOCKER-USER -s "$s" -d "$epip" -p tcp --dport "$epport" \
+      -j RETURN -m comment --comment "$FW_TAG:$eplabel" || return 1
+    firewall_ensure_rule INPUT -s "$s" -d "$epip" -p tcp --dport "$epport" \
+      -j RETURN -m comment --comment "$FW_TAG:in-$eplabel" || return 1
+  done <<< "$(configured_strict_endpoints)"
+  firewall_ensure_rule DOCKER-USER -d "$s" -m conntrack --ctstate ESTABLISHED,RELATED \
+    -j RETURN -m comment --comment "$FW_TAG:estab" || return 1
+  if [ -n "$mip" ]; then
+    firewall_ensure_rule DOCKER-USER -s "$s" -d "$mip" -p tcp --dport 5000 \
+      -j RETURN -m comment --comment "$FW_TAG:mirror" || return 1
+  fi
+  firewall_ensure_rule INPUT -s "$s" -m conntrack --ctstate ESTABLISHED,RELATED \
+    -j RETURN -m comment --comment "$FW_TAG:in-estab" || return 1
+  firewall_delete_exact_rule DOCKER-USER -s "$s" -j DROP -m comment --comment "$FW_TAG:install-guard"
+}
+
+# Replacements avoid a fleet-wide clear/reapply gap. If no tagged policy exists,
+# firewall_apply decides whether an authoritative empty-fleet build is safe or a
+# fail-closed additive live-fleet install is required. Otherwise add the complete
+# current policy alongside old rules still protecting stale managers.
+firewall_prepare_replacement() {
+  [ "$NETWORK_ISOLATION" = strict ] || return 0
+  command -v iptables >/dev/null 2>&1 \
+    || { err "strict isolation needs iptables — egress NOT restricted"; return 1; }
+  local rules
+  if ! rules="$(iptables -w -L DOCKER-USER -n 2>/dev/null)"; then
+    err "strict isolation: could not inspect DOCKER-USER before replacement"
+    return 1
+  fi
+  if ! printf '%s' "$rules" | grep -qF "$FW_TAG"; then
+    log "strict isolation: installing initial firewall policy"
+    firewall_apply
+  else
+    firewall_allow_current_policy
+  fi
+}
+
+# Apply firewall state without ever clearing rules underneath a managed runner.
+# A live fleet receives only the additive fail-closed policy above; obsolete
+# tagged rules are intentionally retained until Stop leaves the fleet empty.
+# With no managed runner, an authoritative clear/rebuild is safe (and removes old
+# strict rules when the selected mode is now off/isolate).
+firewall_apply() {
+  local live
+  live="$(managed_names)" \
+    || { err "could not verify the managed fleet before applying firewall state"; return 1; }
+  if [ -n "$live" ]; then
+    if [ "$NETWORK_ISOLATION" = strict ]; then
+      firewall_allow_current_policy
+    else
+      log "preserving tagged strict firewall rules until the remaining managed fleet is stopped"
+    fi
+    return
+  fi
+
+  firewall_clear || return 1
+  [ "$NETWORK_ISOLATION" = "strict" ] || return 0
+  command -v iptables >/dev/null 2>&1 || { err "strict isolation needs iptables — egress NOT restricted"; return 1; }
+  docker network inspect "$RUNNER_NETWORK" >/dev/null 2>&1 || { err "strict isolation: $RUNNER_NETWORK missing — egress NOT restricted"; return 1; }
+  local s gw mip i=1 epip epport eplabel ini=2
+  s="$(docker network inspect -f '{{range .IPAM.Config}}{{.Subnet}}{{end}}' "$RUNNER_NETWORK" 2>/dev/null)"
+  gw="$(docker network inspect -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' "$RUNNER_NETWORK" 2>/dev/null)"
+  [ -n "$s" ] || { err "strict isolation: could not resolve $RUNNER_NETWORK subnet — egress NOT restricted"; return 1; }
+  mip="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$MIRROR_NAME" 2>/dev/null)"
   # Order matters (top-down): allow mirror + established replies, THEN drop host +
   # every private range. Inserting at increasing indices keeps them in this order
   # ahead of Docker's trailing RETURN.
-  [ -n "$mip" ] && { iptables -w -I DOCKER-USER "$i" -s "$s" -d "$mip" -p tcp --dport 5000 -j RETURN -m comment --comment "$FW_TAG:mirror"; i=$((i+1)); }
-  iptables -w -I DOCKER-USER "$i" -d "$s" -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN -m comment --comment "$FW_TAG:estab"; i=$((i+1))
-  [ -n "$gw" ] && { iptables -w -I DOCKER-USER "$i" -s "$s" -d "$gw" -j DROP -m comment --comment "$FW_TAG:host"; i=$((i+1)); }
-  iptables -w -I DOCKER-USER "$i" -s "$s" -d 10.0.0.0/8     -j DROP -m comment --comment "$FW_TAG:lan10";  i=$((i+1))
-  iptables -w -I DOCKER-USER "$i" -s "$s" -d 172.16.0.0/12  -j DROP -m comment --comment "$FW_TAG:lan172"; i=$((i+1))
-  iptables -w -I DOCKER-USER "$i" -s "$s" -d 192.168.0.0/16 -j DROP -m comment --comment "$FW_TAG:lan192"; i=$((i+1))
-  iptables -w -I DOCKER-USER "$i" -s "$s" -d 100.64.0.0/10  -j DROP -m comment --comment "$FW_TAG:cgnat"; i=$((i+1))
+  if [ -n "$mip" ]; then
+    firewall_insert_rule DOCKER-USER "$i" -s "$s" -d "$mip" -p tcp --dport 5000 -j RETURN -m comment --comment "$FW_TAG:mirror" || return 1
+    i=$((i+1))
+  fi
+  firewall_insert_rule DOCKER-USER "$i" -d "$s" -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN -m comment --comment "$FW_TAG:estab" || return 1
+  i=$((i+1))
+  # Narrow exceptions for an explicitly configured self-managed GitLab and/or
+  # private job-image registry. These precede the LAN drops and match only the
+  # resolved IPv4 plus the endpoint's configured TCP port.
+  while read -r epip epport eplabel; do
+    [ -n "$epip" ] || continue
+    firewall_insert_rule DOCKER-USER "$i" -s "$s" -d "$epip" -p tcp --dport "$epport" -j RETURN -m comment --comment "$FW_TAG:$eplabel" || return 1
+    i=$((i+1))
+  done <<< "$(configured_strict_endpoints)"
+  if [ -n "$gw" ]; then
+    firewall_insert_rule DOCKER-USER "$i" -s "$s" -d "$gw" -j DROP -m comment --comment "$FW_TAG:host" || return 1
+    i=$((i+1))
+  fi
+  firewall_insert_rule DOCKER-USER "$i" -s "$s" -d 10.0.0.0/8 -j DROP -m comment --comment "$FW_TAG:lan10" || return 1; i=$((i+1))
+  firewall_insert_rule DOCKER-USER "$i" -s "$s" -d 172.16.0.0/12 -j DROP -m comment --comment "$FW_TAG:lan172" || return 1; i=$((i+1))
+  firewall_insert_rule DOCKER-USER "$i" -s "$s" -d 192.168.0.0/16 -j DROP -m comment --comment "$FW_TAG:lan192" || return 1; i=$((i+1))
+  firewall_insert_rule DOCKER-USER "$i" -s "$s" -d 100.64.0.0/10 -j DROP -m comment --comment "$FW_TAG:cgnat" || return 1; i=$((i+1))
   # DOCKER-USER is in the FORWARD path only. A runner reaching the Unraid host's OWN
   # ip (e.g. the webGUI on the LAN address, or the host's tailscale ip) is delivered
   # locally via INPUT and never forwarded, so the rules above miss it — that leaves
   # the management UI reachable. Drop new traffic from the runner subnet to the host
   # here too; the runner needs nothing that originates host-side (the mirror is a
   # container = forwarded, DNS is Docker's embedded resolver inside the netns).
-  iptables -w -I INPUT 1 -s "$s" -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN -m comment --comment "$FW_TAG:in-estab"
-  iptables -w -I INPUT 2 -s "$s" -j DROP -m comment --comment "$FW_TAG:in-drop"
-  log "strict isolation: egress locked to internet+mirror for $s (Unraid host + LAN blocked)"
+  firewall_insert_rule INPUT 1 -s "$s" -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN -m comment --comment "$FW_TAG:in-estab" || return 1
+  while read -r epip epport eplabel; do
+    [ -n "$epip" ] || continue
+    firewall_insert_rule INPUT "$ini" -s "$s" -d "$epip" -p tcp --dport "$epport" -j RETURN -m comment --comment "$FW_TAG:in-$eplabel" || return 1
+    ini=$((ini+1))
+  done <<< "$(configured_strict_endpoints)"
+  firewall_insert_rule INPUT "$ini" -s "$s" -j DROP -m comment --comment "$FW_TAG:in-drop" || return 1
+  log "strict isolation: egress locked to internet+mirror+configured CI endpoints for $s (other host/LAN access blocked)"
 }
 
-# resolve the image to run: the locally-built image (builtin) or a remote ref.
-# Falls back to the built-in image if remote is selected but no IMAGE is set.
+# Resolve the provider's executable/default-job image: the locally built tag or
+# a remote ref. GitLab's manager image is deliberately separate.
 effective_image() {
-  if [ "$IMAGE_SOURCE" = "remote" ] && [ -n "$IMAGE" ]; then echo "$IMAGE"; else echo "$BUILTIN_IMAGE"; fi
+  if [ "$IMAGE_SOURCE" = "remote" ] && [ -n "$IMAGE" ]; then echo "$IMAGE"; else builtin_image; fi
 }
 
-# build the docker run argv for one runner. $1=index, $2=name-override(optional)
-build_args() {
-  local idx="$1"; local name="${2:-${NAME_PREFIX}-${idx}}"
-  ARGS=(
-    # --restart=no (NOT unless-stopped): the registration token baked in below is
-    # short-lived (~1h) and the runner re-runs config on start, so letting Docker
-    # auto-restart a crashed/exited runner makes it re-register with an expired
-    # token — GitHub returns 404 ("Not configured") and the container crash-loops.
-    # The plugin is the sole supervisor: start_stopped_managed (boot) and
-    # reap_dead_runners (autoscale) recreate a dead runner with a freshly minted
-    # token instead of resurrecting it with the stale one.
-    -d --restart=no
-    --name "$name" --hostname "$name"
-    --pids-limit=4096
-    --label "${MANAGED_LABEL%=*}=true"
-    --label "net.unraid.ci-runner-farm.index=${idx}"
-    --label "net.unraid.ci-runner-farm.confgen=$(crf_confgen)"
-    -e RUNNER_NAME="$(host)-${name}"
-    -e LABELS="$RUNNER_LABELS"
-    -e DISABLE_AUTO_UPDATE="true"
-    -e DISABLE_AUTOMATIC_DEREGISTRATION="true"   # we deregister host-side (deregister_runner_api)
-    -e RUN_AS_ROOT="$RUN_AS_ROOT"
-    -e RUNNER_ALLOW_RUNASROOT="1"
-    -e RUNNER_WORKDIR="/_work"
-    -e npm_config_cache="/home/runner/.npm"
-  )
-  # myoung34 entrypoints enable ephemeral mode when the EPHEMERAL env var is
-  # PRESENT (any value, including "false") — so only pass it when it is true,
-  # otherwise EPHEMERAL="false" silently produces one-job-then-exit runners.
-  [ "$EPHEMERAL" = "true" ] && ARGS+=( -e EPHEMERAL="true" )
-  # warm caches mounted into the runner, configurable via CACHE_MOUNTS
-  local m
-  for m in $CACHE_MOUNTS; do
-    [ -n "$m" ] || continue
-    local hostdir; hostdir="$(crf_safe_mount_subdir "${m%%:*}")" || { err "skipping unsafe cache mount '${m%%:*}'"; continue; }
-    ARGS+=( -v "$hostdir:${m#*:}" )
-  done
-  [ -n "$RUNNER_CPUS" ]   && ARGS+=( --cpus="$RUNNER_CPUS" )
-  [ -n "$RUNNER_MEMORY" ] && ARGS+=( --memory="$RUNNER_MEMORY" )
-  # network isolation: put the runner on the dedicated bridge (off = default bridge)
-  [ "$NETWORK_ISOLATION" != "off" ] && ARGS+=( --network "$RUNNER_NETWORK" )
-  if [ "$DIND" = "true" ]; then
-    # each runner runs its own dockerd: isolates service-container ports and
-    # makes localhost:<port> reachable from job steps (the runner IS the host).
-    ARGS+=( --privileged -e START_DOCKER_SERVICE=true )
-    # Give the inner dockerd a real-filesystem data root. Without this it writes
-    # /var/lib/docker onto the runner's overlay rootfs, so overlay2 (and buildx's
-    # BuildKit) stack overlay-on-overlay and fail with "mount overlay ...
-    # invalid argument". CACHE_ROOT must be a pool, not FUSE (check_cache_root).
-    mkdir -p "$CACHE_ROOT/docker/$name"
-    ARGS+=( -v "$CACHE_ROOT/docker/$name:/var/lib/docker" )
-    # inner daemon.json: storage-driver + optional pull-through mirror
-    ARGS+=( -v "$CACHE_ROOT/dind-daemon.json:/etc/docker/daemon.json:ro" )
-    # Persisted DinD diagnostics dir (kept by remove_runner, unlike the data root):
-    # the runner image's wait-docker.sh snapshots inner-daemon state (storage driver,
-    # Native Overlay Diff, backing fs, userxattr, uid_map) here and mirrors the inner
-    # dockerd log, so a layer-extraction failure (e.g. the whiteout "operation not
-    # permitted" mknod seen on ZFS-backed overlay2 under the services: workload) leaves
-    # a post-mortem trail off the ephemeral container. Inspect $CACHE_ROOT/dind-logs/<runner>.
-    mkdir -p "$CACHE_ROOT/dind-logs/$name"
-    ARGS+=( -v "$CACHE_ROOT/dind-logs/$name:/var/log/dind" )
-    # Legacy mirror path: reach the host-published mirror via host.docker.internal.
-    # Under isolation the mirror is on the dedicated bridge and reached by name, so
-    # host-gateway isn't needed (and is blocked in strict) — skip it.
-    [ "$SHARED_IMAGE_CACHE" = "true" ] && [ "$NETWORK_ISOLATION" = "off" ] && ARGS+=( --add-host "host.docker.internal:host-gateway" )
-  elif [ "$SHARE_DOCKER_SOCK" = "true" ]; then
-    ARGS+=( -v /var/run/docker.sock:/var/run/docker.sock )
-  fi
-  if [ -n "$WORK_TMPFS_SIZE" ]; then
-    ARGS+=( --tmpfs "/_work:rw,exec,size=${WORK_TMPFS_SIZE}" )
+# Verify a recycle replacement without pulling a GitLab DinD job image through
+# the wrong daemon. Remote images belong to the provider-selected daemon;
+# locally built images must already exist in the host store.
+recycle_image_preflight() {
+  local image="$1"
+  if [ "$IMAGE_SOURCE" = remote ]; then
+    provider_prepare_remote_image "$image" >/dev/null 2>&1
   else
-    mkdir -p "$CACHE_ROOT/work/$name"
-    ARGS+=( -v "$CACHE_ROOT/work/$name:/_work" )
+    docker image inspect "$image" >/dev/null 2>&1
   fi
-  local scope_target=""
-  if [ "$GH_SCOPE" = "org" ]; then
-    ARGS+=( -e RUNNER_SCOPE="org" -e ORG_NAME="$GH_OWNER" )
-    [ -n "$RUNNER_GROUP" ] && ARGS+=( -e RUNNER_GROUP="$RUNNER_GROUP" )
-    scope_target="org:$GH_OWNER"
-  else
-    local repo; repo="$(repo_for_index "$idx")"
-    ARGS+=( -e RUNNER_SCOPE="repo" -e REPO_URL="https://github.com/${repo}" )
-    scope_target="repo:$repo"
-  fi
-  # Hand the container a short-lived registration token, never the PAT (see the
-  # host-side token helpers above). Skipped when no PAT is configured — e.g. the
-  # 'validate' path, which swaps the entrypoint for a sleep and never registers.
-  if [ -n "$ACCESS_TOKEN" ] && [ "${NO_REGISTER:-0}" != "1" ]; then
-    local reg; reg="$(registration_token "$scope_target")"
-    [ -z "$reg" ] && { err "could not mint a runner registration token for ${scope_target#*:} (check the PAT's scope/permissions)"; return 1; }
-    ARGS+=( -e RUNNER_TOKEN="$reg" )
-  fi
-  ARGS+=( "$(effective_image)" )
 }
+
+# Provider adapters own the complete docker argv contract.
+build_args() { provider_call build_args "$@"; }
 
 start_one() {
-  local idx="$1"; local name="${NAME_PREFIX}-${idx}"
-  if docker ps -a --format '{{.Names}}' | grep -qx "$name"; then
-    log "runner $name already exists; skipping"; return 0
+  local idx="$1" name="${NAME_PREFIX}-$1" snapshot
+  if docker inspect "$name" >/dev/null 2>&1; then
+    snapshot="$(managed_runner_snapshot "$name")" \
+      || { err "refusing fixed-name collision while starting $name"; return 1; }
+    log "owned runner $name already exists; skipping"
+    return 0
   fi
-  build_args "$idx" || { err "runner $name not started (registration-token error)"; return 1; }
-  log "starting $name (cpus=$RUNNER_CPUS mem=$RUNNER_MEMORY scope=$GH_SCOPE)"
-  docker run "${ARGS[@]}" >/dev/null
+  provider_call start_one "$idx" "$name"
 }
 
-# Recreate a stopped managed runner with a FRESH registration token. We cannot
-# `docker start` it in place: the baked-in RUNNER_TOKEN is short-lived (~1h) and
-# the runner re-runs config on start, so a stale token yields a GitHub 404
-# ("Not configured") and a crash loop. Only the container is removed — the warm
-# caches and the DinD data root are bind mounts on the pool (see build_args), so
-# they survive under the same name and the replacement starts warm. The stale
-# GitHub registration is dropped host-side first (the PAT never touches the
-# container) so the fresh runner re-registers cleanly.
+# Recreate a stopped managed runner when its provider/config requires it. GitHub
+# needs a fresh short-lived registration token; a stale/provider-switched GitLab
+# manager must unregister its old persisted identity before replacement.
 recreate_stopped_runner() {
-  local c="$1" idx
-  idx="$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.index" }}' "$c" 2>/dev/null)"
-  [ -z "$idx" ] && idx="${c##*-}"
-  deregister_runner_api "$c"
-  docker rm -f "$c" >/dev/null 2>&1
+  local c="$1" supplied_snapshot="${2:-}" snapshot id provider role idx gen
+  snapshot="$supplied_snapshot"
+  [ -n "$snapshot" ] || snapshot="$(managed_runner_snapshot "$c")" || return 1
+  IFS='|' read -r id provider role idx gen <<< "$snapshot"
+  remove_runner "$c" false "$id" "$provider" || return 1
   start_one "$idx"
 }
 
-# Bring back managed runner containers that exist but are stopped — e.g. after
-# Unraid stopped Docker for an array stop, which leaves them "exited", reconciled
-# by the docker_started event hook. Each is recreated with a fresh registration
-# token (see recreate_stopped_runner) rather than started in place, because the
-# original token has almost certainly expired by the time Docker comes back.
+# Bring back managed containers after an array/Docker restart. GitHub slots are
+# recreated with fresh registration tokens. An unchanged GitLab manager instead
+# starts in place with its persisted config/system ID; unregistering it during a
+# routine outage would create needless remote churn and make recovery depend on
+# GitLab availability.
 start_stopped_managed() {
-  local c st
-  for c in $(managed_names); do
+  local c st provider idx names snapshot id role gen
+  names="$(managed_names)" || return 1
+  for c in $names; do
     [ -n "$c" ] || continue
-    st="$(docker inspect -f '{{.State.Running}}' "$c" 2>/dev/null)"
+    snapshot="$(managed_runner_snapshot "$c")" || return 1
+    IFS='|' read -r id provider role idx gen <<< "$snapshot"
+    st="$(docker inspect -f '{{.State.Running}}' "$id" 2>/dev/null)" \
+      || { err "could not inspect stopped/running state for owned runner $c"; return 1; }
     [ "$st" = "true" ] && continue
-    log "recreating stopped runner $c with a fresh registration token"
-    recreate_stopped_runner "$c"
+    if [ "$provider" = gitlab ] && [ "$CI_PROVIDER" = gitlab ] \
+      && [ "$gen" = "$(crf_confgen)" ]; then
+      log "restarting stopped GitLab manager $c with its persisted system ID"
+      gitlab_start_stopped "$c" "$idx" "$id" || return 1
+    else
+      log "recreating stopped runner $c with current provider credentials"
+      recreate_stopped_runner "$c" "$snapshot" || return 1
+    fi
   done
 }
 
 # Cache/network provisioning shared by cmd_start and the Fleet recycle path before
 # they run start_one: validate the cache root (hard guard — aborts on FUSE for
 # DIND, etc.), create the cache dirs / isolated network / image-cache mirror, and
-# log in to a remote registry. Returns non-zero (problem already logged) when the
+# prepare remote-registry access in the daemon that owns job containers. GitHub
+# and GitLab host-socket mode login/pull on the host here; GitLab DinD defers to
+# the per-slot auth, CA trust, and pull in gitlab_ensure_job_image. Returns
+# non-zero (problem already logged) when the
 # cache-root guard OR a real registry login fails, so callers can bail before
 # provisioning (registry_login is a no-op returning 0 for the built-in image or
 # when no remote registry/creds are set, so it only bites an actually-failed remote
 # auth). Firewall handling is deliberately NOT here: the strict-mode egress rules
 # are keyed on the runner subnet, not per container, so a replacement rejoining
-# that subnet is already covered by the fleet's existing rules. cmd_start
-# (re)programs them via provision_preflight; recycle must NOT clear+reapply them
-# mid-recycle, which would briefly drop egress protection for every strict runner.
+# that subnet is already covered by the fleet's existing rules. cmd_start uses
+# authoritative preflight for a fresh/non-strict fleet and additive preparation
+# for an existing strict fleet; recycle must NOT clear+reapply rules mid-drain,
+# which would briefly drop egress protection for every strict runner.
 # (cmd_scale runs its own lighter inline subset and is intentionally not a caller.)
 provision_base() {
   check_cache_root || return 1
-  ensure_dirs
-  ensure_network
-  ensure_mirror
-  registry_login || return 1
+  ensure_dirs || return 1
+  ensure_network || return 1
+  ensure_mirror || return 1
+  if provider_remote_image_host_pull_required; then
+    if [ "$IMAGE_SOURCE" = remote ] && [ -n "$IMAGE" ]; then
+      provider_prepare_remote_image "$(effective_image)" >/dev/null \
+        || { err "could not prepare configured job/runner image $(effective_image) under the selected pull policy"; return 1; }
+    fi
+  else
+    # A stale host-side login must not survive a switch to GitLab DinD. The
+    # adapter writes per-slot auth and the nested daemon performs the pull.
+    rm -f "$HOST_DOCKER_CONFIG/config.json" 2>/dev/null || true
+  fi
 }
 
-# Full Start preflight: the shared base provisioning, then (re)program the strict
-# egress firewall (firewall_apply is a no-op unless NETWORK_ISOLATION=strict).
+# Full Start preflight: shared provisioning followed by safe firewall transition.
+# firewall_apply clears authoritatively only for an empty fleet; otherwise it is
+# additive (strict) or preserves old tagged protection until Stop (off/isolate).
 provision_preflight() {
   provision_base || return 1
-  firewall_clear                                # drop stale rules (e.g. strict -> off/isolate)
-  firewall_apply                                # re-add egress rules (no-op unless strict)
+  firewall_apply
 }
 
 # Serialize all fleet mutation (UI start/stop/restart/scale/recycle AND the autoscale
@@ -1042,12 +1540,12 @@ provision_preflight() {
 with_fleet_lock() {
   local mode="$1"; shift
   if [ "$mode" = try ]; then
-    ( flock -n 8 || exit 0; "$@" ) 8>"$RUNDIR/fleet.lock"
+    ( flock -n 8 || exit 0; reload_locked_snapshot || exit 1; "$@" ) 8>"$RUNDIR/fleet.lock"
   else
-    ( flock -w 20 8 || { err "fleet busy (another start/stop/scale/recycle or a daemon tick is running) — try again"; exit 1; }; "$@" ) 8>"$RUNDIR/fleet.lock"
+    ( flock -w 20 8 || { err "fleet busy (another start/stop/scale/recycle or a daemon tick is running) — try again"; exit 1; }; reload_locked_snapshot || exit 1; "$@" ) 8>"$RUNDIR/fleet.lock"
   fi
 }
-cmd_restart() { cmd_stop; cmd_start; }
+cmd_restart() { cmd_stop || return 1; reload_locked_snapshot || return 1; cmd_start; }
 
 # Operator convenience: (re)start the shared image cache + regenerate the runner DinD
 # config to match — WITHOUT a full fleet Start/Restart (useful after changing
@@ -1055,8 +1553,8 @@ cmd_restart() { cmd_stop; cmd_start; }
 # separate container so this doesn't disrupt runners; already-running runners pick up
 # the new mirror endpoint only when they are next recreated.
 cmd_mirror_up() {
-  ensure_mirror
-  write_dind_config
+  ensure_mirror || return 1
+  write_dind_config || return 1
   if docker ps --format '{{.Names}}' | grep -qx "$MIRROR_NAME"; then
     log "shared image cache ($MIRROR_NAME) is up"
   elif [ "$SHARED_IMAGE_CACHE" = "true" ] && [ "$DIND" = "true" ]; then
@@ -1065,18 +1563,25 @@ cmd_mirror_up() {
 }
 
 # ── Drain-aware config reconciliation ────────────────────────────────────────
-# Recycle AT MOST ONE running runner that predates the current baked config onto the new
+# Recycle AT MOST ONE managed runner that predates the current baked config onto the new
 # one, while it is IDLE or in an ERROR state — a busy runner keeps its in-flight job and is
 # caught on a later pass once it finishes, so a settings change never kills a job. One-per-pass so
 # the fleet migrates gradually and never drops all its capacity at once. Lock-free: the
 # CALLER must hold the fleet lock (cmd_recycle, which this calls, assumes the dispatch or
-# caller already locked). Returns 0 always; callers poll count_stale_runners to know when
-# the fleet is fully migrated.
+# caller already locked). A failed recycle returns non-zero so a drain stops at
+# the first unsafe slot rather than walking through and quiescing the whole fleet.
 reconcile_stale_runners() {
-  local cur c gen; cur="$(crf_confgen)"
-  for c in $(docker ps --filter "label=${MANAGED_LABEL}" --format '{{.Names}}' | sort -V); do
+  # Re-read settings and secret files only after the caller holds fleet.lock.
+  # Otherwise a drain waiting for the lock can recreate per-slot files from a
+  # token that was cleared/rotated while it waited.
+  reload_locked_snapshot || return 1
+  local cur c gen names snapshot id provider role index
+  cur="$(crf_confgen)" || return 1
+  names="$(managed_names)" || return 1
+  for c in $names; do
     [ -n "$c" ] || continue
-    gen="$(runner_confgen "$c")"
+    snapshot="$(managed_runner_snapshot "$c")" || return 1
+    IFS='|' read -r id provider role index gen <<< "$snapshot"
     [ "$gen" = "$cur" ] && continue                  # already on the current config
     # Migrate idle runners; also migrate error-state ones (a wedged runner will never
     # reach idle on its own, so leaving it would strand it on the old config forever).
@@ -1093,6 +1598,7 @@ reconcile_stale_runners() {
         log "reconcile: $c was removed but its replacement failed to start — fleet is down one runner"
         echo "$c" >> "$RUNDIR/reconcile.shrink"
       fi
+      return 1
     fi
     return 0                                          # one per pass; the drain/tick loop re-invokes
   done
@@ -1110,31 +1616,55 @@ cmd_reconcile_drain() {
   # fd 8) so our own `with_fleet_lock wait` below isn't self-blocked. Keep fd 7 — the
   # dispatch wrapper holds it as this drain's own reconcile.lock. See autoscale_daemon.
   exec 8>&- 9>&- 2>/dev/null || true
-  local deadline announced=0 lost
+  trap 'rm -f "$RECONCILE_PID" 2>/dev/null || true' EXIT
+  trap 'rm -f "$RECONCILE_PID" 2>/dev/null || true; exit 0' HUP INT TERM
+  local deadline announced=0 lost paused=0 stale=-1
   rm -f "$RUNDIR/reconcile.shrink"                  # fresh tally of runners lost this drain (see reconcile_stale_runners)
   deadline=$(( $(date +%s) + ${IMAGE_DRAIN_TIMEOUT:-3600} ))
   while :; do
     load_cfg
-    [ -z "$ACCESS_TOKEN" ] && [ -f "$TOKEN_FILE" ] && ACCESS_TOKEN="$(cat "$TOKEN_FILE" 2>/dev/null)"
-    [ "$(count_stale_runners)" -eq 0 ] && break
+    [ "$CI_PROVIDER" = gitlab ] || CI_PROVIDER=github
+    reload_secret_files
+    if ! stale="$(count_stale_runners)"; then
+      paused=1
+      log "reconcile: could not enumerate/inspect the managed fleet; migration stopped fail-closed"
+      break
+    fi
+    [ "$stale" -eq 0 ] && break
     [ "$announced" = 0 ] && { log "reconcile: config changed — migrating runners onto it as they go idle"; announced=1; }
-    with_fleet_lock wait reconcile_stale_runners
-    [ "$(count_stale_runners)" -eq 0 ] && break
+    if ! with_fleet_lock wait reconcile_stale_runners; then
+      paused=1
+      log "reconcile: migration paused after a slot failed; no additional runners will be drained until a later retry"
+      break
+    fi
+    if ! stale="$(count_stale_runners)"; then
+      paused=1
+      log "reconcile: could not verify remaining stale runners; migration stopped fail-closed"
+      break
+    fi
+    [ "$stale" -eq 0 ] && break
     # IMAGE_DRAIN_TIMEOUT=0 means "wait forever" (per the settings help), so only enforce
     # the deadline when it's positive — matching drain_and_recreate's `limit -gt 0` guard.
-    [ "${IMAGE_DRAIN_TIMEOUT:-3600}" -gt 0 ] && [ "$(date +%s)" -ge "$deadline" ] && { log "reconcile: $(count_stale_runners) runner(s) still on the old config after the drain timeout (finishing jobs or wedged in startup) — they'll migrate on their next idle, or Restart the fleet to force it now"; break; }
+    [ "${IMAGE_DRAIN_TIMEOUT:-3600}" -gt 0 ] && [ "$(date +%s)" -ge "$deadline" ] && { log "reconcile: $stale runner(s) still on the old config after the drain timeout (finishing jobs or wedged in startup) — they'll migrate on their next idle, or Restart the fleet to force it now"; break; }
     sleep 15
   done
   lost="$([ -f "$RUNDIR/reconcile.shrink" ] && grep -c . "$RUNDIR/reconcile.shrink" 2>/dev/null || echo 0)"
+  stale="$(count_stale_runners)" || stale=-1
   if [ "$announced" = 1 ]; then
     if [ "${lost:-0}" -gt 0 ]; then
-      if [ "$(count_stale_runners)" -eq 0 ]; then
+      if [ "$stale" -eq 0 ]; then
         log "reconcile: migration finished but $lost runner(s) were removed without a replacement — Start/Restart the fleet to restore capacity"
       else
         log "reconcile: migration incomplete, and $lost runner(s) were also removed without a replacement — Start/Restart the fleet to restore capacity"
       fi
-    elif [ "$(count_stale_runners)" -eq 0 ]; then
+    elif [ "$stale" -eq 0 ]; then
       log "reconcile: fleet is now on the current config"
+    elif [ "$paused" = 1 ]; then
+      if [ "$stale" -ge 0 ]; then
+        log "reconcile: $stale stale runner(s) remain after the fail-closed pause; fix the logged lifecycle error and Apply again"
+      else
+        log "reconcile: remaining stale runners could not be verified after the fail-closed pause; fix Docker/ownership inspection and Apply again"
+      fi
     fi
   fi
   rm -f "$RUNDIR/reconcile.shrink"
@@ -1144,7 +1674,19 @@ cmd_reconcile_drain() {
 # slow). Safe no-op when nothing is stale (the drain exits on the first count). Output
 # shows in the Apply progress frame — human text, not JSON.
 cmd_reconcile_config() {
-  nohup "$0" reconcile-drain >>"$RUNDIR/autoscale.log" 2>&1 &
+  local managed
+  managed="$(managed_names)" \
+    || { err "cannot reconcile: could not enumerate the managed fleet"; return 1; }
+  # Saving an empty farm must remain possible before credentials are entered.
+  # Once a manager exists, however, Apply can launch a provider-switch drain;
+  # require the destination credential before that worker is allowed to start.
+  if [ -n "$managed" ]; then
+    provider_token_ready \
+      || { err "cannot reconcile an existing fleet without a valid $(provider_token_name)"; return 1; }
+  fi
+  provider_validate_settings \
+    || { err "cannot reconcile: invalid $CI_PROVIDER provider settings"; return 1; }
+  reconcile_start || { err "could not start configuration reconcile worker"; return 1; }
   local msg="Configuration saved. Any runner on a previous config will migrate as it goes idle (busy jobs finish first)."
   # A NETWORK_ISOLATION change applies per-runner only as each recycles — so running
   # jobs keep their OLD network until they finish. Say so plainly: a gradual, background
@@ -1153,12 +1695,40 @@ cmd_reconcile_config() {
   echo "$msg"
 }
 
+reconcile_start() {
+  reconcile_stop || return 1
+  nohup "$0" reconcile-drain >>"$RUNDIR/autoscale.log" 2>&1 &
+  ( umask 077; printf '%s\n' "$!" > "$RECONCILE_PID" ) \
+    || { err "could not publish reconcile worker PID"; return 1; }
+}
+
+reconcile_stop() {
+  stop_worker_group "reconcile" "$RECONCILE_PID" '[r]unner-farm.sh reconcile-drain'
+}
+
 cmd_start() {
-  [ -z "$ACCESS_TOKEN" ] && { err "no GitHub token configured (set it in the web UI). Use 'validate' to test provisioning without one."; return 1; }
+  local start_failed=0
+  provider_token_ready || { err "no valid $(provider_token_name) configured (set it in the web UI). Use 'validate' to test provisioning without one."; return 1; }
+  [ "$CI_PROVIDER" = "gitlab" ] && gitlab_validate_settings || { [ "$CI_PROVIDER" != "gitlab" ] || return 1; }
   rm -f "$SECURITY_CACHE"                       # force a fresh public-repo check on an explicit Start
   local secp; secp="$(public_repo_problem)"
   [ -n "$secp" ] && err "SECURITY: $secp"       # warn, do not block (operator's call)
-  provision_preflight || return 1               # cache-root guard + dirs/network/mirror/firewall/registry
+  gitlab_assert_no_orphan_manager_configs || return 1
+  # An existing strict fleet may contain busy runners on the previous network or
+  # endpoint configuration.  Provision the new base resources, then add its full
+  # policy alongside the old one until reconcile drains every stale slot.  Empty
+  # fleets and non-strict modes retain the authoritative preflight (including the
+  # strict -> off/isolate cleanup of old tagged rules).
+  local existing_managed
+  existing_managed="$(managed_names)" \
+    || { err "could not enumerate the existing managed fleet"; return 1; }
+  if [ "$NETWORK_ISOLATION" = strict ] && [ -n "$existing_managed" ]; then
+    provision_base || return 1
+    firewall_prepare_replacement || return 1
+  else
+    provision_preflight || return 1
+  fi
+  gitlab_cleanup_orphan_sidecars || { err "could not safely clean orphaned GitLab sidecars"; return 1; }
   # If NETWORK_ISOLATION changed while the fleet was up, existing runners are still
   # on the old network — they must be recreated so the new mode actually applies (a
   # half-isolated fleet is a false sense of security). Do this in the BACKGROUND: a
@@ -1168,34 +1738,166 @@ cmd_start() {
   # this synchronous Start request under the fleet lock for up to IMAGE_DRAIN_TIMEOUT
   # (hours) while a busy runner finishes. Runners already on the right network match
   # and are left untouched, so a normal Start migrates nothing.
-  local c need_migrate=0
-  for c in $(managed_names); do
-    [ -n "$c" ] && ! on_expected_network "$c" && { need_migrate=1; break; }
+  local c need_migrate=0 snapshot
+  existing_managed="$(managed_names)" || return 1
+  for c in $existing_managed; do
+    [ -n "$c" ] || continue
+    snapshot="$(managed_runner_snapshot "$c")" || return 1
+    ! on_expected_network "$c" && { need_migrate=1; break; }
   done
-  [ "$need_migrate" = 1 ] && { log "network mode changed -> migrating runners onto the new network in the background as they go idle"; nohup "$0" reconcile-drain >>"$RUNDIR/autoscale.log" 2>&1 & }
+  [ "$need_migrate" = 1 ] && {
+    log "network mode changed -> migrating runners onto the new network in the background as they go idle"
+    reconcile_start || start_failed=1
+  }
   # bring back any runners Unraid/Docker left exited (array stop, daemon restart)
-  start_stopped_managed
+  start_stopped_managed || start_failed=1
+  # Only after stopped slots have been restored should genuinely dead/unhealthy
+  # running slots be reaped. This preserves every preexisting autoscale slot
+  # across a Docker/array restart instead of collapsing straight to MIN.
+  reap_dead_runners || start_failed=1
   # with autoscaling on, start the floor (MIN) and let the daemon grow to demand
   local startn="$RUNNER_COUNT"
   [ "$AUTOSCALE" = "true" ] && startn="$AUTOSCALE_MIN"
   local i
-  for i in $(seq 1 "$startn"); do start_one "$i"; done
-  log "fleet up: $(managed_names | wc -l) runner(s)"
-  [ "$AUTOSCALE" = "true" ] && autoscale_start
-  [ "$IMAGE_AUTOUPDATE" = "true" ] && imageupdate_start
+  for i in $(seq 1 "$startn"); do start_one "$i" || start_failed=1; done
+  local final_count
+  final_count="$(current_count)" || start_failed=1
+  log "fleet up: ${final_count:-unknown} runner(s)"
+  if [ "$AUTOSCALE" = "true" ]; then autoscale_start || start_failed=1; fi
+  if [ "$IMAGE_AUTOUPDATE" = "true" ]; then imageupdate_start || start_failed=1; fi
+  if [ "$start_failed" -ne 0 ]; then
+    err "fleet start completed with one or more slots unavailable; see the preceding errors"
+    return 1
+  fi
+  return 0
 }
 
 # Tear down a runner: graceful stop, remove the container, and drop its DinD
 # data root (the per-runner /var/lib/docker bind dir created in build_args) so
 # the pool is reclaimed instead of leaking a tree per retired runner.
+provider_stop_container() {
+  local slot="$1" c="$1" provider timeout=30
+  # remove_runner can bind an immutable ID to the stable slot name through
+  # dynamically scoped locals. Provider adapters continue receiving the slot
+  # name for GitHub API identity and GitLab config/system-ID paths, while the
+  # actual Docker stop/remove cannot be redirected by a name-reuse race.
+  if [ -n "${CRF_REMOVE_ID:-}" ] && [ "$slot" = "${CRF_REMOVE_SLOT:-}" ]; then
+    c="$CRF_REMOVE_ID"
+    provider="$CRF_REMOVE_PROVIDER"
+  else
+    provider="$(container_provider "$c")"
+  fi
+  if [ "$provider" = gitlab ]; then
+    # Official Runner images already declare STOPSIGNAL SIGQUIT, but make the
+    # contract explicit so a pinned compatible image cannot turn an operator
+    # Stop into a forceful SIGTERM. The persisted timeout also covers Docker and
+    # Unraid array shutdown paths that stop the container directly.
+    timeout="$(gitlab_shutdown_timeout)"
+  fi
+  if [ "$provider" = gitlab ]; then
+    docker stop --signal SIGQUIT --timeout "$timeout" "$c"
+  else
+    # Keep GitHub's existing stop signal while avoiding an empty-array expansion,
+    # which is an unbound variable under the macOS Bash 3 test environment.
+    docker stop --timeout "$timeout" "$c"
+  fi >/dev/null 2>&1 || {
+    docker inspect "$c" >/dev/null 2>&1 && { err "could not stop $slot"; return 1; }
+  }
+}
+
+provider_remove_container() {
+  local slot="$1" c="$1"
+  if [ -n "${CRF_REMOVE_ID:-}" ] && [ "$slot" = "${CRF_REMOVE_SLOT:-}" ]; then
+    c="$CRF_REMOVE_ID"
+  fi
+  docker rm "$c" >/dev/null 2>&1 || {
+    docker inspect "$c" >/dev/null 2>&1 && { err "could not remove $slot"; return 1; }
+  }
+}
+
+provider_stop_remove_container() {
+  provider_stop_container "$1" && provider_remove_container "$1"
+}
+
+provider_stop_owned_runner() {
+  local slot="$1" immutable_id="$2" provider="$3"
+  local CRF_REMOVE_SLOT="$slot" CRF_REMOVE_ID="$immutable_id" CRF_REMOVE_PROVIDER="$provider"
+  printf '%s' "$immutable_id" | grep -qE '^[0-9a-f]{64}$' \
+    || { err "refusing to stop $slot with an invalid immutable container ID"; return 1; }
+  case "$provider" in github|gitlab) ;; *) err "refusing to stop $slot without a validated provider"; return 1 ;; esac
+  provider_stop_container "$slot"
+}
+
 remove_runner() {
-  local c="$1"
-  [ -n "$c" ] || return 0                      # never let an empty name make the rm below target docker/
-  deregister_runner_api "$c"                  # host-side (PAT stays off the container)
-  docker stop -t 30 "$c" >/dev/null 2>&1
-  docker rm "$c" >/dev/null 2>&1
-  # $c is a managed container name (ci-runner-N) — no '/' or '..'; path stays under our docker/ subtree.
-  [ -n "$CACHE_ROOT" ] && rm -rf "$CACHE_ROOT/docker/$c" 2>/dev/null || true
+  local c="$1" purge="${2:-true}" immutable_id="${3:-}" provider="${4:-}"
+  local snapshot snapshot_id snapshot_provider role index gen
+  local CRF_REMOVE_SLOT="" CRF_REMOVE_ID="" CRF_REMOVE_PROVIDER=""
+  [ -n "$c" ] || return 0
+  snapshot="$(managed_runner_snapshot "$c")" || return 1
+  IFS='|' read -r snapshot_id snapshot_provider role index gen <<< "$snapshot"
+  if [ -n "$immutable_id" ] \
+     && { [ "$immutable_id" != "$snapshot_id" ] || [ "$provider" != "$snapshot_provider" ]; }; then
+    err "refusing removal of $c because its immutable ownership changed"
+    return 1
+  fi
+  immutable_id="$snapshot_id"
+  provider="$snapshot_provider"
+  CRF_REMOVE_SLOT="$c"
+  CRF_REMOVE_ID="$immutable_id"
+  CRF_REMOVE_PROVIDER="$provider"
+  "${provider}_remove_runner" "$c" "$purge"
+}
+
+# Stop every running GitLab manager concurrently before a full fleet teardown.
+# Signalling them all first prevents later slots from accepting fresh jobs while
+# Stop waits for an earlier slot's graceful timeout, and bounds the fleet-wide
+# drain by one configured timeout instead of one timeout per manager.
+quiesce_gitlab_managers_for_stop() {
+  local c pids="" pid failed=0 count=0 names snapshot id provider role index gen
+  names="$(managed_names)" || return 1
+  for c in $names; do
+    [ -n "$c" ] || continue
+    snapshot="$(managed_runner_snapshot "$c")" || return 1
+    IFS='|' read -r id provider role index gen <<< "$snapshot"
+    [ "$provider" = gitlab ] || continue
+    if ! docker inspect -f '{{.State.Running}}' "$id" 2>/dev/null | grep -qx true; then
+      docker inspect "$id" >/dev/null 2>&1 \
+        || { err "could not inspect owned GitLab manager $c before quiescing"; return 1; }
+      continue
+    fi
+    count=$((count+1))
+    log "stopping $c accepting new GitLab work; draining its active job"
+    provider_stop_owned_runner "$c" "$id" "$provider" &
+    pids="$pids $!"
+  done
+  for pid in $pids; do wait "$pid" || failed=1; done
+  [ "$failed" -eq 0 ] \
+    || { err "one or more GitLab managers could not be quiesced; preserving the fleet for retry"; return 1; }
+  [ "$count" -eq 0 ] || log "$count GitLab manager(s) drained in parallel"
+}
+
+cleanup_orphan_github_validations() {
+  local names c snapshot id provider role index gen failed=0
+  names="$(docker ps -a \
+    --filter 'label=net.unraid.ci-runner-farm.managed=true' \
+    --filter 'label=net.unraid.ci-runner-farm.provider=github' \
+    --filter 'label=net.unraid.ci-runner-farm.role=validate' \
+    --format '{{.Names}}')" \
+    || { err "could not enumerate orphaned GitHub validation containers"; return 1; }
+  for c in $names; do
+    printf '%s' "$c" | grep -qE "^${NAME_PREFIX}-validate-[0-9a-f]{12}$" \
+      || { err "refusing unexpected GitHub validation container name: $c"; failed=1; continue; }
+    snapshot="$(owned_container_snapshot "$c" 99 github-validate)" \
+      || { failed=1; continue; }
+    IFS='|' read -r id provider role index gen <<< "$snapshot"
+    log "removing orphaned GitHub validation container $c"
+    if ! docker rm -f "$id" >/dev/null 2>&1 \
+       && docker inspect "$id" >/dev/null 2>&1; then
+      err "could not remove owned GitHub validation container $c"
+      failed=1
+    fi
+  done
+  return "$failed"
 }
 
 # Full teardown: daemons, runner containers, and the shared pull-through mirror.
@@ -1205,29 +1907,329 @@ remove_runner() {
 # token — so a later Start rebuilds the container with its cache warm; only the
 # container is removed here, not the cached layers.
 cmd_stop() {
-  autoscale_stop
-  imageupdate_stop
-  local names; names="$(managed_names)"
+  # Cancel every process that can create fleet resources before examining the
+  # current Docker state. In particular, a sleeping boot worker must not wake
+  # after Stop/uninstall and recreate the farm from retained credentials.
+  boot_autostart_stop || return 1
+  autoscale_stop || return 1
+  imageupdate_stop || return 1
+  reconcile_stop || return 1
+  quiesce_gitlab_managers_for_stop || return 1
+  local names c remaining remaining_managers stop_failed=0
+  names="$(managed_names)" \
+    || { err "could not enumerate managed runners before stop"; return 1; }
   if [ -z "$names" ]; then
     log "no managed runners running"
   else
-    echo "$names" | while read -r c; do [ -n "$c" ] && { log "stopping $c (graceful deregister)"; remove_runner "$c"; }; done
+    while IFS= read -r c; do
+      [ -n "$c" ] || continue
+      log "stopping $c (graceful deregister)"
+      remove_runner "$c" || stop_failed=1
+    done <<< "$names"
   fi
+  # A provider removal that failed closed can intentionally leave a manager and
+  # its active job/sidecar intact. Do not then perform global cleanup underneath
+  # that workload: host-socket job cleanup, mirror removal, and firewall/network
+  # teardown would defeat the preservation guarantee and weaken strict egress.
+  if ! remaining_managers="$(managed_names)"; then
+    err "could not verify that all runner managers stopped"
+    return 1
+  fi
+  if [ -n "$remaining_managers" ]; then
+    err "runner managers remain after stop: $(printf '%s' "$remaining_managers" | tr '\n' ' ')"
+    return 1
+  fi
+  # A manager deleted manually outside this transaction can leave the only
+  # reusable token/system-ID pair capable of exact manager-only unregister.
+  # Preserve that retry material and require the explicit break-glass action;
+  # never make an invisible remote orphan by treating an empty Docker list as a
+  # complete retirement.
+  gitlab_assert_no_orphan_manager_configs || return 1
+  # Host-socket executor jobs outlive a manager unless explicitly removed.
+  gitlab_stop_cleanup || stop_failed=1
+  # A manager can be manually removed or crash before cleanup. Remove only
+  # ownership-verified orphans; a single spoofed label must never authorize a
+  # force-removal of an unrelated fixed-name container.
+  gitlab_cleanup_orphan_sidecars || stop_failed=1
+  # Fixed-label verification is the final safety barrier for token clearing: a
+  # caller must see a non-zero status if any manager or attributed job survives
+  # and could retain credentials or continue executing after files are scrubbed.
+  if ! remaining="$(docker ps -a --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' --format '{{.Names}}' 2>/dev/null)"; then
+    err "could not verify GitLab job/sidecar cleanup"
+    return 1
+  fi
+  if [ -n "$remaining" ]; then
+    err "GitLab containers remain after stop: $(printf '%s' "$remaining" | tr '\n' ' ')"
+    return 1
+  fi
+  # A killed Validate request can leave its detached GitHub test container after
+  # the fleet itself is gone. It carries a distinct role and random name, so the
+  # numeric-slot loops intentionally ignore it; clean it only through the full
+  # immutable validation ownership contract before shared network/cache teardown.
+  cleanup_orphan_github_validations || return 1
   # drop the shared image-cache container so uninstall/Stop don't orphan it
-  if docker ps -a --format '{{.Names}}' | grep -qx "$MIRROR_NAME"; then
+  if docker inspect "$MIRROR_NAME" >/dev/null 2>&1; then
     log "removing shared image cache ($MIRROR_NAME)"
-    docker rm -f "$MIRROR_NAME" >/dev/null 2>&1 || true
+    mirror_remove_owned || stop_failed=1
   fi
   # tear down the strict-mode egress rules and the now-empty dedicated network
-  firewall_clear
-  if [ "$NETWORK_ISOLATION" != "off" ] && docker network inspect "$RUNNER_NETWORK" >/dev/null 2>&1; then
-    log "removing isolated runner network ($RUNNER_NETWORK)"
-    docker network rm "$RUNNER_NETWORK" >/dev/null 2>&1 || true
+  if ! firewall_clear; then
+    stop_failed=1
+  elif [ "$NETWORK_ISOLATION" != "off" ] && docker network inspect "$RUNNER_NETWORK" >/dev/null 2>&1; then
+    if network_owned "$RUNNER_NETWORK"; then
+      local network_id
+      network_id="$(docker network inspect -f '{{.Id}}' "$RUNNER_NETWORK" 2>/dev/null)"
+      if [ -z "$network_id" ]; then
+        err "could not resolve owned isolated network $RUNNER_NETWORK"
+        stop_failed=1
+      else
+        log "removing owned isolated runner network ($RUNNER_NETWORK)"
+        if ! docker network rm "$network_id" >/dev/null 2>&1 \
+           || docker network inspect "$network_id" >/dev/null 2>&1; then
+          err "could not remove owned isolated runner network $RUNNER_NETWORK"
+          stop_failed=1
+        fi
+      fi
+    else
+      log "preserving unowned pre-existing network $RUNNER_NETWORK"
+    fi
   fi
+  return "$stop_failed"
+}
+
+# ---- credential removal transactions --------------------------------------
+# PHP owns validation and atomic writes, but credential removal also has to
+# invalidate files derived by fleet mutations. Keep that whole operation behind
+# fleet.lock: a queued Start/Recycle then reloads the now-empty secret snapshot
+# instead of recreating an auth/config file from values loaded before it waited.
+remove_plugin_file() {
+  local file="$1"
+  [ -e "$file" ] || [ -L "$file" ] || return 0
+  rm -f "$file" 2>/dev/null || return 1
+  [ ! -e "$file" ] && [ ! -L "$file" ]
+}
+
+scrub_host_registry_auth_locked() {
+  local file failed=0
+  # HOST_DOCKER_CONFIG normally lives on tmpfs. CFGDIR/docker-auth is its rare
+  # fallback when the runtime directory cannot be created during early boot.
+  for file in \
+    "$HOST_DOCKER_CONFIG/config.json" \
+    "$CFGDIR/docker-auth/config.json"; do
+    remove_plugin_file "$file" || failed=1
+  done
+  return "$failed"
+}
+
+scrub_gitlab_runner_configs_locked() {
+  local file failed=0
+  # Remove only the token-bearing generated TOML. The stable system ID is the
+  # manager identity and deliberately survives a token rotation/re-registration.
+  for file in \
+    "$CFGDIR"/gitlab-runners/*/config.toml \
+    "$CFGDIR"/gitlab-runners/*/config.toml.tmp \
+    "$CFGDIR"/gitlab-token-probe/config.toml \
+    "$CFGDIR"/gitlab-token-probe/config.toml.tmp; do
+    [ -e "$file" ] || [ -L "$file" ] || continue
+    remove_plugin_file "$file" || failed=1
+  done
+  return "$failed"
+}
+
+scrub_gitlab_registry_auth_locked() {
+  local file failed=0
+  for file in \
+    "$CFGDIR"/gitlab-runners/*/docker/config.json \
+    "$CFGDIR"/gitlab-runners/*/docker/config.json.tmp; do
+    [ -e "$file" ] || [ -L "$file" ] || continue
+    remove_plugin_file "$file" || failed=1
+  done
+  return "$failed"
+}
+
+cmd_credential_clear_github_token() {
+  local token_removed=false host_auth_removed=false ok=false error=""
+
+  # Preserve the endpoint's historical partial-success contract: attempt the
+  # independent host-auth scrub even if flash refuses the token unlink, and
+  # report each result so the UI changes its token indicator only when warranted.
+  if remove_plugin_file "$TOKEN_FILE"; then
+    token_removed=true
+    ACCESS_TOKEN=""
+  fi
+  scrub_host_registry_auth_locked && host_auth_removed=true
+
+  if [ "$token_removed" = true ] && [ "$host_auth_removed" = true ]; then
+    ok=true
+  elif [ "$token_removed" != true ]; then
+    error="could not remove token"
+  else
+    error="could not remove plugin host-pull Docker auth"
+  fi
+
+  if [ "$ok" = true ]; then
+    printf '{"ok":true,"action":"clear-token","error":null,"token_removed":true,"host_auth_removed":true}\n'
+    return 0
+  fi
+  printf '{"ok":false,"action":"clear-token","error":%s,"token_removed":%s,"host_auth_removed":%s}\n' \
+    "$(printf '%s' "$error" | json_string)" "$token_removed" "$host_auth_removed"
+  return 1
+}
+
+cmd_credential_clear_gitlab_runner() {
+  local confirmed="${1:-0}" active=false token_removed=false
+  local fleet_stop_requested=false fleet_stopped=false slot_configs_removed=false
+  local stop_log="" remaining="" docker_checked=true failed=0 error=""
+  [ "$CI_PROVIDER" = gitlab ] && active=true
+
+  # This is intentionally repeated inside fleet.lock. PHP's fast pre-check is
+  # only a UI convenience; Settings Apply may have changed the active provider
+  # while this action waited for another lifecycle operation.
+  if [ "$active" = true ] && [ "$confirmed" != 1 ]; then
+    printf '{"ok":false,"action":"clear-gitlab-runner-token","confirmation_required":true,"error":%s,"token_removed":false,"fleet_stop_requested":true,"fleet_stopped":false,"slot_configs_removed":false,"log":""}\n' \
+      "$(printf 'Clearing the active GitLab runner token gracefully drains each manager for up to %s seconds, then stops and unregisters it. Jobs still running after that timeout are forced to stop.' "$(gitlab_shutdown_timeout)" | json_string)"
+    return 0
+  fi
+
+  # GitLab verification creates a disposable manager row. If its response or
+  # immediate manager-only unregister was interrupted, the protected probe
+  # config is the only exact cleanup credential. Never remove the bootstrap
+  # token or report success until that saved transaction is complete.
+  if ! gitlab_recover_pending_probe; then
+    printf '{"ok":false,"action":"clear-gitlab-runner-token","error":%s,"token_removed":false,"fleet_stop_requested":false,"fleet_stopped":false,"slot_configs_removed":false,"log":""}\n' \
+      "$(printf '%s' 'could not complete pending GitLab token-probe manager cleanup; retry before clearing the token' | json_string)"
+    return 1
+  fi
+
+  # Remove the bootstrap copy first. If flash is read-only, keep managers and
+  # their mounted config intact so a failed request cannot destroy a working farm.
+  if ! remove_plugin_file "$GITLAB_RUNNER_TOKEN_FILE"; then
+    printf '{"ok":false,"action":"clear-gitlab-runner-token","error":%s,"token_removed":false,"fleet_stop_requested":%s,"fleet_stopped":false,"slot_configs_removed":false,"log":""}\n' \
+      "$(printf '%s' 'could not remove gitlab-runner-token' | json_string)" "$active"
+    return 1
+  fi
+  token_removed=true
+  GITLAB_RUNNER_TOKEN=""
+
+  if [ "$active" = true ]; then
+    fleet_stop_requested=true
+    if stop_log="$(cmd_stop 2>&1)"; then
+      fleet_stopped=true
+    else
+      failed=1
+      error="could not completely stop and unregister the GitLab fleet"
+    fi
+    # An unregister warning represents a partial operation even if every local
+    # container was subsequently removed; surface the lingering GitLab record.
+    case "$stop_log" in
+      *"could not unregister GitLab manager"*)
+        fleet_stopped=false; failed=1
+        error="one or more GitLab managers could not be unregistered" ;;
+    esac
+  fi
+
+  if ! remaining="$(docker ps -a --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' --format '{{.Names}}' 2>/dev/null)"; then
+    docker_checked=false; fleet_stopped=false; failed=1
+    error="could not verify that GitLab containers were stopped"
+  elif [ -n "$remaining" ]; then
+    fleet_stopped=false; failed=1
+    if [ "$active" = true ]; then
+      error="GitLab containers remain after the stop request"
+    else
+      # Never stop a GitHub farm (or unexpected GitLab leftovers) from an
+      # inactive-provider clear that the operator was not asked to confirm.
+      error="GitLab containers remain while GitHub is active; stop them before removing per-slot runner configs"
+    fi
+  else
+    if ! gitlab_assert_no_orphan_manager_configs; then
+      failed=1
+      fleet_stopped=false
+      error="one or more missing GitLab managers still need unregister cleanup or an explicit local Force forget"
+    elif [ "$active" = true ] && [ "$failed" = 0 ]; then
+      fleet_stopped=true
+    fi
+  fi
+
+  # A live manager can retain its bind-mounted config even after the host path
+  # is unlinked. Only scrub once Docker positively reports no GitLab containers.
+  if [ "$failed" = 0 ] && [ "$docker_checked" = true ] && [ -z "$remaining" ]; then
+    if scrub_gitlab_runner_configs_locked; then
+      slot_configs_removed=true
+    else
+      failed=1
+      [ -n "$error" ] || error="could not remove one or more per-slot GitLab runner configs"
+    fi
+  fi
+
+  if [ "$failed" = 0 ] && [ "$slot_configs_removed" = true ]; then
+    printf '{"ok":true,"action":"clear-gitlab-runner-token","error":null,"token_removed":true,"fleet_stop_requested":%s,"fleet_stopped":%s,"slot_configs_removed":true,"log":%s}\n' \
+      "$fleet_stop_requested" "$fleet_stopped" "$(printf '%s' "$stop_log" | json_string)"
+    return 0
+  fi
+  [ -n "$error" ] || error="GitLab runner token was removed, but cleanup was incomplete"
+  printf '{"ok":false,"action":"clear-gitlab-runner-token","error":%s,"token_removed":%s,"fleet_stop_requested":%s,"fleet_stopped":%s,"slot_configs_removed":%s,"log":%s}\n' \
+    "$(printf '%s' "$error" | json_string)" "$token_removed" "$fleet_stop_requested" \
+    "$fleet_stopped" "$slot_configs_removed" "$(printf '%s' "$stop_log" | json_string)"
+  return 1
+}
+
+cmd_credential_clear_registry_token() {
+  local token_removed=false slot_auth_removed=false host_auth_removed=false ok=false
+  local reconcile_requested=false reconcile_started=false reconcile_error="" reconcile_log=""
+  local warning="" error=""
+
+  # Do not scrub derived files when the source credential could not be removed:
+  # a later locked mutation would legitimately repopulate them from that source.
+  if ! remove_plugin_file "$REGISTRY_TOKEN_FILE"; then
+    printf '{"ok":false,"action":"clear-registry-token","error":%s,"token_removed":false,"slot_auth_removed":false,"host_auth_removed":false,"reconcile_requested":false,"reconcile_started":false,"warning":null}\n' \
+      "$(printf '%s' 'could not remove registry-token' | json_string)"
+    return 1
+  fi
+  token_removed=true
+  REGISTRY_TOKEN=""
+
+  scrub_gitlab_registry_auth_locked && slot_auth_removed=true
+  scrub_host_registry_auth_locked && host_auth_removed=true
+
+  if [ "$CI_PROVIDER" = gitlab ]; then
+    reconcile_requested=true
+    if reconcile_log="$(cmd_reconcile_config 2>&1)"; then
+      reconcile_started=true
+    else
+      reconcile_error="${reconcile_log:-could not start reconcile}"
+    fi
+  fi
+
+  if [ "$slot_auth_removed" = true ] && [ "$host_auth_removed" = true ]; then
+    ok=true
+    if [ "$CI_PROVIDER" = gitlab ]; then
+      warning="Per-slot auth files were removed immediately. An image pull that already authenticated may still finish; queued slot reconciliation removes the credential from replacement managers."
+    fi
+  elif [ "$slot_auth_removed" != true ] && [ "$host_auth_removed" != true ]; then
+    error="could not remove per-slot or plugin host-pull Docker auth"
+  elif [ "$slot_auth_removed" != true ]; then
+    error="could not remove one or more per-slot Docker auth files"
+  else
+    error="could not remove plugin host-pull Docker auth"
+  fi
+
+  printf '{"ok":%s,"action":"clear-registry-token","error":%s,"token_removed":%s,"slot_auth_removed":%s,"host_auth_removed":%s,"reconcile_requested":%s,"reconcile_started":%s' \
+    "$ok" "$([ "$ok" = true ] && printf null || printf '%s' "$error" | json_string)" \
+    "$token_removed" "$slot_auth_removed" "$host_auth_removed" "$reconcile_requested" "$reconcile_started"
+  if [ "$reconcile_requested" = true ] && [ "$reconcile_started" != true ]; then
+    printf ',"reconcile_error":%s' "$(printf '%s' "$reconcile_error" | json_string)"
+  fi
+  if [ -n "$warning" ]; then
+    printf ',"warning":%s' "$(printf '%s' "$warning" | json_string)"
+  else
+    printf ',"warning":null'
+  fi
+  printf '}\n'
+  [ "$ok" = true ]
 }
 
 cmd_scale() {
-  local target="$1"
+  local target="$1" failed=0
   # Server-side validate + clamp. The form's max="20" is presentation-only, so a
   # crafted POST (n=99999) would otherwise drive an unbounded provisioning loop —
   # a container + a minted GitHub registration token per iteration (host / API
@@ -1239,22 +2241,60 @@ cmd_scale() {
   # Guard the cache-root shape BEFORE ensure_dirs runs mkdir/chown under it — on every
   # scale path (down/same, not just up), so an unsafe CACHE_ROOT never gets provisioned.
   crf_safe_cache_root >/dev/null 2>&1 || { err "refusing to scale: CACHE_ROOT ($CACHE_ROOT) is unsafe — point it at a dedicated subdir under /mnt/<pool>, not a bare pool/disk/share root or system dir"; return 1; }
-  ensure_dirs; registry_login
-  local current; current="$(managed_names | wc -l)"
+  local current
+  current="$(current_count)" \
+    || { err "could not count managed runners before scaling"; return 1; }
   if [ "$target" -gt "$current" ]; then
-    [ -z "$ACCESS_TOKEN" ] && { err "no token configured"; return 1; }
-    check_cache_root || return 1
-    local i
-    for i in $(seq 1 "$target"); do
-      docker ps -a --format '{{.Names}}' | grep -qx "${NAME_PREFIX}-${i}" || start_one "$i"
+    provider_token_ready || { err "no valid $(provider_token_name) configured"; return 1; }
+    [ "$CI_PROVIDER" = "gitlab" ] && gitlab_validate_settings || { [ "$CI_PROVIDER" != "gitlab" ] || return 1; }
+    gitlab_assert_no_orphan_manager_configs || return 1
+    # Growing an active fleet must not clear and rebuild the entire strict
+    # firewall. Provision shared resources, then add only newly configured
+    # endpoint exceptions (or repair genuinely missing base rules).
+    provision_base || return 1
+    firewall_prepare_replacement || return 1
+    gitlab_cleanup_orphan_sidecars || { err "could not safely clean orphaned GitLab sidecars"; return 1; }
+    # Slot numbers are identities, not a dense array. Failed replacements and
+    # manually removed containers can leave holes, so fill only as many free
+    # indices as needed to reach the requested count.
+    local i=1 name all_names
+    while :; do
+      current="$(current_count)" \
+        || { err "could not recount managed runners while scaling up"; return 1; }
+      [ "$current" -lt "$target" ] && [ "$i" -le "$HARD_MAX" ] || break
+      name="${NAME_PREFIX}-${i}"
+      all_names="$(docker ps -a --format '{{.Names}}')" \
+        || { err "could not enumerate Docker containers while selecting a free runner slot"; return 1; }
+      if ! printf '%s\n' "$all_names" | grep -qx "$name"; then
+        if ! start_one "$i"; then failed=1; break; fi
+      fi
+      i=$((i+1))
     done
   elif [ "$target" -lt "$current" ]; then
-    local i
-    for i in $(seq "$current" -1 $((target+1)) ); do
-      remove_runner "${NAME_PREFIX}-${i}" && log "removed ${NAME_PREFIX}-${i}"
+    # Remove actual highest-numbered slots; count-derived names are wrong when
+    # the fleet contains holes (for example {1,4}).
+    local c names snapshot id provider role index gen
+    names="$(managed_names)" || return 1
+    for c in $(printf '%s\n' "$names" | sort -rV); do
+      current="$(current_count)" || return 1
+      [ "$current" -le "$target" ] && break
+      snapshot="$(managed_runner_snapshot "$c")" || { failed=1; break; }
+      IFS='|' read -r id provider role index gen <<< "$snapshot"
+      if remove_runner "$c" true "$id" "$provider"; then
+        log "removed $c"
+      else
+        failed=1
+        break
+      fi
     done
   fi
-  log "scaled to $(managed_names | wc -l) runner(s)"
+  current="$(current_count)" \
+    || { err "could not count managed runners after scaling"; return 1; }
+  log "scaled to $current runner(s)"
+  if [ "$current" -ne "$target" ] || [ "$failed" -ne 0 ]; then
+    err "scale requested $target runner(s), but the fleet has $current after one or more lifecycle failures"
+    return 1
+  fi
 }
 
 cmd_status() {
@@ -1271,6 +2311,24 @@ cmd_status() {
 }
 
 json_escape() { sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr -d '\000-\037'; }
+
+# Runner and Docker diagnostics are not a trusted redaction boundary. Filter
+# both the currently loaded secrets and recognizable CI-token shapes before any
+# container/farm/build log reaches the UI or CLI. Quoted Bash substitution keeps
+# arbitrary registry-password punctuation literal and out of subprocess argv.
+redact_log_stream() {
+  local line secret
+  while IFS= read -r line || [ -n "$line" ]; do
+    for secret in "$ACCESS_TOKEN" "$GITLAB_RUNNER_TOKEN" "$GITLAB_API_TOKEN" "$REGISTRY_TOKEN"; do
+      [ "${#secret}" -ge 4 ] && line="${line//"$secret"/[REDACTED]}"
+    done
+    printf '%s\n' "$line"
+  done | sed -E \
+    -e 's/([A-Za-z0-9_.@-]{1,64}-)?glrt(r)?-[A-Za-z0-9_.-]{10,507}/[REDACTED_GITLAB_TOKEN]/g' \
+    -e 's/github_pat_[A-Za-z0-9_]{10,}/[REDACTED_GITHUB_TOKEN]/g' \
+    -e 's/gh[pousr]_[A-Za-z0-9_]{10,}/[REDACTED_GITHUB_TOKEN]/g' \
+    -e 's/glpat-[A-Za-z0-9_-]{8,}/[REDACTED_GITLAB_TOKEN]/g'
+}
 # JSON-encode stdin as a string literal (with surrounding quotes), preserving newlines
 # as \n — for multi-line log payloads where json_escape's control-char stripping would
 # collapse the log into one line.
@@ -1285,23 +2343,55 @@ json_string() {
 cmd_image_info_json() {
   # Image facts for the settings page's Runner image tab: existence, id, age,
   # size, base image, and how many managed runners currently run on it.
-  local img; img="$(effective_image)"
+  local img c sock inspect_sock=""; img="$(effective_image)"
   local id; id="$(docker image inspect -f '{{.Id}}' "$img" 2>/dev/null)"
+  # A remote GitLab DinD image intentionally never enters Unraid's host image
+  # store. Inspect a live slot daemon before declaring it absent; if no slot has
+  # pulled it yet, the source-aware UI still reports it as remotely configured
+  # instead of telling the operator to build an unrelated local image.
+  if [ -z "$id" ] && [ "$CI_PROVIDER" = gitlab ] && [ "$IMAGE_SOURCE" = remote ]; then
+    for c in $(managed_names); do
+      [ "$(container_provider "$c")" = gitlab ] || continue
+      sock="$(gitlab_socket_path "$c")"
+      [ "$sock" != /var/run/docker.sock ] || continue
+      id="$(docker --host "unix://$sock" image inspect -f '{{.Id}}' "$img" 2>/dev/null)"
+      if [ -n "$id" ]; then inspect_sock="$sock"; break; fi
+    done
+  fi
   if [ -z "$id" ]; then
-    echo "{\"exists\":false,\"image\":\"$(echo "$img"|json_escape)\",\"source\":\"$(echo "$IMAGE_SOURCE"|json_escape)\"}"
+    echo "{\"exists\":false,\"provider\":\"$CI_PROVIDER\",\"image\":\"$(echo "$img"|json_escape)\",\"source\":\"$(echo "$IMAGE_SOURCE"|json_escape)\"}"
     return 0
   fi
-  local created size; created="$(docker image inspect -f '{{.Created}}' "$img")"
-  size="$(docker image inspect -f '{{.Size}}' "$img")"
-  local df="$CFGDIR/Dockerfile"
-  [ -f "$df" ] || df="/usr/local/emhttp/plugins/$PLUGIN/default.Dockerfile"
+  local created size
+  if [ -n "$inspect_sock" ]; then
+    created="$(docker --host "unix://$inspect_sock" image inspect -f '{{.Created}}' "$img")"
+    size="$(docker --host "unix://$inspect_sock" image inspect -f '{{.Size}}' "$img")"
+  else
+    created="$(docker image inspect -f '{{.Created}}' "$img")"
+    size="$(docker image inspect -f '{{.Size}}' "$img")"
+  fi
+  local df="$CFGDIR/Dockerfile.$CI_PROVIDER"
+  [ "$CI_PROVIDER" = github ] && [ ! -f "$df" ] && [ -f "$CFGDIR/Dockerfile" ] && df="$CFGDIR/Dockerfile"
+  [ -f "$df" ] || df="/usr/local/emhttp/plugins/$PLUGIN/default.$CI_PROVIDER.Dockerfile"
   local base; base="$(grep -m1 '^FROM ' "$df" 2>/dev/null | awk '{print $2}')"
-  local inuse=0 c cid
+  local inuse=0 cid configured
   for c in $(managed_names); do
-    cid="$(docker inspect -f '{{.Image}}' "$c" 2>/dev/null)"
-    [ "$cid" = "$id" ] && inuse=$((inuse+1))
+    [ "$(container_provider "$c")" = "$CI_PROVIDER" ] || continue
+    if [ "$CI_PROVIDER" = gitlab ]; then
+      configured="$(grep -m1 '^[[:space:]]*image[[:space:]]*=' "$(gitlab_slot_config_dir "$c")/config.toml" 2>/dev/null | sed 's/^[^=]*=[[:space:]]*"\([^"]*\)".*/\1/')"
+      [ "$configured" = "$img" ] || continue
+      sock="$(gitlab_socket_path "$c")"
+      if [ "$sock" != /var/run/docker.sock ]; then
+        cid="$(docker --host "unix://$sock" image inspect -f '{{.Id}}' "$img" 2>/dev/null)"
+        [ "$cid" = "$id" ] || continue
+      fi
+      inuse=$((inuse+1))
+    else
+      cid="$(docker inspect -f '{{.Image}}' "$c" 2>/dev/null)"
+      [ "$cid" = "$id" ] && inuse=$((inuse+1))
+    fi
   done
-  echo "{\"exists\":true,\"image\":\"$(echo "$img"|json_escape)\",\"id\":\"$(echo "$id" | cut -c8-19)\",\"created\":\"$created\",\"size_mb\":$(( ${size:-0}/1024/1024 )),\"base\":\"$(echo "$base"|json_escape)\",\"in_use\":$inuse,\"dockerfile\":\"$(echo "$df"|json_escape)\",\"source\":\"$(echo "$IMAGE_SOURCE"|json_escape)\"}"
+  echo "{\"exists\":true,\"provider\":\"$CI_PROVIDER\",\"image\":\"$(echo "$img"|json_escape)\",\"id\":\"$(echo "$id" | cut -c8-19)\",\"created\":\"$created\",\"size_mb\":$(( ${size:-0}/1024/1024 )),\"base\":\"$(echo "$base"|json_escape)\",\"in_use\":$inuse,\"dockerfile\":\"$(echo "$df"|json_escape)\",\"source\":\"$(echo "$IMAGE_SOURCE"|json_escape)\"}"
 }
 
 # "1.5GiB" / "512MiB" / "900kB" -> integer MiB (docker stats human units)
@@ -1312,27 +2402,21 @@ to_mib() {
     printf "%d", v }'
 }
 
+memory_limit_bytes() {
+  printf '%s' "$1" | awk '
+    BEGIN { IGNORECASE=1 }
+    {
+      if (!match($0, /^[0-9]+([.][0-9]+)?[kmgt]?$/)) { print 0; exit }
+      v=$0; u=tolower(substr(v,length(v),1));
+      if (u ~ /[kmgt]/) v=substr(v,1,length(v)-1); else u="";
+      if (u=="k") v*=1024; else if (u=="m") v*=1048576;
+      else if (u=="g") v*=1073741824; else if (u=="t") v*=1099511627776;
+      printf "%.0f", v
+    }'
+}
+
 cmd_queued_refresh() {
-  # Sum queued workflow runs across GH_REPOS into a cache file. Invoked in the
-  # background from cmd_queued_json so the UI poll never blocks on 20+ curls.
-  [ -z "$ACCESS_TOKEN" ] && [ -f "$TOKEN_FILE" ] && ACCESS_TOKEN="$(cat "$TOKEN_FILE" 2>/dev/null)"
-  [ -n "$ACCESS_TOKEN" ] || { echo "$(date +%s) -1" > "$RUNDIR/queued.cache"; return 0; }
-  local total=0 got=0 r n body tmpd i=0
-  tmpd="$(mktemp -d 2>/dev/null)"
-  [ -n "$tmpd" ] || { echo "$(date +%s) -1" > "$RUNDIR/queued.cache"; return 0; }
-  gh_fetch_all "/actions/runs?status=queued&per_page=1" "$tmpd"
-  for r in $GH_REPOS; do
-    [ -n "$r" ] || continue
-    i=$((i+1)); body="$(cat "$tmpd/$i" 2>/dev/null)"
-    case "$body" in *'"total_count"'*) got=1 ;; esac
-    n="$(printf '%s' "$body" | grep -m1 -oE '"total_count":[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1)"
-    total=$(( total + ${n:-0} ))
-  done
-  rm -rf "$tmpd"
-  # total=-1 signals "unavailable" (no token / every repo query failed) so the UI
-  # shows a dash instead of a confident "0 queued" — same sentinel as stats/usage.
-  [ "$got" = "1" ] || total=-1
-  echo "$(date +%s) $total" > "$RUNDIR/queued.cache"
+  provider_call queued_refresh
 }
 
 # Warm dependency caches under CACHE_ROOT — safe to clear even while runners are
@@ -1438,165 +2522,202 @@ cmd_cache_clear_pkg() {
 }
 
 cmd_stats_refresh() {
-  # Tally recent workflow-run conclusions across GH_REPOS. Detached + cached so
-  # the per-repo API sweep never blocks the UI (see queued for the pattern).
-  [ -z "$ACCESS_TOKEN" ] && [ -f "$TOKEN_FILE" ] && ACCESS_TOKEN="$(cat "$TOKEN_FILE" 2>/dev/null)"
-  [ -n "$ACCESS_TOKEN" ] || { echo "$(date +%s) 0 0 0 0 -1" > "$RUNDIR/stats.cache"; return 0; }
-  local ok=0 fail=0 cancel=0 other=0 total got=0 r body c tmpd i=0
-  tmpd="$(mktemp -d 2>/dev/null)"
-  [ -n "$tmpd" ] || { echo "$(date +%s) 0 0 0 0 -1" > "$RUNDIR/stats.cache"; return 0; }
-  gh_fetch_all "/actions/runs?per_page=50" "$tmpd"
-  for r in $GH_REPOS; do
-    [ -n "$r" ] || continue
-    i=$((i+1)); body="$(cat "$tmpd/$i" 2>/dev/null)"
-    case "$body" in *'"workflow_runs"'*) got=1 ;; esac
-    while IFS= read -r c; do
-      case "$c" in
-        *'"success"'*)                              ok=$((ok+1)) ;;
-        *'"failure"'*|*'"timed_out"'*|*'"startup_failure"'*) fail=$((fail+1)) ;;
-        *'"cancelled"'*)                            cancel=$((cancel+1)) ;;
-        *null*) : ;;  # in progress / queued — not a completed run
-        ?*)     other=$((other+1)) ;;
-      esac
-    done <<< "$(echo "$body" | grep -oE '"conclusion": ?(null|"[a-z_]+")')"
-  done
-  rm -rf "$tmpd"
-  # total=-1 signals "stats unavailable" (bad token / API down) vs a real zero.
-  if [ "$got" = "1" ]; then total=$((ok+fail+cancel+other)); else total=-1; fi
-  echo "$(date +%s) $ok $fail $cancel $other $total" > "$RUNDIR/stats.cache"
+  provider_call stats_refresh
 }
 
 cmd_stats_json() {
-  local now ts ok fail cancel other total age=999999
+  local now cache_provider ts ok fail cancel other total age=999999 first
   now=$(date +%s)
   if [ -f "$RUNDIR/stats.cache" ]; then
-    read -r ts ok fail cancel other total < "$RUNDIR/stats.cache"
-    age=$(( now - ${ts:-0} ))
+    read -r first ts ok fail cancel other total < "$RUNDIR/stats.cache"
+    case "$first" in
+      github|gitlab) cache_provider="$first" ;;
+      *) cache_provider=github; total="$other"; other="$cancel"; cancel="$fail"; fail="$ok"; ok="$ts"; ts="$first" ;;
+    esac
+    [ "$cache_provider" = "$CI_PROVIDER" ] && age=$(( now - ${ts:-0} )) || { age=999999; ok=0; fail=0; cancel=0; other=0; total=-1; }
   fi
   if [ "$age" -gt 300 ]; then
     ( flock -n 9 || exit 0; "$0" stats-refresh ) 9>"$RUNDIR/stats.lock" >/dev/null 2>&1 &
   fi
-  echo "{\"ok\":${ok:-0},\"fail\":${fail:-0},\"cancel\":${cancel:-0},\"other\":${other:-0},\"total\":${total:--1},\"age\":$age}"
+  echo "{\"provider\":\"$CI_PROVIDER\",\"ok\":${ok:-0},\"fail\":${fail:-0},\"cancel\":${cancel:-0},\"other\":${other:-0},\"total\":${total:--1},\"age\":$age}"
 }
 
 cmd_queued_json() {
-  local now ts count age=999999
+  local now cache_provider ts count age=999999 first
   now=$(date +%s)
   if [ -f "$RUNDIR/queued.cache" ]; then
-    read -r ts count < "$RUNDIR/queued.cache"
-    age=$(( now - ${ts:-0} ))
+    read -r first ts count < "$RUNDIR/queued.cache"
+    case "$first" in github|gitlab) cache_provider="$first" ;; *) cache_provider=github; count="$ts"; ts="$first" ;; esac
+    [ "$cache_provider" = "$CI_PROVIDER" ] && age=$(( now - ${ts:-0} )) || { age=999999; count=-1; }
   fi
   # flock, not a plain lock file: the advisory lock is released by the kernel
   # even on SIGKILL/reboot, so a killed refresh can never wedge future refreshes.
   if [ "$age" -gt 60 ]; then
     ( flock -n 9 || exit 0; "$0" queued-refresh ) 9>"$RUNDIR/queued.lock" >/dev/null 2>&1 &
   fi
-  echo "{\"queued\":${count:--1},\"age\":$age}"
+  echo "{\"provider\":\"$CI_PROVIDER\",\"queued\":${count:--1},\"age\":$age}"
 }
 
 cmd_recycle() {
-  # Deregister, remove, AND recreate one runner with a fresh registration token.
-  # Recreating (not just removing) keeps the fleet at its configured size even
-  # when autoscaling is off (the default) — otherwise a manual recycle would
-  # permanently shrink a fixed-size fleet by one. Mirrors recreate_stopped_runner:
-  # the warm caches and DinD data root are pool bind mounts keyed by the same
-  # name, so the replacement comes back warm.
-  local name="$1" idx
-  echo "$name" | grep -qE "^${NAME_PREFIX}-[0-9]+$" || { echo '{"ok":false,"error":"bad name"}'; return 1; }
-  idx="$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.index" }}' "$name" 2>/dev/null)"
-  [ -z "$idx" ] && idx="${name##*-}"
-  # Warn (don't block) if the rest of the fleet is on a different network than the
-  # current NETWORK_ISOLATION setting: build_args below uses the LIVE config, so a lone
-  # recycle after an isolation change silently places this one runner on the new
-  # network while its siblings stay on the old — a half-isolated fleet is a false sense
-  # of security. Tell the operator to restart the fleet to make it consistent.
-  local other
-  for other in $(managed_names); do
+  # Replace one slot without purging its Docker/cache roots. The old provider
+  # owns removal ordering; the selected provider owns replacement startup.
+  local name="$1" idx old_provider old_gen cur_gen image
+  local snapshot target_id target_role current_id current_name
+  local was_stale=false
+  echo "$name" | grep -qE "^${NAME_PREFIX}-[0-9]+$" \
+    || { echo '{"ok":false,"error":"bad name"}'; return 1; }
+  snapshot="$(managed_runner_snapshot "$name")" \
+    || { echo '{"ok":false,"error":"runner is not an owned managed slot"}'; return 1; }
+  IFS='|' read -r target_id old_provider target_role idx old_gen <<< "$snapshot"
+  cur_gen="$(crf_confgen)"
+  if [ "$old_provider" != "$CI_PROVIDER" ] || [ "$old_gen" != "$cur_gen" ]; then was_stale=true; fi
+
+  local other other_names other_snapshot stale_count
+  other_names="$(managed_names)" \
+    || { echo '{"ok":false,"error":"could not enumerate managed runners before recycle"}'; return 1; }
+  for other in $other_names; do
     [ -n "$other" ] && [ "$other" != "$name" ] || continue
-    on_expected_network "$other" || { log "recycle: WARNING — $other is not on the network the current NETWORK_ISOLATION setting expects; recycling $name will place it on the new network, leaving the fleet split. Restart the fleet to reconcile."; break; }
+    other_snapshot="$(managed_runner_snapshot "$other")" \
+      || { echo '{"ok":false,"error":"another runner failed its ownership check"}'; return 1; }
+    on_expected_network "$other" || {
+      log "recycle: WARNING — $other is still on a previous network; this slot will join the current one while the drain continues"
+      break
+    }
   done
-  # Provision what the replacement needs (cache-root guard, dirs, isolated network,
-  # mirror, registry login) BEFORE removing the old container, so a config change
-  # since the last Start can't leave the runner removed-but-not-replaced. NOT the
-  # firewall: strict-mode egress rules are subnet-keyed, so the replacement rejoins
-  # a subnet the fleet's existing rules already cover — a clear+reapply here would
-  # briefly drop egress protection for every strict runner (and the rules already
-  # protect the new one). Abort with the runner intact if the cache-root guard,
-  # registry login, or isolated network is unavailable.
-  provision_base || { echo '{"ok":false,"error":"provisioning preflight failed (see log)"}'; return 1; }
-  if [ "$NETWORK_ISOLATION" != "off" ] && ! docker network inspect "$RUNNER_NETWORK" >/dev/null 2>&1; then
-    log "recycle: $name left in place — runner network $RUNNER_NETWORK unavailable"
+
+  provider_token_ready \
+    || { echo "{\"ok\":false,\"error\":\"no valid $(provider_token_name | json_escape) configured\"}"; return 1; }
+  provider_validate_settings \
+    || { echo '{"ok":false,"error":"invalid provider settings"}'; return 1; }
+  provision_base \
+    || { echo '{"ok":false,"error":"provisioning preflight failed (see log)"}'; return 1; }
+  if [ "$NETWORK_ISOLATION" != off ] \
+     && ! docker network inspect "$RUNNER_NETWORK" >/dev/null 2>&1; then
     echo '{"ok":false,"error":"runner network unavailable"}'; return 1
   fi
-  # Recycle deliberately skips the full firewall_clear+reapply cmd_start runs — on a
-  # healthy strict fleet the replacement rejoins a subnet the existing rules already
-  # cover, and clear+reapply would briefly drop egress for EVERY strict runner. But
-  # re-assert when the firewall state is genuinely STALE: (a) strict was enabled since
-  # the last Start so no rules exist yet (the replacement would start unprotected), or
-  # (b) provision_base recreated the image mirror with a new IP so the strict mirror
-  # allow rule now dangles and DinD pull-through would break. Steady state (rules
-  # present + current mirror IP still allowed) skips, so there is no per-recycle
-  # blackout. firewall_apply reprograms from the live subnet + mirror IP.
-  if [ "$NETWORK_ISOLATION" = "strict" ] && command -v iptables >/dev/null 2>&1; then
-    local fwrules mip subnet
-    fwrules="$(iptables -w -L DOCKER-USER -n 2>/dev/null)"
-    mip="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$MIRROR_NAME" 2>/dev/null)"
-    # The current runner-network subnet: provision_base above may have RECREATED
-    # $RUNNER_NETWORK (e.g. after a docker network prune) with a fresh auto-allocated
-    # subnet. The existing rules are subnet-scoped (-s <cidr>), so if the live subnet
-    # no longer appears in them the fleet is sitting on a range the DROP rules were
-    # never written for — strict egress is silently unenforced until we reapply.
-    subnet="$(docker network inspect -f '{{range .IPAM.Config}}{{.Subnet}}{{end}}' "$RUNNER_NETWORK" 2>/dev/null)"
-    if ! printf '%s' "$fwrules" | grep -qF "$FW_TAG" \
-       || { [ -n "$mip" ] && ! printf '%s' "$fwrules" | grep -qF "$mip"; } \
-       || { [ -n "$subnet" ] && ! printf '%s' "$fwrules" | grep -qF "$subnet"; }; then
-      log "recycle: (re)applying strict egress rules — firewall state was stale"
-      firewall_apply
+
+  # Add the new GitLab/registry endpoint ahead of the private-range drops while
+  # retaining old endpoint rules for busy stale managers.
+  firewall_prepare_replacement || {
+    echo '{"ok":false,"error":"strict firewall preparation failed"}'; return 1
+  }
+  gitlab_assert_no_orphan_manager_configs || {
+    echo '{"ok":false,"error":"missing GitLab manager identity requires cleanup before recycle"}'; return 1
+  }
+  gitlab_cleanup_orphan_sidecars || {
+    echo '{"ok":false,"error":"could not safely clean orphaned GitLab sidecars"}'; return 1
+  }
+
+  # Validate replacement images before touching the old manager. GitHub can
+  # safely pre-mint its short registration token. GitLab must defer config.toml
+  # generation until the old manager has unregistered against its old config.
+  if [ "$CI_PROVIDER" = gitlab ]; then
+    docker image inspect "$GITLAB_RUNNER_IMAGE" >/dev/null 2>&1 \
+      || host_docker_pull "$GITLAB_RUNNER_IMAGE" >/dev/null 2>&1 \
+      || { echo '{"ok":false,"error":"cannot pull GitLab manager image"}'; return 1; }
+    # Exercise a temporary target-equivalent Docker endpoint, generated TOML,
+    # registry auth/CA, pull policy, and inert job before touching the old slot.
+    # This is intentionally stronger than a host-side image inspection because
+    # GitLab DinD owns its own image store and trust configuration.
+    gitlab_validate \
+      || { echo '{"ok":false,"error":"GitLab replacement validation failed; existing slot was preserved"}'; return 1; }
+    gitlab_verify_manager_token "$name" \
+      || { echo '{"ok":false,"error":"GitLab rejected the replacement runner token/system ID; existing slot was preserved"}'; return 1; }
+    image="$(effective_image)"
+  else
+    # A GitLab manager may drain for up to 24 hours, while a GitHub runner
+    # registration token expires after one hour. Prove the PAT permission now,
+    # but mint the token used by Docker only after the old slot is gone.
+    github_replacement_preflight "$idx" \
+      || { echo '{"ok":false,"error":"cannot verify GitHub replacement permission"}'; return 1; }
+    image="$(effective_image)"
+  fi
+  if ! recycle_image_preflight "$image"; then
+    if [ "$IMAGE_SOURCE" = remote ]; then
+      echo '{"ok":false,"error":"cannot pull replacement image"}'
+    else
+      echo '{"ok":false,"error":"built-in replacement image is unavailable"}'
+    fi
+    return 1
+  fi
+
+  # Replacement preflight may take minutes. Re-resolve both directions without
+  # trusting the mutable name before crossing the destructive boundary. Labels
+  # themselves are immutable for a container ID and were validated above.
+  current_id="$(docker inspect -f '{{.Id}}' "$name" 2>/dev/null || true)"
+  current_name="$(docker inspect -f '{{.Name}}' "$target_id" 2>/dev/null || true)"
+  if [ "$current_id" != "$target_id" ] || [ "$current_name" != "/$name" ]; then
+    echo '{"ok":false,"error":"runner changed during replacement preflight; retry"}'
+    return 1
+  fi
+
+  if ! remove_runner "$name" false "$target_id" "$old_provider"; then
+    echo '{"ok":false,"error":"remove or provider cleanup failed; replacement was not started"}'
+    return 1
+  fi
+
+  # Never start a replacement over a name that an external Docker client claimed
+  # while the old immutable ID was draining or unregistering.
+  if docker inspect "$target_id" >/dev/null 2>&1; then
+    echo '{"ok":false,"error":"remove returned but the original runner still exists"}'; return 1
+  fi
+  current_id="$(docker inspect -f '{{.Id}}' "$name" 2>/dev/null || true)"
+  if [ -n "$current_id" ]; then
+    echo '{"ok":false,"error":"runner name was claimed during replacement; refusing to overwrite it"}'; return 1
+  fi
+
+  log "recycling $name (provider $old_provider -> $CI_PROVIDER)"
+  if [ "$CI_PROVIDER" = gitlab ]; then
+    if ! start_one "$idx"; then
+      echo '{"ok":false,"error":"removed but GitLab replacement failed to start"}'; return 1
+    fi
+  else
+    if ! build_args "$idx"; then
+      echo '{"ok":false,"error":"removed but a fresh GitHub registration token could not be minted"}'; return 1
+    fi
+    if ! docker run "${ARGS[@]}" >/dev/null 2>&1; then
+      echo '{"ok":false,"error":"removed but not recreated"}'; return 1
     fi
   fi
-  # Validate the REPLACEMENT can be fully provisioned BEFORE touching the old
-  # container. build_args assembles everything start_one needs — it mints a fresh
-  # GitHub registration token and resolves the image. A cleared token (no
-  # ACCESS_TOKEN, which build_args silently skips) or a PAT that can no longer mint
-  # one would otherwise let the replacement run unregistered, or fail, only after
-  # the old runner is already gone. Guard the empty-token case explicitly, then
-  # reuse the validated args so the runner we start is the one we vetted.
-  [ -n "$ACCESS_TOKEN" ] || { echo '{"ok":false,"error":"no GitHub token configured"}'; return 1; }
-  build_args "$idx" || { echo '{"ok":false,"error":"cannot provision replacement (check the GitHub token)"}'; return 1; }
-  # Verify the exact target image while the old runner is still intact. A valid
-  # registry login does not prove that a newly configured tag exists, and the
-  # built-in image may have been removed since this runner was started.
-  local image="${ARGS[${#ARGS[@]}-1]}"
-  if [ "$IMAGE_SOURCE" = "remote" ]; then
-    docker pull "$image" >/dev/null 2>&1 || {
-      log "recycle: $name left in place — could not pull replacement image $image"
-      echo '{"ok":false,"error":"cannot pull replacement image"}'; return 1
-    }
-  elif ! docker image inspect "$image" >/dev/null 2>&1; then
-    log "recycle: $name left in place — built-in replacement image $image is unavailable"
-    echo '{"ok":false,"error":"built-in replacement image is unavailable"}'; return 1
-  fi
-  # Stop gracefully first so the runner's inner dockerd can flush its overlay2 /
-  # containerd metadata before removal. The DinD data root ($CACHE_ROOT/docker/$name)
-  # is preserved and reused WARM by the replacement, so a bare SIGKILL (docker rm -f
-  # with no stop) risks handing the new container an unclean data root that fails to
-  # mount. Then force-remove.
-  docker stop -t 30 "$name" >/dev/null 2>&1
-  if ! docker rm -f "$name" >/dev/null 2>&1; then
-    log "recycle: docker rm failed for $name"; echo '{"ok":false,"error":"remove failed"}'; return 1
-  fi
-  deregister_runner_api "$name"
-  log "recycling $name (manual, from fleet page)"
-  if ! docker run "${ARGS[@]}" >/dev/null 2>&1; then
-    log "recycle: $name removed but its replacement failed to start (idx=$idx)"
-    echo '{"ok":false,"error":"removed but not recreated"}'; return 1
+
+  # Verify final state without converting a failed Docker inspect into zero.
+  # A live fleet is finalized additively; obsolete tagged rules are retired only
+  # after Stop leaves no managed runner, so this call can never open a clear/readd
+  # gap underneath the replacement that just started.
+  if [ "$was_stale" = true ] && [ "$NETWORK_ISOLATION" = strict ]; then
+    stale_count="$(count_stale_runners)" \
+      || { echo '{"ok":false,"error":"replacement started, but stale-runner verification failed"}'; return 1; }
+    if [ "$stale_count" -eq 0 ] && ! firewall_apply; then
+      echo '{"ok":false,"error":"replacement started, but strict firewall finalization failed"}'
+      return 1
+    fi
   fi
   echo '{"ok":true}'
 }
 
+cmd_force_forget_gitlab() {
+  local name="$1"
+  # Validate the target before changing fleet-wide daemon state. A stale UI
+  # request or fixed-name collision must be a side-effect-free failure.
+  gitlab_force_forget_target_ready "$name" || return 1
+  boot_autostart_stop || return 1
+  autoscale_stop || return 1
+  imageupdate_stop || return 1
+  reconcile_stop || return 1
+  gitlab_force_forget_local "$name" || return 1
+  log "WARNING: locally forgot $name without contacting GitLab; remove any lingering offline manager from the GitLab UI"
+}
+
+
 cmd_logs_tail() {
-  echo "$1" | grep -qE "^${NAME_PREFIX}-[0-9]+$" || return 1
-  docker logs --tail "${2:-150}" "$1" 2>&1
+  local name="$1" count="${2:-150}" snapshot id rc
+  case "$count" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$count" -ge 1 ] 2>/dev/null && [ "$count" -le 2000 ] 2>/dev/null || return 1
+  snapshot="$(managed_runner_snapshot "$name")" || return 1
+  id="${snapshot%%|*}"
+  docker logs --tail "$count" "$id" 2>&1 | redact_log_stream
+  rc="${PIPESTATUS[0]}"
+  return "$rc"
 }
 
 # base64 a value for the space-delimited cache (empty -> "_" placeholder); _d64 reverses.
@@ -1609,7 +2730,10 @@ cmd_usage_refresh() {
   # out-of-band: batched docker stats (cpu/mem), the unified phase, and — for busy
   # runners — the job context. cmd_status_json then paints from this cache + a single
   # batched inspect, so the hot path no longer runs docker logs/exec per runner.
-  # Line: "name cpu_pct mem_mib phase b64(job) jstarted b64(repo) pr b64(branch) run_id"
+  # Line (all free-form values are base64):
+  # name cpu mem phase job started provider project job_id job_url ref ref_url
+  # repo pr branch run_id. The final four GitHub fields remain for UI/API
+  # compatibility while the provider-neutral fields work for both adapters.
   # Also refresh the status-envelope verdicts here, OFF the poll hot path: cache the
   # cache-root (df) warning and keep the public-repo security cache warm, so
   # cmd_status_json never runs df or the per-repo curls inline (and there's no
@@ -1621,37 +2745,44 @@ cmd_usage_refresh() {
   public_repo_problem > "$RUNDIR/sec.cache" 2>/dev/null
   local names; names="$(managed_names)"
   [ -n "$names" ] || { : > "$RUNDIR/usage.cache"; return 0; }
-  local statsraw
-  # shellcheck disable=SC2086  # $names is intentionally word-split into one arg per runner
-  statsraw="$(docker stats --no-stream --format '{{.Name}}|{{.CPUPerc}}|{{.MemUsage}}' $names 2>/dev/null)"
+  local statsraw stats_targets="" c provider stat_target
+  : > "$RUNDIR/usage.targets.tmp"
+  # GitHub work runs in the managed container itself. In isolated GitLab mode,
+  # work runs under the outer DinD sidecar cgroup, so sidecar stats represent
+  # the aggregate job+services+daemon slot. Host-socket jobs cannot be safely
+  # attributed among managers and intentionally report usage unavailable.
+  for c in $names; do
+    provider="$(container_provider "$c")"
+    stat_target="$("${provider}_usage_stat_target" "$c")"
+    printf '%s %s %s\n' "$c" "$provider" "$stat_target" >> "$RUNDIR/usage.targets.tmp"
+    [ "$stat_target" != _ ] && stats_targets="$stats_targets $stat_target"
+  done
+  # shellcheck disable=SC2086  # stats_targets is a validated container-name list assembled above
+  [ -n "$stats_targets" ] && statsraw="$(docker stats --no-stream --format '{{.Name}}|{{.CPUPerc}}|{{.MemUsage}}' $stats_targets 2>/dev/null)"
   : > "$RUNDIR/usage.cache.tmp"
-  local c
   for c in $names; do
     [ -z "$c" ] && continue
-    local srow cpu="" mem_mib=0
-    srow="$(printf '%s\n' "$statsraw" | grep -m1 -- "^${c}|")"
-    cpu="$(printf '%s' "$srow" | cut -d'|' -f2 | tr -d '%' | grep -oE '^[0-9]+(\.[0-9]+)?' | head -1)"
-    mem_mib="$(to_mib "$(printf '%s' "$srow" | cut -d'|' -f3 | awk -F' / ' '{print $1}')")"
-    local phase; phase="$(runner_state "$c")"
-    local job="" jstarted="_" jrepo="" jpr="_" jbranch="" jrun="_"
-    if [ "$phase" = "busy" ]; then
-      local jline
-      jline="$(docker logs --timestamps --tail 60 "$c" 2>&1 | grep 'Running job: ' | tail -1 | tr -d '\r')"
-      job="${jline##*Running job: }"
-      jstarted="$(echo "$jline" | awk '{print $1}' | grep -oE '^[0-9T:.Z-]+' | head -1)"; jstarted="${jstarted:-_}"
-      local jenv jref
-      jenv="$(docker exec "$c" sh -c 'for p in /proc/[0-9]*/environ; do if tr "\0" "\n" < $p 2>/dev/null | grep -q "^GITHUB_REPOSITORY="; then tr "\0" "\n" < $p | grep -E "^GITHUB_(REPOSITORY|RUN_ID|REF_NAME)="; break; fi; done' 2>/dev/null)"
-      if [ -n "$jenv" ]; then
-        jrepo="$(echo "$jenv" | grep '^GITHUB_REPOSITORY=' | head -1 | cut -d= -f2)"
-        jrun="$(echo "$jenv" | grep '^GITHUB_RUN_ID=' | head -1 | cut -d= -f2 | grep -oE '^[0-9]+' | head -1)"; jrun="${jrun:-_}"
-        jref="$(echo "$jenv" | grep '^GITHUB_REF_NAME=' | head -1 | cut -d= -f2-)"
-        if echo "$jref" | grep -qE '^[0-9]+/merge$'; then jpr="${jref%%/merge*}"; else jbranch="$jref"; fi
-      fi
+    local srow cpu="-1" mem_mib=-1 targetrow phase
+    targetrow="$(grep -m1 -- "^${c} " "$RUNDIR/usage.targets.tmp")"
+    read -r _ provider stat_target <<< "$targetrow"
+    if [ "$stat_target" != _ ]; then
+      srow="$(printf '%s\n' "$statsraw" | grep -m1 -- "^${stat_target}|")"
+      cpu="$(printf '%s' "$srow" | cut -d'|' -f2 | tr -d '%' | grep -oE '^[0-9]+(\.[0-9]+)?' | head -1)"; cpu="${cpu:--1}"
+      [ -n "$srow" ] && mem_mib="$(to_mib "$(printf '%s' "$srow" | cut -d'|' -f3 | awk -F' / ' '{print $1}')")"
     fi
-    printf '%s %s %s %s %s %s %s %s %s %s\n' "$c" "${cpu:-0}" "${mem_mib:-0}" "$phase" \
-      "$(_b64 "$job")" "$jstarted" "$(_b64 "$jrepo")" "$jpr" "$(_b64 "$jbranch")" "$jrun" >> "$RUNDIR/usage.cache.tmp"
+    phase="$(runner_state "$c")"
+    local job="" jstarted="_" project="" job_id="_" job_url="" ref="" ref_url=""
+    local jrepo="" jpr="_" jbranch="" jrun="_"
+    if [ "$phase" = "busy" ]; then
+      "${provider}_usage_context" "$c"
+    fi
+    printf '%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\n' \
+      "$c" "${cpu:-0}" "${mem_mib:-0}" "$phase" "$(_b64 "$job")" "$jstarted" "$provider" \
+      "$(_b64 "$project")" "$job_id" "$(_b64 "$job_url")" "$(_b64 "$ref")" "$(_b64 "$ref_url")" \
+      "$(_b64 "$jrepo")" "$jpr" "$(_b64 "$jbranch")" "$jrun" >> "$RUNDIR/usage.cache.tmp"
   done
   mv "$RUNDIR/usage.cache.tmp" "$RUNDIR/usage.cache" 2>/dev/null
+  rm -f "$RUNDIR/usage.targets.tmp"
 }
 
 cmd_status_json() {
@@ -1680,40 +2811,69 @@ cmd_status_json() {
   fi
   # ONE batched inspect for the whole fleet's live state + cpu/mem limits (perf: was
   # three separate docker inspects per runner). {{.Name}} carries a leading '/'.
-  local inspraw="" cur_gen stalec=0
+  local inspraw="" cur_gen stalec=0 side_names inspect_names
   cur_gen="$(crf_confgen)"
+  side_names="$(docker ps -a --filter 'label=net.unraid.ci-runner-farm.sidecar=true' --format '{{.Names}}' 2>/dev/null)"
+  inspect_names="$names $side_names"
   # shellcheck disable=SC2086  # $names is intentionally word-split into one arg per runner
-  [ -n "$names" ] && inspraw="$(docker inspect -f '{{.Name}}|{{.State.Status}}|{{.HostConfig.NanoCpus}}|{{.HostConfig.Memory}}|{{index .Config.Labels "net.unraid.ci-runner-farm.confgen"}}' $names 2>/dev/null)"
+  [ -n "$names" ] && inspraw="$(docker inspect -f '{{.Name}}|{{.State.Status}}|{{.HostConfig.NanoCpus}}|{{.HostConfig.Memory}}|{{index .Config.Labels "net.unraid.ci-runner-farm.confgen"}}|{{index .Config.Labels "net.unraid.ci-runner-farm.provider"}}' $inspect_names 2>/dev/null)"
   local out="["; local first=1
   for c in $names; do
     [ -z "$c" ] && continue
-    local irow st cpus mem cgen stale=false
+    local irow st cpus mem cgen row_provider stale=false
     # {{.Name}} carries a leading '/', so field 1 is "/name"; split the pipe-delimited
     # inspect row with one read builtin instead of three cut subshells per runner.
     irow="$(printf '%s\n' "$inspraw" | grep -m1 -E "^/?${c}\|")"
-    IFS='|' read -r _ st cpus mem cgen <<< "$irow"
-    # A RUNNING runner whose baked-config fingerprint differs from the current cfg predates
-    # a config change; the reconciler migrates it as it goes idle. Surface the count for the UI.
-    [ "$st" = running ] && [ "$cgen" != "$cur_gen" ] && { stale=true; stalec=$((stalec+1)); }
+    IFS='|' read -r _ st cpus mem cgen row_provider <<< "$irow"
+    [ "$row_provider" = gitlab ] || row_provider=github
+    "${row_provider}_status_resources" "$c" "$inspraw"
+    # Any managed runner whose baked-config fingerprint differs from the current
+    # cfg predates a change. Include stopped fail-closed managers: hiding them
+    # would make the UI claim migration is complete while unregister/retry work
+    # is still outstanding.
+    [ "$cgen" != "$cur_gen" ] && { stale=true; stalec=$((stalec+1)); }
     # phase + cpu/mem usage + job context: all from the background cache line
-    # "name cpu mem phase b64(job) jstarted b64(repo) pr b64(branch) run_id".
-    local urow phase="starting" cpu_pct=-1 mem_used_mib=-1
-    local job="" jstarted="" jrepo="" jpr="" jbranch="" jrun=""
+    # New cache rows contain provider-neutral metadata followed by the legacy
+    # GitHub fields; pre-provider cache rows are accepted for a seamless upgrade.
+    local urow live_provider="$row_provider" phase="starting" cpu_pct=-1 mem_used_mib=-1
+    local job="" jstarted="" project="" job_id="" job_url="" ref="" ref_url=""
+    local jrepo="" jpr="" jbranch="" jrun=""
     urow="$(printf '%s\n' "$usage" | grep -m1 -- "^${c} ")"
     if [ -n "$urow" ]; then
       # shellcheck disable=SC2086  # deliberate positional split of the fixed cache line
       set -- $urow
-      cpu_pct="$2"; mem_used_mib="$3"; phase="$4"
-      job="$(_d64 "$5" | json_escape)"; jstarted="$(_uu "$6")"
-      jrepo="$(_d64 "$7" | json_escape)"; jpr="$(_uu "$8")"
-      jbranch="$(_d64 "$9" | json_escape)"; jrun="$(_uu "${10}")"
+      if { [ "${7:-}" = github ] || [ "${7:-}" = gitlab ]; } \
+         && [ "$#" -ge 16 ] && [ "$7" = "$live_provider" ]; then
+        cpu_pct="$2"; mem_used_mib="$3"; phase="$4"; job="$(_d64 "$5" | json_escape)"; jstarted="$(_uu "$6")"
+        project="$(_d64 "$8" | json_escape)"; job_id="$(_uu "$9")"
+        job_url="$(_d64 "${10}" | json_escape)"; ref="$(_d64 "${11}" | json_escape)"; ref_url="$(_d64 "${12}" | json_escape)"
+        jrepo="$(_d64 "${13}" | json_escape)"; jpr="$(_uu "${14}")"
+        jbranch="$(_d64 "${15}" | json_escape)"; jrun="$(_uu "${16}")"
+      elif [ "${7:-}" != github ] && [ "${7:-}" != gitlab ] \
+           && [ "$live_provider" = github ] && [ "$#" -ge 10 ]; then
+        # Pre-provider cache rows are valid only for live GitHub containers.
+        # Derive the provider-neutral URLs so compatibility consumers receive
+        # the same fields as newly refreshed rows.
+        cpu_pct="$2"; mem_used_mib="$3"; phase="$4"; job="$(_d64 "$5" | json_escape)"; jstarted="$(_uu "$6")"
+        jrepo="$(_d64 "$7" | json_escape)"; jpr="$(_uu "$8")"
+        jbranch="$(_d64 "$9" | json_escape)"; jrun="$(_uu "${10}")"
+        project="$jrepo"; job_id="$jrun"
+        [ -n "$jrepo" ] && [ "$jrun" != _ ] && job_url="https://github.com/$jrepo/actions/runs/$jrun"
+        if [ "$jpr" != _ ] && [ -n "$jpr" ]; then
+          ref="PR #$jpr"; ref_url="https://github.com/$jrepo/pull/$jpr"
+        else
+          ref="$jbranch"
+          [ -n "$jrepo" ] && [ -n "$jbranch" ] && ref_url="https://github.com/$jrepo/tree/$(urlencode "$jbranch")"
+        fi
+      fi
     fi
     case "$cpu_pct" in ''|*[!0-9.-]*) cpu_pct=-1 ;; esac
     case "$mem_used_mib" in ''|*[!0-9-]*) mem_used_mib=-1 ;; esac
     case "$jpr" in *[!0-9]*) jpr="" ;; esac
     case "$jrun" in *[!0-9]*) jrun="" ;; esac
+    case "$job_id" in *[!0-9]*) job_id="" ;; esac
     [ $first -eq 0 ] && out+=","
-    out+="{\"name\":\"$(echo "$c"|json_escape)\",\"state\":\"${st:-unknown}\",\"phase\":\"$phase\",\"job\":\"${job}\",\"job_started\":\"${jstarted}\",\"repo\":\"${jrepo}\",\"pr\":\"${jpr}\",\"branch\":\"${jbranch}\",\"run_id\":\"${jrun}\",\"cpus\":$(( ${cpus:-0}/1000000000 )),\"mem_gb\":$(( ${mem:-0}/1024/1024/1024 )),\"cpu_pct\":${cpu_pct:-0},\"mem_used_mib\":${mem_used_mib:-0},\"stale\":${stale}}"
+    out+="{\"name\":\"$(echo "$c"|json_escape)\",\"provider\":\"$row_provider\",\"state\":\"${st:-unknown}\",\"phase\":\"$phase\",\"job\":\"${job}\",\"job_started\":\"${jstarted}\",\"project\":\"${project}\",\"job_id\":\"${job_id}\",\"job_url\":\"${job_url}\",\"ref\":\"${ref}\",\"ref_url\":\"${ref_url}\",\"repo\":\"${jrepo}\",\"pr\":\"${jpr}\",\"branch\":\"${jbranch}\",\"run_id\":\"${jrun}\",\"cpus\":$(( ${cpus:-0}/1000000000 )),\"mem_gb\":$(( ${mem:-0}/1024/1024/1024 )),\"cpu_pct\":${cpu_pct:-0},\"mem_used_mib\":${mem_used_mib:-0},\"stale\":${stale}}"
     first=0
   done
   out+="]"
@@ -1724,7 +2884,7 @@ cmd_status_json() {
   # public_repo_problem inline here: on a cold/expired cache that would run the
   # per-repo GitHub curls on the poll's own response path and stall it.
   local sec; sec="$(cat "$RUNDIR/sec.cache" 2>/dev/null | json_escape)"
-  echo "{\"count\":$(echo "$names" | grep -c . ),\"configured\":${RUNNER_COUNT},\"token\":$([ -n "$ACCESS_TOKEN" ] && echo true || echo false),\"autoscale\":\"${as} [${AUTOSCALE_MIN}-${AUTOSCALE_MAX}, buffer ${AUTOSCALE_MIN_IDLE}]\",\"image_autoupdate\":\"$(echo "$iu" | json_escape)\",\"warning\":\"${warn}\",\"security\":\"${sec}\",\"stale\":${stalec},\"runners\":${out}}"
+  echo "{\"provider\":\"$CI_PROVIDER\",\"count\":$(echo "$names" | grep -c . ),\"configured\":${RUNNER_COUNT},\"token\":$(provider_token_ready && echo true || echo false),\"autoscale\":\"${as} [${AUTOSCALE_MIN}-${AUTOSCALE_MAX}, buffer ${AUTOSCALE_MIN_IDLE}]\",\"image_autoupdate\":\"$(echo "$iu" | json_escape)\",\"warning\":\"${warn}\",\"security\":\"${sec}\",\"stale\":${stalec},\"runners\":${out}}"
 }
 
 # Aggregate-only status for the Main -> Dashboard nchan widget: {count,up,busy,idle}.
@@ -1756,41 +2916,20 @@ cmd_dashboard_json() {
   printf '{"count":%s,"up":%s,"busy":%s,"idle":%s}\n' "$(printf '%s\n' "$names" | grep -c .)" "$up" "$busy" "$idle"
 }
 
-cmd_logs() { docker logs --tail "${2:-100}" -f "${NAME_PREFIX}-${1:-1}"; }
-
-cmd_validate() {
-  # Prove the provisioning mechanics WITHOUT a GitHub token: launch the image
-  # with an inert entrypoint, verify mounts/limits, then tear it down.
-  check_cache_root || return 1
-  ensure_dirs
-  registry_login
-  local name="${NAME_PREFIX}-validate"
-  docker rm -f "$name" >/dev/null 2>&1
-  local NO_REGISTER=1               # validate swaps the entrypoint for a sleep — never registers
-  build_args 99 "$name"
-  # swap real entrypoint for an inert sleep so no registration is attempted
-  local injected=(); local a; local eimg; eimg="$(effective_image)"
-  for a in "${ARGS[@]}"; do
-    [ "$a" = "$eimg" ] && injected+=( --entrypoint /bin/sh "$eimg" -c "sleep 30" ) || injected+=( "$a" )
-  done
-  log "validate: launching inert container to verify mounts/limits..."
-  local errf; errf="$(mktemp /tmp/crf-validate.XXXXXX)"
-  if ! docker run "${injected[@]}" >/dev/null 2>"$errf"; then
-    err "docker run failed:"; cat "$errf" >&2; rm -f "$errf"; return 1
-  fi
-  rm -f "$errf"
-  echo "--- resource limits ---"
-  docker inspect -f 'cpus={{.HostConfig.NanoCpus}} mem={{.HostConfig.Memory}} pids={{.HostConfig.PidsLimit}}' "$name"
-  echo "--- mounts ---"
-  docker inspect -f '{{range .Mounts}}{{.Source}} -> {{.Destination}}{{println}}{{end}}' "$name"
-  echo "--- tmpfs ---"
-  docker inspect -f '{{json .HostConfig.Tmpfs}}' "$name"
-  echo "--- docker.sock reachable inside container ---"
-  docker exec "$name" sh -c '[ -S /var/run/docker.sock ] && echo "yes: docker.sock present" || echo "no socket"' 2>/dev/null
-  docker rm -f "$name" >/dev/null 2>&1
-  [ -n "$name" ] && [ -n "$CACHE_ROOT" ] && rm -rf "$CACHE_ROOT/docker/$name" 2>/dev/null || true
-  log "validate: OK (container removed). Provisioning mechanics verified on this host."
+cmd_logs() {
+  local index="${1:-1}" count="${2:-100}" name snapshot id rc
+  case "$index:$count" in *[!0-9:]*) return 1 ;; esac
+  [ "$index" -ge 1 ] 2>/dev/null && [ "$count" -ge 1 ] 2>/dev/null \
+    && [ "$count" -le 2000 ] 2>/dev/null || return 1
+  name="${NAME_PREFIX}-${index}"
+  snapshot="$(managed_runner_snapshot "$name")" || return 1
+  id="${snapshot%%|*}"
+  docker logs --tail "$count" -f "$id" 2>&1 | redact_log_stream
+  rc="${PIPESTATUS[0]}"
+  return "$rc"
 }
+
+cmd_validate() { provider_call validate; }
 
 # Clear the plugin's caches under CACHE_ROOT. Two independent safeguards: (1) the
 # root must pass crf_safe_cache_root — a dedicated subdir under a pool/disk, never a
@@ -1804,9 +2943,21 @@ cmd_prune_cache() {
   # NEVER a bare "$root"/* glob: even if CACHE_ROOT is somehow mis-pointed at a
   # shared location, prune then cannot wipe unrelated data (appdata, VMs, other
   # shares) that happens to sit alongside our subdirs on the same pool.
-  local root d m dirs removed=0
+  local root d m dirs removed=0 active
+  active="$(docker ps -a --filter 'label=net.unraid.ci-runner-farm.managed=true' --format '{{.Names}}' 2>/dev/null)" \
+    || { err "cannot verify managed runners before pruning cache"; return 1; }
+  [ -z "$active" ] \
+    || { err "refusing to prune cache while runner/validation containers exist; Stop the fleet and finish Validate first"; return 1; }
+  active="$(docker ps -a --filter 'label=net.unraid.ci-runner-farm.sidecar=true' --format '{{.Names}}' 2>/dev/null)" \
+    || { err "cannot verify GitLab sidecars before pruning cache"; return 1; }
+  [ -z "$active" ] \
+    || { err "refusing to prune cache while GitLab sidecars exist; complete Stop/Force forget first"; return 1; }
+  active="$(docker ps -a --filter 'label=com.gitlab.gitlab-runner.managed=true' --filter 'label=net.unraid.ci-runner-farm.provider=gitlab' --format '{{.Names}}' 2>/dev/null)" \
+    || { err "cannot verify host-socket GitLab executor containers before pruning cache"; return 1; }
+  [ -z "$active" ] \
+    || { err "refusing to prune cache while GitLab executor containers exist"; return 1; }
   root="$(crf_safe_cache_root)" || { err "refusing to prune-cache: CACHE_ROOT='$CACHE_ROOT' is unsafe (system dir, share/pool root, or unresolvable — point it at /mnt/<pool>/<subdir>)"; return 1; }
-  dirs="docker work dind-logs registry-mirror $CACHE_PKG_DIRS"
+  dirs="docker work dind-logs gitlab-cache gitlab-sockets registry-mirror $CACHE_PKG_DIRS"
   for m in $CACHE_MOUNTS; do dirs="$dirs ${m%%:*}"; done
   for d in $dirs; do
     case "$d" in ''|.|..|*/*) continue ;; esac   # simple child names only — never a path/traversal
@@ -1850,7 +3001,7 @@ cmd_build_async() {
 # from the __BUILD_RC__ sentinel only once the build is no longer running.
 cmd_build_status() {
   local log="$RUNDIR/build.log" txt running rc n disp
-  txt="$([ -f "$log" ] && tail -n 120 "$log")"
+  txt="$([ -f "$log" ] && tail -n 120 "$log" | redact_log_stream)"
   if pgrep -f '[r]unner-farm.sh build-image' >/dev/null 2>&1; then running=true; else running=false; fi
   rc=null
   if [ "$running" = false ]; then
@@ -1866,23 +3017,27 @@ cmd_build_status() {
 cmd_farm_log() {
   local as="$RUNDIR/autoscale.log" bt="$CFGDIR/boot.log" src txt
   src="$as"; [ -f "$as" ] || src="$bt"
-  txt="$([ -f "$src" ] && tail -n 150 "$src" | grep -v 'swap limit capabilities' | tail -n 60)"
+  txt="$([ -f "$src" ] && tail -n 150 "$src" | grep -v 'swap limit capabilities' | tail -n 60 | redact_log_stream)"
   printf '{"ok":true,"log":%s}\n' "$(printf '%s' "$txt" | json_string)"
 }
 
 cmd_build_image() {
   # Build the runner image from the editable Dockerfile. Uses a CLEAN temp
   # context (only the Dockerfile) so the token/config never enter the build.
-  local df="$CFGDIR/Dockerfile"
-  [ -f "$df" ] || df="/usr/local/emhttp/plugins/$PLUGIN/default.Dockerfile"
+  local df="$CFGDIR/Dockerfile.$CI_PROVIDER" tag
+  # Upgrade compatibility: an existing unsuffixed Dockerfile remains the GitHub
+  # editor source until build-plg.sh migrates it to Dockerfile.github.
+  [ "$CI_PROVIDER" = github ] && [ ! -f "$df" ] && [ -f "$CFGDIR/Dockerfile" ] && df="$CFGDIR/Dockerfile"
+  [ -f "$df" ] || df="/usr/local/emhttp/plugins/$PLUGIN/default.$CI_PROVIDER.Dockerfile"
   [ -f "$df" ] || { err "no Dockerfile found"; return 1; }
+  tag="$(builtin_image)"
   local ctx; ctx="$(mktemp -d)"
   cp "$df" "$ctx/Dockerfile"
-  log "building image '$BUILTIN_IMAGE' from $df"
-  docker build -t "$BUILTIN_IMAGE" "$ctx"; local rc=$?
+  log "building $CI_PROVIDER image '$tag' from $df"
+  docker build -t "$tag" "$ctx"; local rc=$?
   rm -rf "$ctx"
   if [ $rc -eq 0 ]; then
-    log "build complete: $BUILTIN_IMAGE — set Image source to Built-in and restart the fleet to use it"
+    log "build complete: $tag — set Image source to Built-in and restart/reconcile the $CI_PROVIDER fleet to use it"
   else
     err "build failed (rc=$rc)"
   fi
@@ -1899,7 +3054,11 @@ cmd_build_image() {
 # ones, and (re)starts the autoscale daemon, so the fleet self-heals after a
 # reboot OR a Docker restart.
 cmd_boot_autostart() {
-  [ -n "$ACCESS_TOKEN" ] || { log "boot-autostart: no token configured yet — skipping"; return 0; }
+  ( umask 077; printf '%s\n' "$$" > "$BOOT_AUTOSTART_PID" ) \
+    || { err "boot-autostart: could not publish worker PID"; return 1; }
+  trap 'rm -f "$BOOT_AUTOSTART_PID" 2>/dev/null || true' EXIT
+  trap 'rm -f "$BOOT_AUTOSTART_PID" 2>/dev/null || true; exit 0' HUP INT TERM
+  provider_token_ready || { log "boot-autostart: no valid $(provider_token_name) configured yet — skipping"; return 0; }
   local i
   for i in $(seq 1 150); do
     docker info >/dev/null 2>&1 && check_cache_root >/dev/null 2>&1 && break
@@ -1915,9 +3074,94 @@ cmd_boot_autostart() {
   with_fleet_lock wait cmd_start
 }
 
+boot_autostart_stop() {
+  stop_worker_group "boot-autostart" "$BOOT_AUTOSTART_PID" '[r]unner-farm.sh boot-autostart'
+}
+
+# Unraid invokes event/stopping_docker before it stops the Docker service. A
+# GitLab manager's SIGQUIT drain is useful only while its per-slot DinD daemon
+# is still alive: once that privileged sidecar disappears, the active job and
+# helper containers disappear with it. Stop every running GitLab manager in
+# parallel here so all of them stop accepting work immediately and can finish
+# against their still-live sidecars. Leave managers, sidecars, config.toml, and
+# system IDs in place; docker_started restarts the same identities afterward.
+# GitHub containers are deliberately untouched, preserving their existing
+# Docker-service event behavior.
+cmd_docker_stopping_locked() {
+  local c timeout pids="" pid failed=0 count=0 names snapshot id provider role index gen
+  names="$(managed_names)" || return 1
+  for c in $names; do
+    [ -n "$c" ] || continue
+    snapshot="$(managed_runner_snapshot "$c")" || return 1
+    IFS='|' read -r id provider role index gen <<< "$snapshot"
+    timeout="$("${provider}_docker_stopping_timeout" "$id")"
+    case "$timeout" in ''|*[!0-9]*) timeout=0 ;; esac
+    [ "$timeout" -gt 0 ] || continue
+    if ! docker inspect -f '{{.State.Running}}' "$id" 2>/dev/null | grep -qx true; then
+      docker inspect "$id" >/dev/null 2>&1 \
+        || { err "docker shutdown: could not inspect owned manager $c"; return 1; }
+      continue
+    fi
+    count=$((count+1))
+    log "docker shutdown: gracefully quiescing $provider manager $c"
+    provider_stop_owned_runner "$c" "$id" "$provider" &
+    pids="$pids $!"
+  done
+  for pid in $pids; do wait "$pid" || failed=1; done
+  if [ "$failed" -ne 0 ]; then
+    err "docker shutdown: one or more GitLab managers could not be quiesced"
+    return 1
+  fi
+  [ "$count" -eq 0 ] || log "docker shutdown: $count GitLab manager(s) quiesced; preserving their local identities for restart"
+}
+
+cmd_docker_stopping() {
+  boot_autostart_stop || return 1
+  autoscale_stop || return 1
+  imageupdate_stop || return 1
+  reconcile_stop || return 1
+
+  # Avoid changing the legacy GitHub-only event path beyond stopping its two
+  # host daemons. During a provider transition, however, a stale GitLab manager
+  # still needs the pre-stop drain even when CI_PROVIDER already says github.
+  local c timeout lock_wait=0 names snapshot id provider role index gen
+  names="$(managed_names)" || return 1
+  for c in $names; do
+    snapshot="$(managed_runner_snapshot "$c")" || return 1
+    IFS='|' read -r id provider role index gen <<< "$snapshot"
+    timeout="$("${provider}_docker_stopping_timeout" "$id")"
+    case "$timeout" in ''|*[!0-9]*) timeout=0 ;; esac
+    [ "$timeout" -gt "$lock_wait" ] && lock_wait="$timeout"
+  done
+
+  # Always acquire the fleet lock, even when the first snapshot is GitHub-only.
+  # A concurrent Start may be holding it and can spawn a GitLab manager/worker
+  # after the pre-lock stop calls. Re-stop every creator under the lock, then
+  # enumerate the authoritative post-lock fleet through immutable snapshots.
+  lock_wait=$((lock_wait + 60))
+  ( flock -w "$lock_wait" 8 || {
+      err "docker shutdown: fleet mutation did not release its lock in time"
+      exit 1
+    }
+    reload_locked_snapshot || exit 1
+    boot_autostart_stop || exit 1
+    autoscale_stop || exit 1
+    imageupdate_stop || exit 1
+    reconcile_stop || exit 1
+    cmd_docker_stopping_locked
+  ) 8>"$RUNDIR/fleet.lock"
+}
+
+# Test harnesses may source the engine to exercise adapter functions with
+# mocked Docker/curl endpoints. Production execution never sets this flag.
+if [ "${CRF_SOURCE_ONLY:-0}" = 1 ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
 case "${1:-status}" in
   start)        with_fleet_lock wait cmd_start ;;
   boot-autostart)   cmd_boot_autostart ;;
+  docker-stopping)  cmd_docker_stopping ;;
   stop)         with_fleet_lock wait cmd_stop ;;
   restart)      with_fleet_lock wait cmd_restart ;;
   mirror-up)    with_fleet_lock wait cmd_mirror_up ;;
@@ -1935,25 +3179,29 @@ case "${1:-status}" in
   stats-json)   cmd_stats_json ;;
   stats-refresh) cmd_stats_refresh ;;
   recycle)      with_fleet_lock wait cmd_recycle "${2:?usage: recycle <name>}" ;;
-  reconcile-config) cmd_reconcile_config ;;
+  force-forget-gitlab) with_fleet_lock wait cmd_force_forget_gitlab "${2:?usage: force-forget-gitlab <name>}" ;;
+  reconcile-config) with_fleet_lock wait cmd_reconcile_config ;;
   reconcile-drain)  ( flock -w 5 7 || { echo "reconcile: a drain is already running (it re-reads the cfg each pass and will pick up this change) — skipping duplicate" >>"$RUNDIR/autoscale.log"; exit 0; }; cmd_reconcile_drain ) 7>"$RUNDIR/reconcile.lock" ;;
   logs-tail)    cmd_logs_tail "${2:?usage: logs-tail <name> [n]}" "${3:-150}" ;;
   logs)         cmd_logs "${2:-1}" "${3:-100}" ;;
-  validate)         cmd_validate ;;
+  validate)         with_fleet_lock wait cmd_validate ;;
   build-image)      cmd_build_image ;;
   build-async)      cmd_build_async ;;
   build-status)     cmd_build_status ;;
   farm-log)         cmd_farm_log ;;
-  prune-cache)      cmd_prune_cache ;;
+  prune-cache)      with_fleet_lock wait cmd_prune_cache ;;
   autoscale-daemon) autoscale_daemon ;;
-  autoscale-tick)   autoscale_tick ;;
+  autoscale-tick)   with_fleet_lock wait autoscale_tick ;;
   autoscale-start)  autoscale_start ;;
   autoscale-stop)   autoscale_stop ;;
   autoscale-status) autoscale_status ;;
   imageupdate-daemon) imageupdate_daemon ;;
-  imageupdate-tick)   imageupdate_tick ;;
+  imageupdate-tick)   with_fleet_lock wait imageupdate_tick ;;
   imageupdate-start)  imageupdate_start ;;
   imageupdate-stop)   imageupdate_stop ;;
   imageupdate-status) imageupdate_status ;;
-  *) echo "usage: $0 {start|boot-autostart|stop|restart|scale N|status|status-json|logs i|validate|build-image|prune-cache|autoscale-tick|autoscale-start|autoscale-stop|autoscale-status|imageupdate-tick|imageupdate-start|imageupdate-stop|imageupdate-status}"; exit 1 ;;
+  credential-clear-github-token) with_fleet_lock wait cmd_credential_clear_github_token ;;
+  credential-clear-gitlab-runner) with_fleet_lock wait cmd_credential_clear_gitlab_runner "${2:-0}" ;;
+  credential-clear-registry-token) with_fleet_lock wait cmd_credential_clear_registry_token ;;
+  *) echo "usage: $0 {start|boot-autostart|docker-stopping|stop|restart|scale N|recycle NAME|force-forget-gitlab NAME|status|status-json|logs i|validate|build-image|prune-cache|autoscale-tick|autoscale-start|autoscale-stop|autoscale-status|imageupdate-tick|imageupdate-start|imageupdate-stop|imageupdate-status}"; exit 1 ;;
 esac

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Full repository check used by GitHub Actions and the containerized local runner.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+RUNTIME="src/usr/local/emhttp/plugins/ci-runner-farm"
+
+echo "== Shell syntax =="
+while IFS= read -r file; do
+  echo "bash -n $file"
+  bash -n "$file"
+done < <(find . -path './.git' -prune -o -type f -name '*.sh' -print | sort)
+while IFS= read -r file; do
+  case "$(head -1 "$file" 2>/dev/null)" in
+    '#!'*sh*) echo "bash -n $file"; bash -n "$file" ;;
+  esac
+done < <(find "$RUNTIME/event" "$RUNTIME/nchan" -type f -print | sort)
+
+echo "== PHP syntax =="
+command -v php >/dev/null 2>&1 || {
+  echo "php is required; run ./tests/run-linux-checks.sh for the bundled Linux environment" >&2
+  exit 1
+}
+while IFS= read -r file; do
+  grep -q '<?php' "$file" || continue
+  echo "php -l $file"
+  php -l "$file" >/dev/null
+done < <(find "$RUNTIME" -type f \( -name '*.php' -o -name '*.page' \) -print | sort)
+
+echo "== Contracts and package =="
+bash tests/config-parity.sh
+bash tests/safe-paths.sh
+bash tests/provider-contract.sh
+bash tests/exec-csrf.sh
+bash tests/provider-mocks.sh
+bash tests/ownership-safety.sh
+bash tests/resource-ownership.sh
+bash tests/gitlab-policy.sh
+bash tests/firewall-transition.sh
+bash tests/deploy-uninstall-safety.sh
+bash tests/install-dev-safety.sh
+bash tests/release-guard.sh
+bash tests/package-contents.sh
+bash tests/dev-package.sh
+
+echo "All repository checks passed."

--- a/tests/config-parity.sh
+++ b/tests/config-parity.sh
@@ -38,6 +38,16 @@ parse_val() {
 
 declare -A ENG CFGV UIV
 
+# Unraid parses every shipped default.cfg with PHP before merging the saved
+# plugin config. PHP's INI scanner accepts `;` comments, not shell-style `#`
+# comments on current Unraid releases; catch a file that is textually correct
+# for the shell tests but unusable by the webGUI.
+command -v php >/dev/null 2>&1 || bad "php is required to validate default.cfg"
+if command -v php >/dev/null 2>&1 \
+   && ! php -r '$v = parse_ini_file($argv[1]); exit(is_array($v) ? 0 : 1);' "$CFG"; then
+  bad "default.cfg is not valid for PHP parse_ini_file (and therefore Unraid parse_plugin_cfg)"
+fi
+
 # --- engine defaults: the block from the "# ---- defaults" header to its closing
 #     pure-dashes divider (the "# ---- image auto-update ----" sub-header has text,
 #     so only the final all-dashes line matches and bounds the block) ---
@@ -47,7 +57,7 @@ done < <(awk '/^# ---- defaults/{f=1;next} f&&/^# -+$/{exit} f' "$ENGINE")
 
 # --- default.cfg (plain KEY="value") ---
 while IFS= read -r line; do
-  case "$line" in \#*|'') continue ;; [A-Z_]*=*) CFGV["${line%%=*}"]="$(parse_val "$line")" ;; esac
+  case "$line" in \#*|\;*|'') continue ;; [A-Z_]*=*) CFGV["${line%%=*}"]="$(parse_val "$line")" ;; esac
 done < "$CFG"
 
 # --- UI $defaults array ('KEY'=>'VALUE') ---

--- a/tests/config-parity.sh
+++ b/tests/config-parity.sh
@@ -42,9 +42,9 @@ declare -A ENG CFGV UIV
 # plugin config. PHP's INI scanner accepts `;` comments, not shell-style `#`
 # comments on current Unraid releases; catch a file that is textually correct
 # for the shell tests but unusable by the webGUI.
-command -v php >/dev/null 2>&1 || bad "php is required to validate default.cfg"
-if command -v php >/dev/null 2>&1 \
-   && ! php -r '$v = parse_ini_file($argv[1]); exit(is_array($v) ? 0 : 1);' "$CFG"; then
+if ! command -v php >/dev/null 2>&1; then
+  bad "php is required to validate default.cfg"
+elif ! php -r '$v = parse_ini_file($argv[1]); exit(is_array($v) ? 0 : 1);' "$CFG"; then
   bad "default.cfg is not valid for PHP parse_ini_file (and therefore Unraid parse_plugin_cfg)"
 fi
 

--- a/tests/deploy-uninstall-safety.sh
+++ b/tests/deploy-uninstall-safety.sh
@@ -8,7 +8,7 @@ DEPLOY="deploy.sh"
 BUILD="build-plg.sh"
 
 fail() { printf 'DEPLOY/UNINSTALL SAFETY FAIL: %s\n' "$*" >&2; exit 1; }
-first_line() { grep -nF -- "$2" "$1" | head -1 | cut -d: -f1; }
+first_line() { grep -nF -- "$2" "$1" | head -1 | cut -d: -f1 || true; }
 
 lock_line="$(first_line "$DEPLOY" 'flock -w 20 8')"
 manager_check_line="$(first_line "$DEPLOY" 'owned_managers="$(docker ps -a')"
@@ -24,6 +24,25 @@ grep -qF 'COPYFILE_DISABLE=1 tar --no-xattrs -C "$SRC" -cf - .' "$DEPLOY" \
   || fail "deploy does not suppress macOS AppleDouble metadata at the source"
 grep -qF "find \"\$stage\" -name '._*' -print" "$DEPLOY" \
   || fail "deploy does not reject AppleDouble metadata in the staged runtime"
+grep -qF 'remote_stage_suffix="${REMOTE_STAGE#"$DEST".deploy.}"' "$DEPLOY" \
+  && grep -qF 'stage_suffix="${stage#"$dest".deploy.}"' "$DEPLOY" \
+  && [ "$(grep -cF "''|*[!A-Za-z0-9]*)" "$DEPLOY" || true)" -eq 2 ] \
+  || fail "deploy does not require a nonempty alphanumeric staging suffix locally and remotely"
+for executable_tree in nchan event; do
+  grep -qxF "find \"\$stage/$executable_tree\" -type f -exec chmod 0755 {} +" "$DEPLOY" \
+    || fail "deploy does not propagate $executable_tree permission failures"
+done
+grep -qF 'trap rollback ERR' "$DEPLOY" \
+  && grep -qF 'if [ "$#" -gt 0 ]; then status="$1"; fi' "$DEPLOY" \
+  || fail "deploy rollback does not preserve ERR status separately from signals"
+for signal_trap in \
+  "trap 'rollback 129' HUP" \
+  "trap 'rollback 130' INT" \
+  "trap 'rollback 143' TERM"
+do
+  grep -qF "$signal_trap" "$DEPLOY" \
+    || fail "deploy rollback lacks nonzero signal status: $signal_trap"
+done
 if sed -n "${lock_line},${swap_line}p" "$DEPLOY" | grep -F 'flock -u 8' >/dev/null; then
   fail "deploy releases fleet.lock before the staged tree swap"
 fi
@@ -125,9 +144,11 @@ printf '%s\n' "$remove_block" | grep -qF 'if ! rm -rf -- "\$PLGDIR" || [ -e "\$P
 printf '%s\n' "$remove_block" | grep -qF 'if ! rm -f -- "\$CFGDIR"/${NAME}-*.tgz; then' \
   || fail "plugin remove action does not fail on cached-package deletion"
 
-runtime_delete_line="$(printf '%s\n' "$remove_block" | grep -nF 'if ! rm -rf -- "\$PLGDIR"' | head -1 | cut -d: -f1)"
-package_delete_line="$(printf '%s\n' "$remove_block" | grep -nF 'if ! rm -f -- "\$CFGDIR"/${NAME}-*.tgz' | head -1 | cut -d: -f1)"
-success_line="$(printf '%s\n' "$remove_block" | grep -nF 'ci-runner-farm removed. Config + credentials left' | head -1 | cut -d: -f1)"
+runtime_delete_line="$(printf '%s\n' "$remove_block" | grep -nF 'if ! rm -rf -- "\$PLGDIR"' | head -1 | cut -d: -f1 || true)"
+package_delete_line="$(printf '%s\n' "$remove_block" | grep -nF 'if ! rm -f -- "\$CFGDIR"/${NAME}-*.tgz' | head -1 | cut -d: -f1 || true)"
+success_line="$(printf '%s\n' "$remove_block" | grep -nF 'ci-runner-farm removed. Config + credentials left' | head -1 | cut -d: -f1 || true)"
+[ -n "$runtime_delete_line" ] && [ -n "$package_delete_line" ] && [ -n "$success_line" ] \
+  || fail "could not locate runtime deletion, cached-package deletion, and uninstall success"
 [ "$runtime_delete_line" -lt "$success_line" ] && [ "$package_delete_line" -lt "$success_line" ] \
   || fail "plugin remove action can announce success before cleanup completes"
 

--- a/tests/deploy-uninstall-safety.sh
+++ b/tests/deploy-uninstall-safety.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Static safety contracts for the development deploy transaction and generated
+# Unraid uninstall action. Package-output assertions live in package-contents.sh.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+DEPLOY="deploy.sh"
+BUILD="build-plg.sh"
+
+fail() { printf 'DEPLOY/UNINSTALL SAFETY FAIL: %s\n' "$*" >&2; exit 1; }
+first_line() { grep -nF -- "$2" "$1" | head -1 | cut -d: -f1; }
+
+lock_line="$(first_line "$DEPLOY" 'flock -w 20 8')"
+manager_check_line="$(first_line "$DEPLOY" 'owned_managers="$(docker ps -a')"
+swap_line="$(first_line "$DEPLOY" 'mv "$stage" "$dest"')"
+[ -n "$lock_line" ] && [ -n "$manager_check_line" ] && [ -n "$swap_line" ] \
+  || fail "could not locate deploy lock, inactive-state check, and tree swap"
+[ "$lock_line" -lt "$manager_check_line" ] && [ "$manager_check_line" -lt "$swap_line" ] \
+  || fail "deploy does not hold fleet.lock across inactive-state verification and tree swap"
+
+grep -qF 'exec 8>"$rundir/fleet.lock"' "$DEPLOY" \
+  || fail "deploy does not open the engine-compatible fleet lock"
+grep -qF 'COPYFILE_DISABLE=1 tar --no-xattrs -C "$SRC" -cf - .' "$DEPLOY" \
+  || fail "deploy does not suppress macOS AppleDouble metadata at the source"
+grep -qF "find \"\$stage\" -name '._*' -print" "$DEPLOY" \
+  || fail "deploy does not reject AppleDouble metadata in the staged runtime"
+if sed -n "${lock_line},${swap_line}p" "$DEPLOY" | grep -F 'flock -u 8' >/dev/null; then
+  fail "deploy releases fleet.lock before the staged tree swap"
+fi
+grep -qF "docker ps -a" "$DEPLOY" || fail "deploy does not inspect stopped Docker objects"
+if grep -qF "docker ps -q --filter 'label=net.unraid.ci-runner-farm.managed=true'" "$DEPLOY"; then
+  fail "deploy still checks only running managers"
+fi
+for label in \
+  'label=net.unraid.ci-runner-farm.managed=true' \
+  'label=net.unraid.ci-runner-farm.sidecar=true' \
+  'label=net.unraid.ci-runner-farm.role=dind' \
+  'label=com.gitlab.gitlab-runner.managed=true' \
+  'label=net.unraid.ci-runner-farm.provider=gitlab' \
+  'label=net.unraid.ci-runner-farm.slot' \
+  'label=net.unraid.ci-runner-farm.resource=true' \
+  'label=net.unraid.ci-runner-farm.role=mirror' \
+  'label=net.unraid.ci-runner-farm.provider=github' \
+  'label=net.unraid.ci-runner-farm.role=validate' \
+  'label=net.unraid.ci-runner-farm.role=validate-job'
+do
+  grep -qF "$label" "$DEPLOY" || fail "deploy ownership scan is missing $label"
+done
+mirror_block="$(sed -n '/^owned_mirrors="$(docker ps -a/,/^}/p' "$DEPLOY")"
+printf '%s\n' "$mirror_block" | grep -qF "'label=net.unraid.ci-runner-farm.resource=true'" \
+  && printf '%s\n' "$mirror_block" | grep -qF "'label=net.unraid.ci-runner-farm.role=mirror'" \
+  || fail "deploy mirror scan does not require the complete owned resource/role contract"
+github_validation_block="$(sed -n '/^owned_github_validations="$(docker ps -a/,/^}/p' "$DEPLOY")"
+for label in \
+  "'label=net.unraid.ci-runner-farm.managed=true'" \
+  "'label=net.unraid.ci-runner-farm.provider=github'" \
+  "'label=net.unraid.ci-runner-farm.role=validate'"
+do
+  printf '%s\n' "$github_validation_block" | grep -qF "$label" \
+    || fail "deploy GitHub validation scan is missing exact contract label $label"
+done
+gitlab_validation_block="$(sed -n '/^owned_gitlab_validations="$(docker ps -a/,/^}/p' "$DEPLOY")"
+for label in \
+  "'label=net.unraid.ci-runner-farm.provider=gitlab'" \
+  "'label=net.unraid.ci-runner-farm.role=validate-job'" \
+  "'label=net.unraid.ci-runner-farm.slot'"
+do
+  printf '%s\n' "$gitlab_validation_block" | grep -qF "$label" \
+    || fail "deploy GitLab validation scan is missing exact contract label $label"
+done
+for owned in owned_mirrors owned_legacy_mirrors owned_github_validations owned_gitlab_validations; do
+  sed -n "${manager_check_line},${swap_line}p" "$DEPLOY" | grep -F '[ -n "$'"$owned"'" ]' >/dev/null \
+    || fail "deploy inactive decision ignores $owned"
+done
+for provenance in \
+  "legacy_name\" = /ci-runner-mirror" \
+  "legacy_image\" = registry:2" \
+  'legacy_source" = "$legacy_cache_root/registry-mirror"' \
+  'REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io'
+do
+  grep -qF "$provenance" "$DEPLOY" \
+    || fail "deploy legacy mirror recognition is missing provenance check: $provenance"
+done
+grep -qF "printf '%s\\n' \"\$all_container_names\" | grep -qxF 'ci-runner-mirror'" "$DEPLOY" \
+  || fail "deploy does not distinguish an absent mirror from an inspect failure"
+for failure in \
+  'Docker CLI is unavailable; cannot prove the fleet is inactive' \
+  'cannot enumerate CI Runner Farm managers; refusing deployment' \
+  'cannot enumerate GitLab DinD sidecars; refusing deployment' \
+  'cannot enumerate GitLab host-socket jobs/helpers/services; refusing deployment' \
+  'cannot enumerate shared registry mirrors; refusing deployment' \
+  'cannot enumerate Docker names for legacy mirror verification; refusing deployment' \
+  'cannot verify fixed-name registry mirror provenance; refusing deployment' \
+  'cannot enumerate GitHub validation containers; refusing deployment' \
+  'cannot enumerate GitLab validation jobs; refusing deployment' \
+  'cannot verify CI Runner Farm background-daemon state; refusing deployment'
+do
+  grep -qF "$failure" "$DEPLOY" || fail "deploy lacks fail-closed diagnostic: $failure"
+done
+
+remove_block="$(awk '
+  /<FILE Run="\/bin\/bash" Method="remove">/ { emit=1 }
+  emit { print }
+  emit && /<\/FILE>/ { exit }
+' "$BUILD")"
+[ -n "$remove_block" ] || fail "could not locate generated plugin remove action"
+printf '%s\n' "$remove_block" | grep -qF 'set -euo pipefail' \
+  || fail "plugin remove action lacks strict shell error handling"
+printf '%s\n' "$remove_block" | grep -qF 'if ! "\$PLGDIR/include/runner-farm.sh" stop' \
+  || fail "plugin remove action does not surface fleet stop failures"
+for fallback_contract in \
+  'cleanup engine is missing and Docker is unavailable' \
+  'label=net.unraid.ci-runner-farm.managed=true' \
+  'label=net.unraid.ci-runner-farm.sidecar=true' \
+  'label=net.unraid.ci-runner-farm.role=mirror' \
+  'label=com.gitlab.gitlab-runner.managed=true' \
+  'label=net.unraid.ci-runner-farm.provider=gitlab' \
+  'cleanup engine is missing while plugin-owned Docker resources still exist'
+do
+  printf '%s\n' "$remove_block" | grep -qF "$fallback_contract" \
+    || fail "plugin remove action lacks missing-engine safety contract: $fallback_contract"
+done
+printf '%s\n' "$remove_block" | grep -qF 'if ! rm -rf -- "\$PLGDIR" || [ -e "\$PLGDIR" ]; then' \
+  || fail "plugin remove action does not fail on incomplete runtime deletion"
+printf '%s\n' "$remove_block" | grep -qF 'if ! rm -f -- "\$CFGDIR"/${NAME}-*.tgz; then' \
+  || fail "plugin remove action does not fail on cached-package deletion"
+
+runtime_delete_line="$(printf '%s\n' "$remove_block" | grep -nF 'if ! rm -rf -- "\$PLGDIR"' | head -1 | cut -d: -f1)"
+package_delete_line="$(printf '%s\n' "$remove_block" | grep -nF 'if ! rm -f -- "\$CFGDIR"/${NAME}-*.tgz' | head -1 | cut -d: -f1)"
+success_line="$(printf '%s\n' "$remove_block" | grep -nF 'ci-runner-farm removed. Config + credentials left' | head -1 | cut -d: -f1)"
+[ "$runtime_delete_line" -lt "$success_line" ] && [ "$package_delete_line" -lt "$success_line" ] \
+  || fail "plugin remove action can announce success before cleanup completes"
+
+echo "deploy-uninstall-safety: OK — deploy is fleet-locked/fail-closed and uninstall propagates cleanup failures"

--- a/tests/dev-package.sh
+++ b/tests/dev-package.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+fail() {
+  echo "dev-package: FAIL: $*" >&2
+  exit 1
+}
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+md5_of() {
+  if command -v md5sum >/dev/null 2>&1; then
+    md5sum "$1" | cut -d' ' -f1
+  else
+    md5 -q "$1"
+  fi
+}
+
+file_state() {
+  if [ -f "$1" ]; then
+    printf 'file:%s\n' "$(sha256_of "$1")"
+  elif [ -e "$1" ]; then
+    printf 'other\n'
+  else
+    printf 'absent\n'
+  fi
+}
+
+manifest_field() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    value = json.load(handle)[sys.argv[2]]
+print(value)
+PY
+}
+
+before_plg="$(file_state ci-runner-farm.plg)"
+before_tgz="$(file_state ci-runner-farm.tgz)"
+log="$(mktemp "${TMPDIR:-/tmp}/ci-runner-farm-dev-package.XXXXXX")"
+trap 'rm -f -- "$log"' EXIT HUP INT TERM
+
+run_dev() {
+  DATE=2026.08.04.1234 \
+    BUILD_NUMBER=0 \
+    INTERNAL_VERSION=1.8.0 \
+    bash ./build-plg.sh --dev
+}
+
+if ! tar --version 2>/dev/null | grep -qi 'gnu tar'; then
+  if run_dev >"$log" 2>&1; then
+    fail "--dev succeeded without GNU tar"
+  fi
+  grep -qi 'requires GNU tar' "$log" || fail "missing GNU tar failure message"
+  [ "$(file_state ci-runner-farm.plg)" = "$before_plg" ] || fail "failed --dev changed ci-runner-farm.plg"
+  [ "$(file_state ci-runner-farm.tgz)" = "$before_tgz" ] || fail "failed --dev changed ci-runner-farm.tgz"
+  echo "dev-package: SKIP positive artifact checks (GNU tar unavailable; fail-closed behavior passed)"
+  exit 0
+fi
+
+run_dev >"$log"
+[ "$(file_state ci-runner-farm.plg)" = "$before_plg" ] || fail "--dev changed canonical ci-runner-farm.plg"
+[ "$(file_state ci-runner-farm.tgz)" = "$before_tgz" ] || fail "--dev changed canonical ci-runner-farm.tgz"
+
+out="tmp/dev-package"
+manifest="$out/manifest.json"
+plg="$out/ci-runner-farm.plg"
+[ -f "$manifest" ] || fail "manifest.json is missing"
+[ -f "$plg" ] || fail "ci-runner-farm.plg is missing"
+
+python3 - "$manifest" <<'PY' || fail "manifest schema or serialization is invalid"
+import json
+import re
+import sys
+
+path = sys.argv[1]
+raw = open(path, encoding="utf-8").read()
+data = json.loads(raw)
+keys = [
+    "schema", "name", "mode", "version", "plugin_file", "package_file",
+    "package_md5", "package_sha256", "source_path", "runtime_root",
+]
+assert list(data) == keys
+assert raw == json.dumps(data, separators=(",", ":")) + "\n"
+assert data["schema"] == 1
+assert data["name"] == "ci-runner-farm"
+assert data["mode"] == "dev"
+assert data["plugin_file"] == "ci-runner-farm.plg"
+assert data["runtime_root"] == "src/usr/local/emhttp/plugins/ci-runner-farm"
+assert re.fullmatch(r"[0-9a-f]{32}", data["package_md5"])
+assert re.fullmatch(r"[0-9a-f]{64}", data["package_sha256"])
+assert re.fullmatch(
+    r"2026\.08\.04\.1234\.0-1\.8\.0-jcuratec\.gitlab\.dev\.[0-9a-f]{12}",
+    data["version"],
+)
+assert data["package_file"] == f"ci-runner-farm-jcuratec-dev-{data['version']}.tgz"
+assert data["source_path"] == f"/boot/config/ci-runner-farm-dev/artifacts/{data['package_file']}"
+PY
+
+version="$(manifest_field "$manifest" version)"
+package_name="$(manifest_field "$manifest" package_file)"
+package_md5="$(manifest_field "$manifest" package_md5)"
+package_sha="$(manifest_field "$manifest" package_sha256)"
+source_path="$(manifest_field "$manifest" source_path)"
+package="$out/$package_name"
+
+[ -f "$package" ] || fail "$package_name is missing"
+[ "$package_md5" = "$(md5_of "$package")" ] || fail "manifest MD5 does not match package"
+[ "$package_sha" = "$(sha256_of "$package")" ] || fail "manifest SHA256 does not match package"
+case "$version" in
+  *"jcuratec.gitlab.dev.${package_sha:0:12}"*) ;;
+  *) fail "dev version is not bound to the first 12 package SHA256 characters" ;;
+esac
+
+entry_count="$(find "$out" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ')"
+[ "$entry_count" = 3 ] || fail "dev output must contain exactly three artifacts"
+
+python3 - "$plg" "$package_name" "$package_md5" "$package_sha" "$source_path" <<'PY' \
+  || fail "development PLG contract check failed"
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+path, package, md5, sha256, source = sys.argv[1:]
+text = open(path, encoding="utf-8").read()
+ET.parse(path)
+assert "pluginURL" not in text
+assert "packageURL" not in text
+assert "<URL>" not in text
+assert "base64" not in text.lower()
+assert '<!ENTITY author        "j-curatec local dev">' in text
+assert 'support="https://github.com/j-curatec/ci-runner-farm/issues"' in text
+assert "Local development build from the j-curatec GitLab-provider working tree." in text
+assert "Adds CI_PROVIDER=github|gitlab while retaining the GitHub provider." in text
+assert "has no automatic update URL." in text
+assert f'<!ENTITY packageName   "{package}">' in text
+assert f'<FILE Name="/tmp/&packageName;">' in text
+assert f'<LOCAL>{source}</LOCAL>' in text
+assert f'<!ENTITY packageMD5    "{md5}">' in text
+assert f'<!ENTITY packageSHA256 "{sha256}">' in text
+assert '<SHA256>&packageSHA256;</SHA256>' in text
+assert f'PKG="/tmp/{package}"' in text
+assert f'EXPECTED_PACKAGE_SHA256="{sha256}"' in text
+verify = text.index('actual_package_sha256="$(sha256sum "$PKG"')
+extract = text.index('tar -xzf "$PKG"')
+remove = text.index('rm -f -- "$PKG"', extract)
+assert verify < extract < remove
+assert 'find "$CFGDIR" -maxdepth 1 -name \'ci-runner-farm-*.tgz\'' not in text
+assert 'rm -f -- "$CFGDIR"/ci-runner-farm-*.tgz' not in text
+assert not re.search(r'rm\s+[^\n]*?/boot/config/ci-runner-farm-dev', text)
+assert "External dev artifacts and rollback packages are installer-owned and retained." in text
+PY
+
+extract_dir="$(mktemp -d "${TMPDIR:-/tmp}/ci-runner-farm-dev-extract.XXXXXX")"
+trap 'rm -f -- "$log"; rm -rf -- "$extract_dir"' EXIT HUP INT TERM
+tar -xzf "$package" -C "$extract_dir"
+diff -r "src/usr/local/emhttp/plugins/ci-runner-farm" "$extract_dir" >/dev/null \
+  || fail "package contents differ from the runtime source tree"
+
+while IFS= read -r entry; do
+  case "$entry" in
+    /*|../*|*/../*) fail "unsafe package path: $entry" ;;
+  esac
+  trimmed="${entry%/}"
+  base="${trimmed##*/}"
+  case "$base" in
+    token|gitlab-runner-token|gitlab-api-token|registry-token|gitlab-ca.crt|ci-runner-farm.cfg|config.toml|config.json|.runner_system_id)
+      fail "credential or persisted configuration included in package: $entry"
+      ;;
+  esac
+done < <(tar -tzf "$package")
+
+first_manifest_sha="$(sha256_of "$manifest")"
+first_plg_sha="$(sha256_of "$plg")"
+first_package_sha="$(sha256_of "$package")"
+run_dev >"$log"
+[ "$first_manifest_sha" = "$(sha256_of "$manifest")" ] || fail "manifest is not deterministic"
+[ "$first_plg_sha" = "$(sha256_of "$plg")" ] || fail "PLG is not deterministic"
+[ "$first_package_sha" = "$(sha256_of "$package")" ] || fail "package is not deterministic"
+[ "$(file_state ci-runner-farm.plg)" = "$before_plg" ] || fail "second --dev changed canonical ci-runner-farm.plg"
+[ "$(file_state ci-runner-farm.tgz)" = "$before_tgz" ] || fail "second --dev changed canonical ci-runner-farm.tgz"
+
+echo "dev-package: PASS"

--- a/tests/exec-csrf.sh
+++ b/tests/exec-csrf.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Exercise both CSRF paths in exec.php. Unraid 7.3 validates and consumes the
+# request token in auto_prepend_file before the endpoint runs; CLI/tests need the
+# endpoint's standalone fallback instead. Every action input below is invalid so
+# this test can never write the real /boot credential path.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail() { printf 'exec-csrf: FAIL: %s\n' "$*" >&2; exit 1; }
+command -v php >/dev/null 2>&1 || fail "php is required"
+
+# Short enough to fit the deliberately undersized token case, but distinctive
+# enough to prove that no rejected input is reflected in a JSON response.
+sentinel='Z9Q7X5'
+
+run_case() {
+  CRF_CSRF_CASE="$1" CRF_TOKEN_CASE="${2:-prefix}" CRF_TOKEN_SENTINEL="$sentinel" \
+    php -d auto_prepend_file= <<'PHP'
+<?php
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$var = ['csrf_token'=>'known-test-token'];
+$csrfCase = getenv('CRF_CSRF_CASE');
+$tokenCase = getenv('CRF_TOKEN_CASE');
+$sentinel = getenv('CRF_TOKEN_SENTINEL');
+
+switch ($tokenCase) {
+  case 'empty':
+    $token = '';
+    break;
+  case 'wrapped-command':
+    $token = 'gitlab-runner register --url https://gitlab.example.test --token glrt-' . $sentinel . 'abcdef';
+    break;
+  case 'wrapped-quotes':
+    $token = '"glrt-' . $sentinel . 'abcdef"';
+    break;
+  case 'wrapped-assignment':
+    $token = 'RUNNER_AUTH_TOKEN=glrt-' . $sentinel . 'abcdef';
+    break;
+  case 'legacy':
+    $token = 'glrtr-' . $sentinel . 'abcdef';
+    break;
+  case 'api':
+    $token = 'glpat-' . $sentinel . 'abcdef';
+    break;
+  case 'custom-prefix':
+    $token = 'acme-glrt-' . $sentinel . 'abcdef';
+    break;
+  case 'prefix':
+    $token = 'runner-' . $sentinel . '-abcdef';
+    break;
+  case 'too-short':
+    // 6 sentinel bytes + 3 ASCII bytes = a 9-byte suffix (<10).
+    $token = 'glrt-' . $sentinel . 'abc';
+    break;
+  case 'too-long':
+    // 6 sentinel bytes + 502 ASCII bytes = a 508-byte suffix (>507).
+    $token = 'glrt-' . $sentinel . str_repeat('A', 502);
+    break;
+  case 'punctuation':
+    $token = 'glrt-' . $sentinel . 'abc!def';
+    break;
+  case 'control':
+    $token = 'glrt-' . $sentinel . "abc\x01def";
+    break;
+  case 'non-ascii':
+    $token = 'glrt-' . $sentinel . "abc\xC3\xA9def";
+    break;
+  case 'non-scalar':
+    $token = [$sentinel];
+    break;
+  default:
+    fwrite(STDERR, "unknown token test case\n");
+    exit(2);
+}
+
+if ($csrfCase === 'platform') {
+  function csrf_terminate($reason) {}
+  $csrf_token = 'known-test-token';
+  // This is the state Unraid 7.3 leaves after successful prevalidation.
+  $_POST = ['action'=>'set-gitlab-runner-token', 'token'=>$token];
+} elseif ($csrfCase === 'platform-spoof') {
+  function csrf_terminate($reason) {}
+  $csrf_token = 'wrong-test-token';
+  $_POST = ['action'=>'set-gitlab-runner-token', 'token'=>$token];
+} elseif ($csrfCase === 'standalone') {
+  $_POST = [
+    'csrf_token'=>'known-test-token',
+    'action'=>'set-gitlab-runner-token',
+    'token'=>$token,
+  ];
+} elseif ($csrfCase === 'standalone-bad') {
+  $_POST = [
+    'csrf_token'=>'wrong-test-token',
+    'action'=>'set-gitlab-runner-token',
+    'token'=>$token,
+  ];
+} else {
+  fwrite(STDERR, "unknown CSRF test case\n");
+  exit(2);
+}
+include 'src/usr/local/emhttp/plugins/ci-runner-farm/include/exec.php';
+PHP
+}
+
+assert_action_error() {
+  local label="$1" actual="$2" expected_code="$3" expected_message="$4"
+  case "$actual" in
+    *"$sentinel"*) fail "$label reflected rejected token material" ;;
+  esac
+  if ! CRF_ACTUAL_JSON="$actual" CRF_EXPECTED_CODE="$expected_code" \
+      CRF_EXPECTED_MESSAGE="$expected_message" php -r '
+        $body = json_decode(getenv("CRF_ACTUAL_JSON"), true);
+        $ok = is_array($body)
+          && array_key_exists("ok", $body) && $body["ok"] === false
+          && ($body["error_code"] ?? null) === getenv("CRF_EXPECTED_CODE")
+          && ($body["error"] ?? null) === getenv("CRF_EXPECTED_MESSAGE");
+        exit($ok ? 0 : 1);
+      '
+  then
+    fail "$label returned the wrong static error contract"
+  fi
+}
+
+check_token_case() {
+  local token_case="$1" expected_code="$2" expected_message="$3" csrf_case actual
+  for csrf_case in platform standalone; do
+    actual="$(run_case "$csrf_case" "$token_case")" \
+      || fail "$csrf_case/$token_case endpoint invocation failed"
+    assert_action_error "$csrf_case/$token_case" "$actual" "$expected_code" "$expected_message"
+  done
+}
+
+empty_message='No runner authentication token was provided.'
+wrapped_message='Paste only the raw glrt- runner authentication token, without a command, flag, variable assignment, or quotes.'
+legacy_message='Tokens beginning glrtr- come from GitLab’s legacy registration-token flow and are not supported; create a runner with GitLab’s modern workflow and use its glrt- token.'
+api_message='That looks like a GitLab API token. Paste the runner authentication token beginning glrt-.'
+custom_message='This token has a custom instance prefix. This build requires glrt- at the start for safe manager-only removal.'
+prefix_message='The runner authentication token must begin exactly glrt-.'
+length_message='The runner authentication token must contain 10–507 characters after glrt-.'
+characters_message='After glrt-, use only ASCII letters, digits, dots, hyphens, and underscores.'
+
+check_token_case empty runner_token_empty "$empty_message"
+check_token_case wrapped-command runner_token_wrapped "$wrapped_message"
+check_token_case wrapped-quotes runner_token_wrapped "$wrapped_message"
+check_token_case wrapped-assignment runner_token_wrapped "$wrapped_message"
+check_token_case legacy runner_token_legacy "$legacy_message"
+check_token_case api runner_token_api "$api_message"
+check_token_case custom-prefix runner_token_custom_prefix "$custom_message"
+check_token_case prefix runner_token_prefix "$prefix_message"
+check_token_case too-short runner_token_length "$length_message"
+check_token_case too-long runner_token_length "$length_message"
+check_token_case punctuation runner_token_characters "$characters_message"
+check_token_case control runner_token_characters "$characters_message"
+check_token_case non-ascii runner_token_characters "$characters_message"
+check_token_case non-scalar runner_token_prefix "$prefix_message"
+
+csrf_error='{"ok":false,"error":"csrf"}'
+[ "$(run_case platform-spoof prefix)" = "$csrf_error" ] \
+  || fail "spoofed platform CSRF variable bypassed validation"
+[ "$(run_case standalone-bad prefix)" = "$csrf_error" ] \
+  || fail "standalone invalid CSRF token bypassed validation"
+
+echo "exec-csrf: PASS"

--- a/tests/firewall-transition.sh
+++ b/tests/firewall-transition.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Mock the strict-network endpoint handoff used during provider/config drains.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export CRF_CFGDIR="$tmp/config" CRF_RUNDIR="$tmp/run" CRF_SOURCE_ONLY=1
+mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+# shellcheck source=/dev/null
+source src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+
+fail() { printf 'FIREWALL TRANSITION FAIL: %s\n' "$*" >&2; exit 1; }
+CI_PROVIDER=gitlab
+GITLAB_URL='https://new-gitlab.example.test:8443/gitlab'
+IMAGE_SOURCE=remote
+REGISTRY_SERVER='registry.example.test:5001'
+NETWORK_ISOLATION=strict
+RUNNER_NETWORK='ci-runner-net'
+SHARED_IMAGE_CACHE=true
+DIND=true
+IPTABLES_LOG="$tmp/iptables.log"; export IPTABLES_LOG
+
+getent() {
+  local host="${3:-${2:-}}"
+  case "$host" in
+    new-gitlab.example.test) printf '10.20.30.40 STREAM host\n' ;;
+    registry.example.test)   printf '10.20.30.50 STREAM host\n' ;;
+  esac
+}
+
+docker() {
+  if [ "${1:-}" = network ] && [ "${2:-}" = inspect ]; then
+    case "$*" in
+      *Subnet*) printf '172.31.0.0/16\n' ;;
+      *Gateway*) printf '172.31.0.1\n' ;;
+    esac
+    return 0
+  fi
+  if [ "${1:-}" = inspect ]; then
+    case "$*" in *IPAddress*) printf '172.31.0.2\n' ;; esac
+    return 0
+  fi
+  return 0
+}
+
+iptables() {
+  printf '%s\n' "$*" >> "$IPTABLES_LOG"
+  case "$*" in
+    *'-L DOCKER-USER --line-numbers'*)
+      printf '1 old allow /* ci-runner-farm:gitlab */\n2 old allow /* ci-runner-farm:registry */\n' ;;
+    *'-L INPUT --line-numbers'*)
+      printf '1 old allow /* ci-runner-farm:in-gitlab */\n' ;;
+    *'-L DOCKER-USER -n'*)
+      # A healthy existing base policy on the PREVIOUS subnet/mirror.  A
+      # network/subnet change must not clear it while busy stale slots drain.
+      printf 'RETURN 172.30.0.0/16 172.30.0.2 tcp dpt:5000 /* ci-runner-farm:mirror */\n'
+      printf 'DROP 172.30.0.0/16 10.0.0.0/8 /* ci-runner-farm:lan10 */\n' ;;
+    *' -C '*) return 1 ;;
+  esac
+  return 0
+}
+
+# The pre-replacement phase is additive: install current endpoint exceptions
+# ahead of the LAN drops without deleting old exceptions still used by busy slots.
+firewall_prepare_replacement
+if grep -Eq ' -D (DOCKER-USER|INPUT) [0-9]+$' "$IPTABLES_LOG"; then
+  fail "additive handoff deleted an old tagged rule"
+fi
+grep -q -- '-I DOCKER-USER 1 -s 172.31.0.0/16 -j DROP .*ci-runner-farm:install-guard' "$IPTABLES_LOG" \
+  || fail "additive handoff did not install its temporary fail-closed guard first"
+grep -q -- '-D DOCKER-USER -s 172.31.0.0/16 -j DROP .*ci-runner-farm:install-guard' "$IPTABLES_LOG" \
+  || fail "successful additive handoff did not retire its temporary guard"
+grep -q -- '-d 10.20.30.40 -p tcp --dport 8443' "$IPTABLES_LOG" \
+  || fail "new GitLab endpoint was not allowed"
+grep -q -- '-d 10.20.30.50 -p tcp --dport 5001' "$IPTABLES_LOG" \
+  || fail "new registry endpoint was not allowed"
+grep -q -- '-I INPUT 1' "$IPTABLES_LOG" || fail "host-input endpoint exception was not added"
+grep -q -- '-I DOCKER-USER 1 -s 172.31.0.0/16 -d 192.168.0.0/16 -j DROP' "$IPTABLES_LOG" \
+  || fail "complete policy for the replacement subnet was not added"
+grep -q -- '-I INPUT 1 -s 172.31.0.0/16 -j DROP' "$IPTABLES_LOG" \
+  || fail "replacement subnet did not receive a host-input drop"
+grep -q -- '-s 172.31.0.0/16 -d 172.31.0.2 -p tcp --dport 5000' "$IPTABLES_LOG" \
+  || fail "replacement subnet did not receive its mirror allow"
+
+# A GitLab job/service can override a locally built default image. Keep the one
+# configured private-registry exception in that mode, while preserving GitHub's
+# historical remote-default-only behavior.
+IMAGE_SOURCE=builtin
+gitlab_builtin_endpoints="$(configured_strict_endpoints)"
+printf '%s\n' "$gitlab_builtin_endpoints" | grep -q '^10\.20\.30\.50 5001 registry$' \
+  || fail "built-in-default GitLab policy omitted the configured override registry"
+CI_PROVIDER=github
+if configured_strict_endpoints | grep -q ' registry$'; then
+  fail "built-in GitHub policy unexpectedly enabled a registry exception"
+fi
+CI_PROVIDER=gitlab
+IMAGE_SOURCE=remote
+
+# Start must select the same additive path when managed runners already exist.
+# Mock every later lifecycle step so this checks only the preflight decision.
+: > "$IPTABLES_LOG"
+managed_names() { printf 'ci-runner-1\n'; }
+managed_runner_snapshot() {
+  printf '%064d|gitlab|manager|1|mock-generation\n' 1
+}
+provider_token_ready() { return 0; }
+gitlab_validate_settings() { return 0; }
+public_repo_problem() { return 0; }
+provision_base() { printf 'base\n' >> "$IPTABLES_LOG"; }
+provision_preflight() { fail "existing strict fleet used destructive preflight"; }
+firewall_prepare_replacement() { printf 'additive\n' >> "$IPTABLES_LOG"; }
+gitlab_cleanup_orphan_sidecars() { return 0; }
+on_expected_network() { return 0; }
+start_stopped_managed() { return 0; }
+reap_dead_runners() { return 0; }
+start_one() { return 0; }
+AUTOSCALE=false IMAGE_AUTOUPDATE=false RUNNER_COUNT=1
+cmd_start >/dev/null
+[ "$(sed -n '1p' "$IPTABLES_LOG")" = base ] || fail "Start skipped shared base provisioning"
+[ "$(sed -n '2p' "$IPTABLES_LOG")" = additive ] || fail "Start skipped additive strict policy preparation"
+
+# Even when a replacement is now current, firewall_apply must remain additive
+# while any manager is live. It may retire only the temporary exact guard, never
+# an old tagged rule still protecting a stale endpoint/subnet.
+: > "$IPTABLES_LOG"
+firewall_apply
+if grep -Eq ' -D (DOCKER-USER|INPUT) [0-9]+$' "$IPTABLES_LOG"; then
+  fail "live-fleet firewall finalization deleted tagged rules"
+fi
+grep -q -- '-I DOCKER-USER 1' "$IPTABLES_LOG" \
+  || fail "live-fleet firewall finalization was not additive"
+
+# Only a positively empty managed fleet permits the authoritative clear/rebuild.
+: > "$IPTABLES_LOG"
+managed_names() { :; }
+firewall_apply
+grep -q ' -D DOCKER-USER ' "$IPTABLES_LOG" || fail "authoritative rebuild did not remove old forward rules"
+grep -q ' -D INPUT ' "$IPTABLES_LOG" || fail "authoritative rebuild did not remove old input rules"
+grep -q -- '-d 10.20.30.40 -p tcp --dport 8443' "$IPTABLES_LOG" \
+  || fail "authoritative rebuild omitted current GitLab endpoint"
+
+echo 'firewall-transition: OK — current endpoints are added before old exceptions are retired'

--- a/tests/gitlab-policy.sh
+++ b/tests/gitlab-policy.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# GitLab Docker-executor policy controls: upgrade-safe defaults, generated TOML,
+# validation, and config fingerprints that force a safe manager recreation.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export CRF_CFGDIR="$tmp/config"
+export CRF_RUNDIR="$tmp/run"
+export CRF_SOURCE_ONLY=1
+mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+# shellcheck source=/dev/null
+source src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+
+fail() { printf 'GITLAB POLICY FAIL: %s\n' "$*" >&2; exit 1; }
+
+CI_PROVIDER=gitlab
+GITLAB_URL='https://gitlab.example.test'
+GITLAB_RUNNER_TOKEN='glrt-policytest000000000000000'
+GITLAB_RUNNER_IMAGE='gitlab/gitlab-runner:alpine'
+CACHE_ROOT="$tmp/cache"
+CACHE_MOUNTS=''
+IMAGE_SOURCE=builtin
+DIND=true
+SHARE_DOCKER_SOCK=false
+NETWORK_ISOLATION=off
+mkdir -p "$CACHE_ROOT"
+
+# Empty allowlists intentionally preserve GitLab Runner's permissive upgrade
+# behavior. Pull-policy "auto" preserves the existing built-in/remote choice,
+# while allowed_pull_policies prevents a job from selecting a weaker policy.
+gitlab_validate_settings || fail "default execution policy was rejected"
+REGISTRY_SERVER='http://registry.example.test:5000'
+if gitlab_validate_settings >/dev/null 2>&1; then
+  fail "GitLab accepted an insecure HTTP registry endpoint"
+fi
+REGISTRY_SERVER='https://registry.example.test:5443'
+gitlab_validate_settings || fail "GitLab rejected a normalized HTTPS registry endpoint"
+REGISTRY_SERVER=''
+gitlab_write_config 1 ci-runner-1 || fail "default policy TOML generation failed"
+cfg="$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml"
+if grep -qE 'allowed_(images|services)[[:space:]]*=' "$cfg"; then
+  fail "blank allowlists were emitted instead of preserving Runner defaults"
+fi
+grep -qF '    pull_policy = "if-not-present"' "$cfg" \
+  || fail "auto policy did not preserve the built-in image pull behavior"
+grep -qF '    allowed_pull_policies = ["if-not-present"]' "$cfg" \
+  || fail "job-level pull-policy overrides are not restricted"
+grep -qF '    shm_size = 0' "$cfg" || fail "default shared-memory size changed"
+
+# Space-separated wildcard patterns become quoted TOML arrays without pathname
+# expansion. A configured policy must survive exactly as the operator entered it.
+GITLAB_ALLOWED_IMAGES='registry.example.test/team/*:* node:24'
+GITLAB_ALLOWED_SERVICES='postgres:* redis:*'
+GITLAB_PULL_POLICY='if-not-present'
+GITLAB_SHM_SIZE='1073741824'
+gitlab_validate_settings || fail "valid custom execution policy was rejected"
+gitlab_write_config 1 ci-runner-1 || fail "custom policy TOML generation failed"
+grep -qF '    allowed_images = ["registry.example.test/team/*:*", "node:24"]' "$cfg" \
+  || fail "allowed image patterns were not emitted exactly"
+grep -qF '    allowed_services = ["postgres:*", "redis:*"]' "$cfg" \
+  || fail "allowed service patterns were not emitted exactly"
+grep -qF '    pull_policy = "if-not-present"' "$cfg" || fail "custom pull policy missing"
+grep -qF '    allowed_pull_policies = ["if-not-present"]' "$cfg" \
+  || fail "custom pull policy is not enforced against job overrides"
+grep -qF '    shm_size = 1073741824' "$cfg" || fail "custom shared-memory size missing"
+python3 - "$cfg" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as fh:
+    docker = tomllib.load(fh)["runners"][0]["docker"]
+assert docker["allowed_images"] == ["registry.example.test/team/*:*", "node:24"]
+assert docker["allowed_services"] == ["postgres:*", "redis:*"]
+assert docker["pull_policy"] == "if-not-present"
+assert docker["allowed_pull_policies"] == ["if-not-present"]
+assert docker["shm_size"] == 1073741824
+PY
+
+for invalid_policy in never sometimes; do
+  GITLAB_PULL_POLICY="$invalid_policy"
+  if gitlab_validate_settings >/dev/null 2>&1; then fail "invalid pull policy accepted: $invalid_policy"; fi
+done
+IMAGE_SOURCE=builtin; GITLAB_PULL_POLICY=always
+if gitlab_validate_settings >/dev/null 2>&1; then fail "always pull policy accepted for a local-only built-in image"; fi
+IMAGE_SOURCE=remote; GITLAB_PULL_POLICY=always
+gitlab_validate_settings >/dev/null 2>&1 || fail "always pull policy rejected for a remote default image"
+IMAGE_SOURCE=builtin
+GITLAB_PULL_POLICY='auto'
+GITLAB_SHUTDOWN_TIMEOUT=07200
+if gitlab_validate_settings >/dev/null 2>&1; then fail "leading-zero shutdown timeout accepted into invalid TOML"; fi
+GITLAB_SHUTDOWN_TIMEOUT=7200
+original_mounts="$CACHE_MOUNTS"
+for invalid_mounts in \
+  'cache:relative/path' \
+  'cache:/cache' \
+  'cache:/var/run/docker.sock' \
+  'cache:/etc/gitlab-runner/certs/ca.crt' \
+  'cache:/foo/../cache' \
+  'cache:/var/run/../run/docker.sock' \
+  'cache:/opt//shared' \
+  'cache:/opt/shared/' \
+  'one:/opt/shared two:/opt/shared' \
+  '../escape:/opt/cache' \
+  'cache:/opt/cache:ro'
+do
+  CACHE_MOUNTS="$invalid_mounts"
+  if gitlab_validate_settings >/dev/null 2>&1; then
+    fail "invalid GitLab cache destination/source accepted: $invalid_mounts"
+  fi
+done
+CACHE_MOUNTS='one:/opt/cache-one two:/opt/cache-two'
+gitlab_validate_settings >/dev/null 2>&1 || fail "valid distinct GitLab cache mounts were rejected"
+CACHE_MOUNTS="$original_mounts"
+for invalid_shm in -1 01 1g 92233720368547758070; do
+  GITLAB_SHM_SIZE="$invalid_shm"
+  if gitlab_validate_settings >/dev/null 2>&1; then
+    fail "invalid shared-memory size accepted: $invalid_shm"
+  fi
+done
+GITLAB_SHM_SIZE=0
+for invalid_images in 'node:24,alpine:3' $'node:24\nredis:7' 'node:24\evil'; do
+  GITLAB_ALLOWED_IMAGES="$invalid_images"
+  if gitlab_validate_settings >/dev/null 2>&1; then
+    fail "unsafe allowed-image pattern accepted"
+  fi
+done
+
+# Every baked policy value participates in confgen, so Apply drains and recreates
+# stale managers instead of silently leaving old executor policy in service.
+GITLAB_ALLOWED_IMAGES=''
+GITLAB_ALLOWED_SERVICES=''
+GITLAB_PULL_POLICY='auto'
+GITLAB_SHM_SIZE=0
+baseline="$(crf_confgen)"
+for assignment in \
+  'GITLAB_ALLOWED_IMAGES=node:*' \
+  'GITLAB_ALLOWED_SERVICES=postgres:*' \
+  'GITLAB_PULL_POLICY=always' \
+  'GITLAB_SHM_SIZE=67108864'
+do
+  GITLAB_ALLOWED_IMAGES=''
+  GITLAB_ALLOWED_SERVICES=''
+  GITLAB_PULL_POLICY='auto'
+  GITLAB_SHM_SIZE=0
+  key="${assignment%%=*}"; value="${assignment#*=}"
+  printf -v "$key" '%s' "$value"
+  [ "$(crf_confgen)" != "$baseline" ] || fail "confgen ignores $key"
+done
+
+echo "gitlab-policy: OK — executor allowlists, pull policy, shm size, validation, and confgen are wired"

--- a/tests/gitlab-runner-lint.sh
+++ b/tests/gitlab-runner-lint.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Validate the generated provider config with the configured official GitLab
+# Runner image. CI runs this on a Linux host with Docker; local developers can
+# run it after starting their daemon.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+docker info >/dev/null 2>&1 || { echo "gitlab-runner-lint: Docker daemon unavailable" >&2; exit 1; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export CRF_CFGDIR="$tmp/config"
+export CRF_RUNDIR="$tmp/run"
+export CRF_SOURCE_ONLY=1
+mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+# shellcheck source=/dev/null
+source src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+
+CI_PROVIDER=gitlab
+GITLAB_URL=https://gitlab.example.test
+# Synthetic GitLab 18 routable-token shape: URL-safe payload plus the two
+# version/length/CRC separators that originally exposed a stale local parser.
+GITLAB_RUNNER_TOKEN=glrt-AAECAwQFBgcICQoLDA0OD286MQpwOjIKdTozCnQ6Mw8.01.170z6aiyq
+GITLAB_RUNNER_IMAGE="$(sed -n 's/^GITLAB_RUNNER_IMAGE="\([^"]*\)".*/\1/p' src/usr/local/emhttp/plugins/ci-runner-farm/default.cfg | head -1)"
+CACHE_ROOT="$tmp/cache"
+CACHE_MOUNTS=''
+RUNNER_CPUS='2'
+GITLAB_ALLOWED_IMAGES='ci-runner-farm-gitlab-job:* registry.example.test/team/*:*'
+GITLAB_ALLOWED_SERVICES='postgres:* redis:*'
+GITLAB_PULL_POLICY='if-not-present'
+GITLAB_SHM_SIZE='1073741824'
+DIND=true
+SHARE_DOCKER_SOCK=false
+mkdir -p "$CACHE_ROOT"
+# Exercise the conditional self-managed CA key with a real PEM bundle so Runner
+# can open the configured path as well as parse it.
+if [ -r /etc/ssl/certs/ca-certificates.crt ]; then
+  cp /etc/ssl/certs/ca-certificates.crt "$GITLAB_CA_FILE"
+else
+  cp /etc/ssl/cert.pem "$GITLAB_CA_FILE"
+fi
+printf '%s' "$GITLAB_RUNNER_TOKEN" > "$GITLAB_RUNNER_TOKEN_FILE"
+reload_secret_files
+gitlab_write_config 1 ci-runner-1
+config_dir="$CRF_CFGDIR/gitlab-runners/ci-runner-1"
+
+# Runner's decoder may discard an unknown TOML key before lint/schema checks.
+# Verify the exact generated shape independently, including all conditional
+# resource/CA keys, then let the official binary validate its own semantics.
+CONFIG_PATH="$config_dir/config.toml" python3 - <<'PY'
+import os
+import tomllib
+
+with open(os.environ["CONFIG_PATH"], "rb") as fh:
+    config = tomllib.load(fh)
+
+def exact_keys(value, expected, label):
+    actual = set(value)
+    expected = set(expected)
+    if actual != expected:
+        raise SystemExit(f"{label} keys differ: missing={sorted(expected-actual)} extra={sorted(actual-expected)}")
+
+exact_keys(config, {
+    "concurrent", "check_interval", "shutdown_timeout", "listen_address", "runners",
+}, "global")
+runners = config["runners"]
+if not isinstance(runners, list) or len(runners) != 1:
+    raise SystemExit("expected exactly one generated [[runners]] entry")
+runner = runners[0]
+exact_keys(runner, {
+    "name", "url", "token", "executor", "limit", "request_concurrency",
+    "environment", "tls-ca-file", "docker",
+}, "runner")
+docker = runner["docker"]
+exact_keys(docker, {
+    "host", "tls_verify", "image", "pull_policy", "allowed_pull_policies",
+    "allowed_images", "allowed_services", "privileged",
+    "disable_entrypoint_overwrite", "oom_kill_disable", "disable_cache",
+    "cpus", "service_cpus", "memory", "service_memory", "shm_size",
+    "volumes", "container_labels",
+}, "runner.docker")
+exact_keys(docker["container_labels"], {
+    "net.unraid.ci-runner-farm.provider", "net.unraid.ci-runner-farm.slot",
+}, "runner.docker.container_labels")
+if runner["executor"] != "docker" or runner["tls-ca-file"] != "/etc/gitlab-runner/certs/gitlab-ca.crt":
+    raise SystemExit("executor or self-managed CA path differs")
+if not any(v.endswith(":/etc/gitlab-runner/certs/ca.crt:ro") for v in docker["volumes"]):
+    raise SystemExit("self-managed CA is not mounted at the helper/job trust path")
+if docker["cpus"] != "2" or docker["service_cpus"] != "2":
+    raise SystemExit("job/service CPU keys differ")
+if docker["pull_policy"] != "if-not-present" or docker["allowed_pull_policies"] != ["if-not-present"]:
+    raise SystemExit("executor pull policy or its job-level restriction differs")
+if docker["allowed_images"] != ["ci-runner-farm-gitlab-job:*", "registry.example.test/team/*:*"]:
+    raise SystemExit("allowed image patterns differ")
+if docker["allowed_services"] != ["postgres:*", "redis:*"]:
+    raise SystemExit("allowed service patterns differ")
+if docker["shm_size"] != 1073741824:
+    raise SystemExit("executor shared-memory size differs")
+PY
+
+docker image inspect "$GITLAB_RUNNER_IMAGE" >/dev/null 2>&1 \
+  || docker pull "$GITLAB_RUNNER_IMAGE" >/dev/null
+if docker run --rm "$GITLAB_RUNNER_IMAGE" --help 2>&1 | grep -qE '(^|[[:space:]])lint([[:space:]]|$)'; then
+  docker run --rm -v "$config_dir:/etc/gitlab-runner:ro" "$GITLAB_RUNNER_IMAGE" \
+    lint --config /etc/gitlab-runner/config.toml
+  echo "gitlab-runner-lint: generated config accepted by $GITLAB_RUNNER_IMAGE"
+else
+  list_rc=0
+  list_output="$(docker run --rm -v "$config_dir:/etc/gitlab-runner:ro" \
+    "$GITLAB_RUNNER_IMAGE" list 2>&1)" || list_rc=$?
+  [ "$list_rc" -eq 0 ] \
+    && gitlab_list_output_valid "$(host)-ci-runner-1" "$list_output" \
+    || { printf '%s\n' "$list_output" >&2; echo "gitlab-runner-lint: list fallback rejected generated config" >&2; exit 1; }
+  echo "gitlab-runner-lint: selected official image has no lint command; config parse fallback passed"
+fi

--- a/tests/gitlab-runner-lint.sh
+++ b/tests/gitlab-runner-lint.sh
@@ -21,6 +21,8 @@ GITLAB_URL=https://gitlab.example.test
 # version/length/CRC separators that originally exposed a stale local parser.
 GITLAB_RUNNER_TOKEN=glrt-AAECAwQFBgcICQoLDA0OD286MQpwOjIKdTozCnQ6Mw8.01.170z6aiyq
 GITLAB_RUNNER_IMAGE="$(sed -n 's/^GITLAB_RUNNER_IMAGE="\([^"]*\)".*/\1/p' src/usr/local/emhttp/plugins/ci-runner-farm/default.cfg | head -1)"
+[ -n "$GITLAB_RUNNER_IMAGE" ] \
+  || { echo "gitlab-runner-lint: could not read GITLAB_RUNNER_IMAGE from default.cfg" >&2; exit 1; }
 CACHE_ROOT="$tmp/cache"
 CACHE_MOUNTS=''
 RUNNER_CPUS='2'
@@ -35,8 +37,11 @@ mkdir -p "$CACHE_ROOT"
 # can open the configured path as well as parse it.
 if [ -r /etc/ssl/certs/ca-certificates.crt ]; then
   cp /etc/ssl/certs/ca-certificates.crt "$GITLAB_CA_FILE"
-else
+elif [ -r /etc/ssl/cert.pem ]; then
   cp /etc/ssl/cert.pem "$GITLAB_CA_FILE"
+else
+  echo "gitlab-runner-lint: no host CA bundle found for the self-managed CA case" >&2
+  exit 1
 fi
 printf '%s' "$GITLAB_RUNNER_TOKEN" > "$GITLAB_RUNNER_TOKEN_FILE"
 reload_secret_files

--- a/tests/install-dev-safety.sh
+++ b/tests/install-dev-safety.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Safety and failure-order contracts for install-dev.sh.  All host interaction
+# is mocked; this test never reads or writes an Unraid /boot tree.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+INSTALLER=install-dev.sh
+fail() { printf 'INSTALL-DEV SAFETY FAIL: %s\n' "$*" >&2; exit 1; }
+line_of() {
+  local value
+  value="$(grep -nF -- "$2" "$1" | head -1 | cut -d: -f1)"
+  [ -n "$value" ] || fail "missing contract: $2"
+  printf '%s\n' "$value"
+}
+
+bash -n "$INSTALLER" || fail "installer has invalid shell syntax"
+
+# The local bundle is authenticated before the first remote mutation, and the
+# lock-protected live deployment completes before flash state is created.
+validate_line="$(line_of "$INSTALLER" '  validate_bundle')"
+deploy_line="$(line_of "$INSTALLER" '  bash "$SCRIPT_DIR/deploy.sh" "$HOST"')"
+stage_line="$(line_of "$INSTALLER" '  REMOTE_STAGE="$(ssh -- "$HOST"')"
+[ "$validate_line" -lt "$deploy_line" ] && [ "$deploy_line" -lt "$stage_line" ] \
+  || fail "bundle validation/deploy/upload ordering is unsafe"
+
+for contract in \
+  'set -euo pipefail' \
+  'manifest fields do not exactly match schema 1' \
+  'package MD5 does not match the manifest' \
+  'package SHA-256 does not match the manifest' \
+  'invalid plugin XML' \
+  'plugin package LOCAL source does not match manifest source_path' \
+  'plugin package SHA-256 does not match the manifest' \
+  'host must be root@ followed by a simple SSH hostname or IPv4 address'
+do
+  grep -qF -- "$contract" "$INSTALLER" || fail "missing local validation: $contract"
+done
+grep -qF 'case "${HOST#root@}"' "$INSTALLER" || fail "host shell syntax is not rejected"
+if grep -qF 'set -x' "$INSTALLER"; then fail "installer enables shell tracing"; fi
+
+# Baseline creation is one-time and copies exactly the public canonical
+# descriptor plus the one package it references.  It must not sweep or copy the
+# config directory that contains tokens, certificates, TOMLs, and Docker auth.
+for contract in \
+  'rollback="$dev_root/rollback"' \
+  'chmod 0700 "$rollback_tmp"' \
+  'if [ -e "$rollback" ] || [ -L "$rollback" ]; then' \
+  'cp -- "$canonical_plg" "$rollback_tmp/ci-runner-farm.plg"' \
+  'baseline_package="$canonical_cfg/$baseline_name"' \
+  'cp -- "$baseline_package" "$rollback_tmp/packages/$baseline_name"' \
+  'printf '\''%s\n'\'' absent >"$rollback_tmp/state"' \
+  'canonical descriptor'\''s exact cached package is unavailable; refusing an incomplete baseline'
+do
+  grep -qF -- "$contract" "$INSTALLER" || fail "missing rollback-baseline contract: $contract"
+done
+if grep -Eq 'cp[[:space:]]+-R.*(canonical_cfg|/boot/config/plugins/ci-runner-farm)' "$INSTALLER"; then
+  fail "installer recursively copies the persistent config/credential directory"
+fi
+if grep -Eq 'find[[:space:]]+"?\$canonical_cfg|rm[[:space:]].*\$canonical_cfg/.*\*' "$INSTALLER"; then
+  fail "installer sweeps canonical cached packages"
+fi
+
+# Uploaded bytes are verified, then the external package commits before Unraid
+# registers the canonical descriptor.  A retained descriptor is only a hash
+# provenance record and never replaces the canonical file itself.
+upload_verify_line="$(line_of "$INSTALLER" '[ "$(sha256_of "$uploaded_package")" = "$package_sha256" ]')"
+baseline_commit_line="$(line_of "$INSTALLER" '  mv -- "$rollback_tmp" "$rollback"')"
+package_commit_line="$(line_of "$INSTALLER" 'commit_artifact "$uploaded_package" "$artifacts/$package_name"')"
+plugin_install_line="$(line_of "$INSTALLER" 'plugin install "$uploaded_plugin"')"
+canonical_verify_line="$(line_of "$INSTALLER" 'canonical descriptor verification failed after plugin install')"
+[ "$upload_verify_line" -lt "$baseline_commit_line" ] \
+  && [ "$baseline_commit_line" -lt "$package_commit_line" ] \
+  && [ "$package_commit_line" -lt "$plugin_install_line" ] \
+  && [ "$plugin_install_line" -lt "$canonical_verify_line" ] \
+  || fail "upload/baseline/artifact/plugin commit ordering is unsafe"
+
+# Rollback uses the current engine, then holds the same fleet lock while proving
+# every owned class and daemon empty.  It restores package first and descriptor
+# last, without invoking plugin install or extracting an old runtime.
+stop_line="$(line_of "$INSTALLER" 'if ! "$engine" stop >/dev/null 2>&1; then')"
+lock_line="$(line_of "$INSTALLER" 'exec 8>"$rundir/fleet.lock"')"
+manager_line="$(line_of "$INSTALLER" 'docker_names "runner managers"')"
+restore_package_line="$(line_of "$INSTALLER" '      mv -- "$package_tmp" "$destination"')"
+restore_descriptor_line="$(line_of "$INSTALLER" '    mv -- "$descriptor_tmp" "$canonical_plg"')"
+[ "$stop_line" -lt "$lock_line" ] && [ "$lock_line" -lt "$manager_line" ] \
+  && [ "$manager_line" -lt "$restore_package_line" ] \
+  && [ "$restore_package_line" -lt "$restore_descriptor_line" ] \
+  || fail "Stop/lock/empty-check/restore ordering is unsafe"
+for resource in \
+  'runner managers' \
+  'GitLab DinD sidecars' \
+  'GitLab host-socket jobs/helpers/services' \
+  'registry mirrors' \
+  'GitHub validation containers' \
+  'GitLab validation jobs' \
+  'fixed-name registry mirror remains after Stop' \
+  'CI Runner Farm background daemon remains after Stop'
+do
+  grep -qF -- "$resource" "$INSTALLER" || fail "rollback omits empty check: $resource"
+done
+rollback_block="$(awk '
+  /^ssh -- "\$HOST" \/bin\/bash -s <<'"'"'REMOTE_ROLLBACK'"'"'$/ { emit=1 }
+  emit { print }
+  emit && /^REMOTE_ROLLBACK$/ { exit }
+' "$INSTALLER")"
+[ -n "$rollback_block" ] || fail "could not locate rollback transaction"
+if printf '%s\n' "$rollback_block" | grep -qF 'plugin install'; then
+  fail "rollback overlays the baseline runtime through plugin install"
+fi
+if printf '%s\n' "$rollback_block" | grep -Eq 'tar[[:space:]]+-x|/usr/local/emhttp/plugins.*(cp|mv)'; then
+  fail "rollback overlays files into the live runtime"
+fi
+grep -qF 'Reboot is required; this script did not reboot.' "$INSTALLER" \
+  || fail "rollback does not state the reboot boundary"
+if printf '%s\n' "$rollback_block" | grep -Eq '(^|[[:space:]])(reboot|shutdown)([[:space:]]|$)'; then
+  fail "rollback reboots the host"
+fi
+
+# Exercise local validation and the observable failure order with mocked
+# deploy/SSH commands.  The remote heredocs are deliberately not executed.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+repo="$tmp/repo"
+mkdir -p "$repo/tmp/dev-package" "$tmp/bin"
+cp "$INSTALLER" "$repo/install-dev.sh"
+chmod 0755 "$repo/install-dev.sh"
+
+cat >"$repo/deploy.sh" <<'MOCK_DEPLOY'
+#!/usr/bin/env bash
+printf 'deploy\n' >>"$TEST_LOG"
+[ "${MOCK_DEPLOY_FAIL:-0}" = 0 ] || exit 42
+MOCK_DEPLOY
+chmod 0755 "$repo/deploy.sh"
+
+cat >"$tmp/bin/ssh" <<'MOCK_SSH'
+#!/usr/bin/env bash
+args=" $* "
+case "$args" in
+  *' mktemp -d /tmp/ci-runner-farm-dev.XXXXXX '*)
+    printf 'ssh-stage\n' >>"$TEST_LOG"
+    printf '/tmp/ci-runner-farm-dev.ABC123\n'
+    ;;
+  *' tar -xf - -C '*)
+    printf 'ssh-upload\n' >>"$TEST_LOG"
+    while IFS= read -r -n 8192 chunk; do :; done || true
+    ;;
+  *' /bin/bash -s -- '*)
+    printf 'ssh-install\n' >>"$TEST_LOG"
+    while IFS= read -r line; do :; done
+    ;;
+  *' /bin/bash -s '*)
+    printf 'ssh-rollback\n' >>"$TEST_LOG"
+    while IFS= read -r line; do :; done
+    ;;
+  *' rm -rf -- '*) printf 'ssh-cleanup\n' >>"$TEST_LOG" ;;
+  *) printf 'unexpected ssh call: %s\n' "$*" >&2; exit 91 ;;
+esac
+MOCK_SSH
+chmod 0755 "$tmp/bin/ssh"
+
+version=2026.08.04.1615.1-1.8.0-jcuratec.gitlab.dev.0123456789ab
+package="ci-runner-farm-jcuratec-dev-$version.tgz"
+printf 'mock development package bytes\n' >"$repo/tmp/dev-package/$package"
+read -r package_md5 package_sha <<EOF
+$(python3 - "$repo/tmp/dev-package/$package" <<'PY'
+import hashlib, sys
+data = open(sys.argv[1], "rb").read()
+print(hashlib.md5(data).hexdigest(), hashlib.sha256(data).hexdigest())
+PY
+)
+EOF
+cat >"$repo/tmp/dev-package/ci-runner-farm.plg" <<EOF
+<?xml version='1.0' standalone='yes'?>
+<!DOCTYPE PLUGIN [
+<!ENTITY name "ci-runner-farm">
+<!ENTITY version "$version">
+<!ENTITY packageName "$package">
+<!ENTITY packageMD5 "$package_md5">
+<!ENTITY packageSHA256 "$package_sha">
+]>
+<PLUGIN name="&name;" version="&version;">
+<FILE Name="/tmp/&packageName;"><LOCAL>/boot/config/ci-runner-farm-dev/artifacts/&packageName;</LOCAL><MD5>&packageMD5;</MD5><SHA256>&packageSHA256;</SHA256></FILE>
+</PLUGIN>
+EOF
+python3 - "$repo/tmp/dev-package/manifest.json" "$version" "$package" "$package_md5" "$package_sha" <<'PY'
+import json, sys
+path, version, package, md5, sha = sys.argv[1:]
+with open(path, "w", encoding="utf-8") as stream:
+    json.dump({
+        "schema": 1,
+        "name": "ci-runner-farm",
+        "mode": "dev",
+        "version": version,
+        "plugin_file": "ci-runner-farm.plg",
+        "package_file": package,
+        "package_md5": md5,
+        "package_sha256": sha,
+        "source_path": "/boot/config/ci-runner-farm-dev/artifacts/" + package,
+        "runtime_root": "src/usr/local/emhttp/plugins/ci-runner-farm",
+    }, stream, separators=(",", ":"))
+    stream.write("\n")
+PY
+
+log="$tmp/actions.log"
+: >"$log"
+TEST_LOG="$log" PATH="$tmp/bin:$PATH" "$repo/install-dev.sh" root@mock-unraid >/dev/null
+expected="$(printf 'deploy\nssh-stage\nssh-upload\nssh-install\nssh-cleanup\n')"
+[ "$(cat "$log")" = "$expected" ] || fail "mocked successful install order was: $(tr '\n' ' ' <"$log")"
+
+: >"$log"
+if TEST_LOG="$log" MOCK_DEPLOY_FAIL=1 PATH="$tmp/bin:$PATH" \
+    "$repo/install-dev.sh" root@mock-unraid >/dev/null 2>&1; then
+  fail "installer ignored deploy failure"
+fi
+[ "$(cat "$log")" = deploy ] || fail "flash/upload mutation occurred after deploy failure"
+
+: >"$log"
+printf 'tamper\n' >>"$repo/tmp/dev-package/$package"
+if TEST_LOG="$log" PATH="$tmp/bin:$PATH" "$repo/install-dev.sh" root@mock-unraid >/dev/null 2>&1; then
+  fail "installer accepted a package hash mismatch"
+fi
+[ ! -s "$log" ] || fail "installer mutated the host before rejecting a package hash mismatch"
+
+: >"$log"
+if TEST_LOG="$log" PATH="$tmp/bin:$PATH" "$repo/install-dev.sh" 'root@host;touch_bad' >/dev/null 2>&1; then
+  fail "installer accepted an unsafe host"
+fi
+[ ! -s "$log" ] || fail "unsafe host reached deploy/SSH"
+
+: >"$log"
+TEST_LOG="$log" PATH="$tmp/bin:$PATH" "$repo/install-dev.sh" --rollback root@mock-unraid >/dev/null
+[ "$(cat "$log")" = ssh-rollback ] || fail "rollback invoked deploy or an unexpected SSH sequence"
+
+echo "install-dev-safety: OK — local validation and failure/commit/rollback ordering are fail-closed"

--- a/tests/install-dev-safety.sh
+++ b/tests/install-dev-safety.sh
@@ -8,12 +8,17 @@ INSTALLER=install-dev.sh
 fail() { printf 'INSTALL-DEV SAFETY FAIL: %s\n' "$*" >&2; exit 1; }
 line_of() {
   local value
-  value="$(grep -nF -- "$2" "$1" | head -1 | cut -d: -f1)"
+  value="$(grep -nF -- "$2" "$1" | head -1 | cut -d: -f1 || true)"
   [ -n "$value" ] || fail "missing contract: $2"
   printf '%s\n' "$value"
 }
 
 bash -n "$INSTALLER" || fail "installer has invalid shell syntax"
+missing_line_output="$( (line_of "$INSTALLER" '__install_dev_missing_contract_probe__') 2>&1 || true)"
+case "$missing_line_output" in
+  *'missing contract: __install_dev_missing_contract_probe__'*) ;;
+  *) fail "line_of suppresses its focused missing-contract diagnostic" ;;
+esac
 
 # The local bundle is authenticated before the first remote mutation, and the
 # lock-protected live deployment completes before flash state is created.
@@ -37,6 +42,9 @@ do
 done
 grep -qF 'case "${HOST#root@}"' "$INSTALLER" || fail "host shell syntax is not rejected"
 if grep -qF 'set -x' "$INSTALLER"; then fail "installer enables shell tracing"; fi
+if grep -qF 'PACKAGE="$BUNDLE_DIR/$PACKAGE_FILE"' "$INSTALLER"; then
+  fail "installer retains the unused PACKAGE assignment"
+fi
 
 # Baseline creation is one-time and copies exactly the public canonical
 # descriptor plus the one package it references.  It must not sweep or copy the
@@ -52,6 +60,22 @@ for contract in \
   'canonical descriptor'\''s exact cached package is unavailable; refusing an incomplete baseline'
 do
   grep -qF -- "$contract" "$INSTALLER" || fail "missing rollback-baseline contract: $contract"
+done
+cleanup_function_line="$(line_of "$INSTALLER" 'cleanup_install_temps() {')"
+cleanup_trap_line="$(line_of "$INSTALLER" 'trap cleanup_install_temps EXIT')"
+rollback_tmp_line="$(line_of "$INSTALLER" '  rollback_tmp="$(mktemp -d "$dev_root/.rollback.XXXXXX")"')"
+commit_tmp_line="$(line_of "$INSTALLER" '  commit_tmp="$(mktemp "$artifacts/.commit.XXXXXX")"')"
+[ "$cleanup_function_line" -lt "$cleanup_trap_line" ] \
+  && [ "$cleanup_trap_line" -lt "$rollback_tmp_line" ] \
+  && [ "$cleanup_trap_line" -lt "$commit_tmp_line" ] \
+  || fail "temporary-path cleanup is not armed before temporary paths are created"
+for contract in \
+  '"$dev_root"/.rollback.*) rm -rf -- "$rollback_tmp" || status=1' \
+  '"$artifacts"/.commit.*) rm -f -- "$commit_tmp" || status=1' \
+  '  rollback_tmp=' \
+  '  commit_tmp='
+do
+  grep -qF -- "$contract" "$INSTALLER" || fail "missing temporary cleanup contract: $contract"
 done
 if grep -Eq 'cp[[:space:]]+-R.*(canonical_cfg|/boot/config/plugins/ci-runner-farm)' "$INSTALLER"; then
   fail "installer recursively copies the persistent config/credential directory"
@@ -98,6 +122,22 @@ for resource in \
 do
   grep -qF -- "$resource" "$INSTALLER" || fail "rollback omits empty check: $resource"
 done
+for contract in \
+  'legacy_name="$(docker inspect -f '\''{{.Name}}'\'' ci-runner-mirror 2>/dev/null)"' \
+  'legacy_image="$(docker inspect -f '\''{{.Config.Image}}'\'' ci-runner-mirror 2>/dev/null)"' \
+  'legacy_source="$(docker inspect -f '\''{{range .Mounts}}{{if eq .Destination "/var/lib/registry"}}{{.Source}}{{end}}{{end}}'\'' ci-runner-mirror 2>/dev/null)"' \
+  'REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io' \
+  '[ "$legacy_name" = /ci-runner-mirror ]' \
+  '[ "$legacy_image" = registry:2 ]' \
+  '[ "$legacy_source" = "$legacy_cache_root/registry-mirror" ]'
+do
+  grep -qF -- "$contract" "$INSTALLER" || fail "rollback omits legacy mirror provenance: $contract"
+done
+legacy_name_line="$(line_of "$INSTALLER" 'legacy_name="$(docker inspect')"
+legacy_tuple_line="$(line_of "$INSTALLER" '  if [ "$legacy_name" = /ci-runner-mirror ]')"
+legacy_fail_line="$(line_of "$INSTALLER" '    fail "fixed-name registry mirror remains after Stop"')"
+[ "$legacy_name_line" -lt "$legacy_tuple_line" ] && [ "$legacy_tuple_line" -lt "$legacy_fail_line" ] \
+  || fail "an unrelated fixed-name mirror can still trigger rollback failure before provenance matches"
 rollback_block="$(awk '
   /^ssh -- "\$HOST" \/bin\/bash -s <<'"'"'REMOTE_ROLLBACK'"'"'$/ { emit=1 }
   emit { print }
@@ -120,6 +160,35 @@ fi
 # deploy/SSH commands.  The remote heredocs are deliberately not executed.
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
+
+# Execute the install transaction's actual EXIT-trap function against both
+# temporary path classes. An implicit set -e failure must retain its non-zero
+# status while removing the baseline directory and the artifact staging file.
+cleanup_function="$(awk '
+  /^cleanup_install_temps\(\) \{$/ { emit=1 }
+  emit { print }
+  emit && /^}$/ { exit }
+' "$INSTALLER")"
+[ -n "$cleanup_function" ] || fail "could not extract temporary cleanup function"
+cleanup_root="$tmp/cleanup-probe"
+cleanup_artifacts="$cleanup_root/artifacts"
+cleanup_rollback="$cleanup_root/.rollback.ABC123"
+cleanup_commit="$cleanup_artifacts/.commit.ABC123"
+mkdir -p "$cleanup_rollback" "$cleanup_artifacts"
+printf 'partial artifact\n' >"$cleanup_commit"
+cleanup_probe="$tmp/cleanup-probe.sh"
+{
+  printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
+  printf '%s\n' 'dev_root="$1"' 'artifacts="$2"' 'rollback_tmp="$3"' 'commit_tmp="$4"'
+  printf '%s\n' "$cleanup_function"
+  printf '%s\n' 'trap cleanup_install_temps EXIT' 'false'
+} >"$cleanup_probe"
+if bash "$cleanup_probe" "$cleanup_root" "$cleanup_artifacts" "$cleanup_rollback" "$cleanup_commit"; then
+  fail "temporary cleanup probe lost the triggering failure status"
+fi
+[ ! -e "$cleanup_rollback" ] || fail "rollback temporary directory survived a transaction failure"
+[ ! -e "$cleanup_commit" ] || fail "artifact temporary file survived a transaction failure"
+
 repo="$tmp/repo"
 mkdir -p "$repo/tmp/dev-package" "$tmp/bin"
 cp "$INSTALLER" "$repo/install-dev.sh"

--- a/tests/linux-checks.Dockerfile
+++ b/tests/linux-checks.Dockerfile
@@ -1,21 +1,29 @@
 # Reproducible Linux check environment for macOS and other non-Unraid hosts.
 # Build context is the repository root; tests/run-linux-checks.sh drives it.
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
+# The minimal Ubuntu image has no CA bundle. Bootstrap that one package from
+# signed snapshot metadata, then require normal TLS verification for everything
+# else. Both archive/security and ports images resolve through this fixed URL.
+RUN sed -Ei \
+      's#https?://(archive\.ubuntu\.com|security\.ubuntu\.com)/ubuntu/?#https://snapshot.ubuntu.com/ubuntu/20260801T000000Z/#; s#http://ports\.ubuntu\.com/ubuntu-ports/?#https://snapshot.ubuntu.com/ubuntu/20260801T000000Z/#' \
+      /etc/apt/sources.list.d/ubuntu.sources \
+ && apt-get -o Acquire::https::Verify-Peer=false update \
+ && apt-get -o Acquire::https::Verify-Peer=false install -y --no-install-recommends \
+      ca-certificates=20260601~24.04.1 \
+ && apt-get update \
  && apt-get install -y --no-install-recommends \
-      bash \
-      ca-certificates \
-      coreutils \
-      diffutils \
-      findutils \
-      git \
-      gzip \
-      php-cli \
-      python3 \
-      sed \
-      tar \
+      bash=5.2.21-2ubuntu4 \
+      coreutils=9.4-3ubuntu6.2 \
+      diffutils=1:3.10-1build1 \
+      findutils=4.9.0-5build1 \
+      git=1:2.43.0-1ubuntu7.3 \
+      gzip=1.12-1ubuntu3.2 \
+      php-cli=2:8.3+93ubuntu2 \
+      python3=3.12.3-0ubuntu2.1 \
+      sed=4.9-2ubuntu0.24.04.1 \
+      tar=1.35+dfsg-3ubuntu0.4 \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/tests/linux-checks.Dockerfile
+++ b/tests/linux-checks.Dockerfile
@@ -1,0 +1,23 @@
+# Reproducible Linux check environment for macOS and other non-Unraid hosts.
+# Build context is the repository root; tests/run-linux-checks.sh drives it.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      bash \
+      ca-certificates \
+      coreutils \
+      diffutils \
+      findutils \
+      git \
+      gzip \
+      php-cli \
+      python3 \
+      sed \
+      tar \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY . /workspace
+RUN bash tests/check.sh

--- a/tests/ownership-safety.sh
+++ b/tests/ownership-safety.sh
@@ -1,0 +1,468 @@
+#!/usr/bin/env bash
+# Destructive fixed-name operations must be authorized by one immutable Docker
+# object snapshot. Exercise the real recycle and GitHub validation paths with a
+# mocked Docker CLI so regressions cannot hide behind UI-only name validation.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ENGINE="src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() { echo "ownership-safety: $*" >&2; exit 1; }
+
+run_recycle_tests() (
+  export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/recycle-cfg" CRF_RUNDIR="$tmp/recycle-run"
+  mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+  # shellcheck source=/dev/null
+  source "$ENGINE"
+
+  local_id="1111111111111111111111111111111111111111111111111111111111111111"
+  mutation_log="$tmp/recycle-mutations.log"
+  : > "$mutation_log"
+  SNAP_MODE=unlabeled
+  REMOVED=0
+
+  docker() {
+    local cmd="${1:-}" fmt="" target="" managed provider role index
+    shift || true
+    case "$cmd" in
+      inspect)
+        if [ "${1:-}" = -f ]; then
+          fmt="$2"; target="$3"
+          case "$fmt" in
+            *net.unraid.ci-runner-farm.managed*)
+              managed=true; provider=github; role=runner; index=1
+              case "$SNAP_MODE" in
+                unlabeled) managed='<no value>'; provider='<no value>'; role='<no value>'; index='<no value>' ;;
+                wrong-provider) provider=foreign ;;
+                wrong-role) role=foreign ;;
+                wrong-index) index=2 ;;
+                legacy) provider='<no value>'; role='<no value>' ;;
+                valid) ;;
+              esac
+              printf '%s|%s|%s|%s|%s|abc123|/%s\n' \
+                "$local_id" "$managed" "$provider" "$role" "$index" "$target"
+              ;;
+            '{{.Id}}')
+              [ "$REMOVED" -eq 0 ] && [ "$target" = ci-runner-1 ] \
+                && printf '%s\n' "$local_id" || return 1
+              ;;
+            '{{.Name}}')
+              [ "$REMOVED" -eq 0 ] && [ "$target" = "$local_id" ] \
+                && printf '/ci-runner-1\n' || return 1
+              ;;
+            *) printf 'mock-inspect\n' ;;
+          esac
+        else
+          target="${1:-}"
+          [ "$REMOVED" -eq 0 ] && { [ "$target" = "$local_id" ] || [ "$target" = ci-runner-1 ]; }
+        fi
+        ;;
+      stop)
+        printf 'docker stop %s\n' "$*" >> "$mutation_log"
+        [ "${*: -1}" = "$local_id" ]
+        ;;
+      rm)
+        printf 'docker rm %s\n' "$*" >> "$mutation_log"
+        [ "${*: -1}" = "$local_id" ] || return 1
+        REMOVED=1
+        ;;
+      run)
+        printf 'docker run %s\n' "$*" >> "$mutation_log"
+        ;;
+      *) return 0 ;;
+    esac
+  }
+
+  managed_names() { printf '%s\n' ci-runner-1; }
+  crf_confgen() { printf 'abc123\n'; }
+  provider_token_ready() { return 0; }
+  provider_validate_settings() { return 0; }
+  provision_base() { return 0; }
+  firewall_prepare_replacement() { return 0; }
+  gitlab_cleanup_orphan_sidecars() { return 0; }
+  github_replacement_preflight() { return 0; }
+  recycle_image_preflight() { return 0; }
+  effective_image() { printf 'replacement-image\n'; }
+  build_args() { ARGS=( replacement-image ); }
+  github_deregister_runner_api() { printf 'provider-api %s\n' "$1" >> "$mutation_log"; }
+  CI_PROVIDER=github
+  NETWORK_ISOLATION=off
+  IMAGE_SOURCE=builtin
+
+  # Every incomplete/mismatched ownership contract must fail before a pull,
+  # stop, remote deregistration, or Docker removal can happen.
+  for SNAP_MODE in unlabeled wrong-provider wrong-role wrong-index; do
+    : > "$mutation_log"; REMOVED=0
+    if cmd_recycle ci-runner-1 >"$tmp/recycle-$SNAP_MODE.out" 2>/dev/null; then
+      fail "recycle accepted $SNAP_MODE ownership labels"
+    fi
+    [ ! -s "$mutation_log" ] || fail "recycle mutated an $SNAP_MODE collision"
+  done
+
+  # Existing managed GitHub slots from before provider/role labels remain a
+  # narrow upgrade-compatible form; managed+matching index are still required.
+  SNAP_MODE=legacy
+  legacy="$(managed_runner_snapshot ci-runner-1)" || fail "legacy managed GitHub slot was rejected"
+  case "$legacy" in "$local_id|github|runner|1|abc123") ;; *) fail "legacy GitHub snapshot was not normalized" ;; esac
+
+  # A current owned slot is stopped/removed only through its immutable ID, while
+  # the provider API still receives the stable ci-runner-N identity.
+  SNAP_MODE=valid
+  : > "$mutation_log"; REMOVED=0
+  cmd_recycle ci-runner-1 >"$tmp/recycle-valid.out" \
+    || { cat "$tmp/recycle-valid.out" >&2; fail "owned recycle failed"; }
+  grep -q "^docker stop --timeout 30 $local_id$" "$mutation_log" \
+    || fail "recycle did not stop the immutable container ID"
+  grep -q "^docker rm $local_id$" "$mutation_log" \
+    || fail "recycle did not remove the immutable container ID"
+  grep -q '^provider-api ci-runner-1$' "$mutation_log" \
+    || fail "provider API did not retain the stable slot name"
+  if grep -Eq '^docker (stop|rm).*ci-runner-1$' "$mutation_log"; then
+    fail "recycle sent the mutable slot name to a destructive Docker command"
+  fi
+)
+
+run_github_validate_test() (
+  export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/validate-cfg" CRF_RUNDIR="$tmp/validate-run"
+  mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR" "$tmp/validate-cache"
+  # shellcheck source=/dev/null
+  source "$ENGINE"
+
+  MOCK_VALIDATION_ID="2222222222222222222222222222222222222222222222222222222222222222"
+  docker_log="$tmp/github-validate-docker.log"
+  : > "$docker_log"
+  VALIDATE_NAME=""
+
+  check_cache_root() { return 0; }
+  ensure_dirs() { return 0; }
+  registry_login() { return 0; }
+  crf_safe_cache_root() { printf '%s\n' "$CACHE_ROOT"; }
+  crf_confgen() { printf 'abc123\n'; }
+  effective_image() { printf 'validation-image\n'; }
+  CACHE_ROOT="$tmp/validate-cache"
+  CACHE_MOUNTS=""
+  DIND=false
+  SHARE_DOCKER_SOCK=false
+  WORK_TMPFS_SIZE=""
+  RUNNER_CPUS=""
+  RUNNER_MEMORY=""
+  GH_REPOS="example/project"
+
+  docker() {
+    local cmd="${1:-}" fmt="" target="" prev="" arg
+    shift || true
+    case "$cmd" in
+      run)
+        for arg in "$@"; do
+          [ "$prev" = --name ] && VALIDATE_NAME="$arg"
+          prev="$arg"
+        done
+        printf 'docker run %s\n' "$*" >> "$docker_log"
+        [ -n "$VALIDATE_NAME" ] || return 1
+        ;;
+      inspect)
+        [ "${1:-}" = -f ] || return 1
+        fmt="$2"; target="$3"
+        case "$fmt" in
+          *net.unraid.ci-runner-farm.managed*)
+            [ "$target" = "$VALIDATE_NAME" ] || return 1
+            printf '%s|true|github|validate|99|abc123|/%s\n' "$MOCK_VALIDATION_ID" "$VALIDATE_NAME"
+            ;;
+          *) printf 'mock-inspect\n' ;;
+        esac
+        ;;
+      exec)
+        printf 'docker exec %s\n' "$*" >> "$docker_log"
+        [ "${1:-}" = "$MOCK_VALIDATION_ID" ]
+        ;;
+      rm)
+        printf 'docker rm %s\n' "$*" >> "$docker_log"
+        [ "${1:-}" = -f ] && [ "${2:-}" = "$MOCK_VALIDATION_ID" ]
+        ;;
+      *) return 0 ;;
+    esac
+  }
+
+  github_validate >"$tmp/github-validate.out" \
+    || { cat "$tmp/github-validate.out" >&2; fail "GitHub validation failed"; }
+  printf '%s' "$VALIDATE_NAME" | grep -qE '^ci-runner-validate-[0-9a-f]{12}$' \
+    || fail "GitHub validation did not use a randomized container name"
+  grep -q 'net.unraid.ci-runner-farm.provider=github' "$docker_log" \
+    || fail "GitHub validation container lacks its provider label"
+  grep -q 'net.unraid.ci-runner-farm.role=validate' "$docker_log" \
+    || fail "GitHub validation container lacks its validation-role label"
+  grep -q "^docker rm -f $MOCK_VALIDATION_ID$" "$docker_log" \
+    || fail "GitHub validation did not remove its immutable container ID"
+  if grep -Eq 'docker rm -f ci-runner-validate($| )' "$docker_log"; then
+    fail "GitHub validation attempted to remove the old fixed name"
+  fi
+)
+
+run_log_ownership_tests() (
+  export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/log-cfg" CRF_RUNDIR="$tmp/log-run"
+  mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+  # shellcheck source=/dev/null
+  source "$ENGINE"
+
+  log_id="3333333333333333333333333333333333333333333333333333333333333333"
+  docker_calls="$tmp/log-docker.calls"; : > "$docker_calls"
+  LOG_OWNED=0
+  docker() {
+    if [ "${1:-}" = inspect ] && [ "${2:-}" = -f ]; then
+      if [ "$LOG_OWNED" = 1 ]; then
+        printf '%s|true|github|runner|1|abc123|/ci-runner-1\n' "$log_id"
+      else
+        printf '%s|<no value>|<no value>|<no value>|<no value>|<no value>|/ci-runner-1\n' "$log_id"
+      fi
+      return 0
+    fi
+    if [ "${1:-}" = logs ]; then
+      printf 'docker %s\n' "$*" >> "$docker_calls"
+      printf 'owned runner log\n'
+      return 0
+    fi
+    return 1
+  }
+
+  if cmd_logs_tail ci-runner-1 150 >/dev/null 2>&1; then
+    fail "log tail accepted an unowned fixed-name collision"
+  fi
+  [ ! -s "$docker_calls" ] || fail "unowned log request reached docker logs"
+
+  LOG_OWNED=1
+  cmd_logs_tail ci-runner-1 150 > "$tmp/owned-runner.log" \
+    || fail "owned runner log request failed"
+  grep -q "^docker logs --tail 150 $log_id$" "$docker_calls" \
+    || fail "runner logs were read through the mutable fixed name instead of immutable ID"
+  grep -q '^owned runner log$' "$tmp/owned-runner.log" \
+    || fail "owned runner logs were not returned"
+)
+
+run_orphan_validation_cleanup_tests() (
+  export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/orphan-validate-cfg" CRF_RUNDIR="$tmp/orphan-validate-run"
+  mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+  # shellcheck source=/dev/null
+  source "$ENGINE"
+
+  orphan_id="4444444444444444444444444444444444444444444444444444444444444444"
+  orphan_name=ci-runner-validate-abcdef123456
+  orphan_index=99
+  orphan_enum_fail=0
+  orphan_log="$tmp/orphan-validate-docker.log"; : > "$orphan_log"
+
+  docker() {
+    local cmd="${1:-}" fmt target
+    shift || true
+    case "$cmd" in
+      ps)
+        [ "$orphan_enum_fail" -eq 0 ] || return 1
+        printf '%s\n' "$orphan_name"
+        ;;
+      inspect)
+        [ "${1:-}" = -f ] || return 1
+        fmt="$2"; target="$3"
+        case "$fmt" in
+          *net.unraid.ci-runner-farm.managed*)
+            printf '%s|true|github|validate|%s|abc123|/%s\n' \
+              "$orphan_id" "$orphan_index" "$target"
+            ;;
+          *) return 1 ;;
+        esac
+        ;;
+      rm)
+        printf 'docker rm %s\n' "$*" >> "$orphan_log"
+        [ "${1:-}" = -f ] && [ "${2:-}" = "$orphan_id" ]
+        ;;
+      *) return 1 ;;
+    esac
+  }
+
+  cleanup_orphan_github_validations \
+    || fail "owned orphaned GitHub validation container was not cleaned"
+  grep -qx "docker rm -f $orphan_id" "$orphan_log" \
+    || fail "orphaned GitHub validation was not removed through its immutable ID"
+
+  : > "$orphan_log"; orphan_index=1
+  if cleanup_orphan_github_validations >/dev/null 2>&1; then
+    fail "orphan cleanup accepted a validation container with the wrong index"
+  fi
+  [ ! -s "$orphan_log" ] || fail "wrong-index validation collision reached docker rm"
+
+  orphan_index=99; orphan_name=ci-runner-validate-fixed
+  if cleanup_orphan_github_validations >/dev/null 2>&1; then
+    fail "orphan cleanup accepted a non-random validation container name"
+  fi
+  [ ! -s "$orphan_log" ] || fail "unexpected validation name reached docker rm"
+
+  orphan_name=ci-runner-validate-abcdef123456; orphan_enum_fail=1
+  if cleanup_orphan_github_validations >/dev/null 2>&1; then
+    fail "orphan cleanup treated Docker enumeration failure as an empty result"
+  fi
+  [ ! -s "$orphan_log" ] || fail "enumeration failure reached docker rm"
+)
+
+run_lifecycle_failure_tests() (
+  export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/lifecycle-cfg" CRF_RUNDIR="$tmp/lifecycle-run"
+  mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+  # shellcheck source=/dev/null
+  source "$ENGINE"
+
+  life_id1="5555555555555555555555555555555555555555555555555555555555555555"
+  life_id2="6666666666666666666666666666666666666666666666666666666666666666"
+  life_mode=one
+  life_log="$tmp/lifecycle-mutations.log"; : > "$life_log"
+  managed_names() {
+    case "$life_mode" in
+      enum-fail) return 1 ;;
+      none) return 0 ;;
+      one|inspect-fail) printf '%s\n' ci-runner-1 ;;
+      two) printf '%s\n' ci-runner-1 ci-runner-2 ;;
+    esac
+  }
+  managed_runner_snapshot() {
+    [ "$life_mode" != inspect-fail ] || return 1
+    case "$1" in
+      ci-runner-1) printf '%s|github|runner|1|old-generation\n' "$life_id1" ;;
+      ci-runner-2) printf '%s|github|runner|2|old-generation\n' "$life_id2" ;;
+      *) return 1 ;;
+    esac
+  }
+  crf_confgen() { printf '%s\n' current-generation; }
+  github_remove_runner() {
+    printf 'remove %s %s %s\n' "$1" "${CRF_REMOVE_ID:-missing}" "${CRF_REMOVE_PROVIDER:-missing}" >> "$life_log"
+    [ "$1" != ci-runner-2 ]
+  }
+  docker() {
+    if [ "${1:-}" = inspect ] && [ "${2:-}" = -f ]; then
+      case "$3" in
+        '{{.State.Status}}') printf '%s\n' exited ;;
+        '{{if .State.Health}}{{.State.Health.Status}}{{end}}') printf '%s\n' healthy ;;
+        *) return 1 ;;
+      esac
+      return 0
+    fi
+    return 1
+  }
+
+  life_mode=inspect-fail
+  if remove_runner ci-runner-1 >/dev/null 2>&1; then
+    fail "remove_runner accepted a slot whose ownership snapshot failed"
+  fi
+  [ ! -s "$life_log" ] || fail "failed ownership snapshot reached a provider removal adapter"
+
+  life_mode=one
+  remove_runner ci-runner-1 || fail "owned removal snapshot was rejected"
+  grep -qx "remove ci-runner-1 $life_id1 github" "$life_log" \
+    || fail "remove_runner did not bind immutable ID/provider into the adapter transaction"
+
+  life_mode=enum-fail
+  if count_stale_runners >/dev/null 2>&1; then
+    fail "stale count treated Docker enumeration failure as zero"
+  fi
+  life_mode=inspect-fail
+  if count_stale_runners >/dev/null 2>&1; then
+    fail "stale count ignored an ownership/inspect failure"
+  fi
+
+  : > "$life_log"; life_mode=two
+  if reap_dead_runners >/dev/null 2>&1; then
+    fail "dead-runner reap hid a provider removal failure"
+  fi
+  grep -qx "remove ci-runner-1 $life_id1 github" "$life_log" \
+    || fail "dead-runner reap skipped the first owned slot"
+  grep -qx "remove ci-runner-2 $life_id2 github" "$life_log" \
+    || fail "dead-runner reap did not aggregate the later slot failure"
+
+  AUTOSCALE=true
+  reap_dead_runners() { return 0; }
+  provider_call() { return 1; }
+  cmd_scale() { printf 'unsafe scale\n' >> "$life_log"; }
+  : > "$life_log"
+  if autoscale_tick >/dev/null 2>&1; then
+    fail "autoscale accepted failed provider fleet counts"
+  fi
+  [ ! -s "$life_log" ] || fail "autoscale mutated capacity after count failure"
+
+  IMAGEUPDATE_PENDING="$tmp/lifecycle-imageupdate.pending"
+  printf '%s\n' ci-runner-7 > "$IMAGEUPDATE_PENDING"
+  life_mode=enum-fail
+  if imageupdate_rollover false >/dev/null 2>&1; then
+    fail "image rollover treated fleet enumeration failure as completion"
+  fi
+  grep -qx ci-runner-7 "$IMAGEUPDATE_PENDING" \
+    || fail "image rollover discarded pending state after enumeration failure"
+
+  life_mode=none
+  current_count() { return 1; }
+  if imageupdate_rollover false >/dev/null 2>&1; then
+    fail "image rollover reported completion when final fleet verification failed"
+  fi
+  grep -qx ci-runner-7 "$IMAGEUPDATE_PENDING" \
+    || fail "image rollover cleared pending state before final verification"
+)
+
+run_reconcile_gate_tests() (
+  export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/reconcile-cfg" CRF_RUNDIR="$tmp/reconcile-run"
+  mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+  # shellcheck source=/dev/null
+  source "$ENGINE"
+
+  gate_log="$tmp/reconcile-gate.log"
+  gate_fleet=""
+  gate_enum_ok=1
+  gate_token_ok=0
+  gate_settings_ok=1
+  managed_names() {
+    [ "$gate_enum_ok" -eq 1 ] || return 1
+    [ -z "$gate_fleet" ] || printf '%s\n' "$gate_fleet"
+  }
+  provider_token_ready() {
+    printf '%s\n' token >> "$gate_log"
+    [ "$gate_token_ok" -eq 1 ]
+  }
+  provider_token_name() { printf '%s\n' 'provider token'; }
+  provider_validate_settings() {
+    printf '%s\n' settings >> "$gate_log"
+    [ "$gate_settings_ok" -eq 1 ]
+  }
+  reconcile_start() { printf '%s\n' start >> "$gate_log"; }
+  NETWORK_ISOLATION=off
+
+  : > "$gate_log"
+  cmd_reconcile_config >/dev/null \
+    || fail "empty farm could not save valid provider settings before credentials"
+  if grep -q '^token$' "$gate_log"; then
+    fail "empty-fleet settings save unnecessarily required provider credentials"
+  fi
+  [ "$(tr '\n' ' ' < "$gate_log")" = 'settings start ' ] \
+    || fail "empty-fleet reconcile did not validate settings before launching"
+
+  : > "$gate_log"; gate_fleet=ci-runner-1; gate_token_ok=0
+  if cmd_reconcile_config >/dev/null 2>&1; then
+    fail "existing-fleet reconcile launched without destination credentials"
+  fi
+  grep -qx token "$gate_log" || fail "existing-fleet reconcile skipped its credential check"
+  if grep -q '^start$' "$gate_log"; then fail "credential failure still launched reconcile worker"; fi
+
+  : > "$gate_log"; gate_token_ok=1; gate_settings_ok=0
+  if cmd_reconcile_config >/dev/null 2>&1; then
+    fail "existing-fleet reconcile launched with invalid provider settings"
+  fi
+  if grep -q '^start$' "$gate_log"; then fail "settings failure still launched reconcile worker"; fi
+
+  : > "$gate_log"; gate_enum_ok=0; gate_settings_ok=1
+  if cmd_reconcile_config >/dev/null 2>&1; then
+    fail "config reconcile treated fleet enumeration failure as empty"
+  fi
+  [ ! -s "$gate_log" ] || fail "enumeration failure reached validation or worker launch"
+)
+
+run_recycle_tests
+run_github_validate_test
+run_log_ownership_tests
+run_orphan_validation_cleanup_tests
+run_lifecycle_failure_tests
+run_reconcile_gate_tests
+echo "ownership-safety: OK — lifecycle cleanup and mutation use verified immutable IDs and fail-closed fleet snapshots"

--- a/tests/package-contents.sh
+++ b/tests/package-contents.sh
@@ -51,6 +51,8 @@ for required_remove_line in \
   'set -euo pipefail' \
   'if ! "$PLGDIR/include/runner-farm.sh" stop' \
   'cleanup engine is missing and Docker is unavailable' \
+  'cleanup engine is missing and Docker ownership enumeration failed' \
+  'cleanup engine is missing and GitLab executor ownership enumeration failed' \
   'cleanup engine is missing while plugin-owned Docker resources still exist' \
   'if ! rm -rf -- "$PLGDIR" || [ -e "$PLGDIR" ]; then' \
   'if ! rm -f -- "$CFGDIR"/ci-runner-farm-*.tgz; then'
@@ -60,8 +62,8 @@ do
     exit 1
   }
 done
-cleanup_line="$(printf '%s\n' "$remove_block" | grep -nF 'if ! rm -f -- "$CFGDIR"/ci-runner-farm-*.tgz' | head -1 | cut -d: -f1)"
-success_line="$(printf '%s\n' "$remove_block" | grep -nF 'ci-runner-farm removed. Config + credentials left' | head -1 | cut -d: -f1)"
+cleanup_line="$(printf '%s\n' "$remove_block" | grep -nF 'if ! rm -f -- "$CFGDIR"/ci-runner-farm-*.tgz' | head -1 | cut -d: -f1 || true)"
+success_line="$(printf '%s\n' "$remove_block" | grep -nF 'ci-runner-farm removed. Config + credentials left' | head -1 | cut -d: -f1 || true)"
 [ -n "$cleanup_line" ] && [ -n "$success_line" ] && [ "$cleanup_line" -lt "$success_line" ] || {
   echo "package-contents: generated remove action can report success before cleanup completes" >&2
   exit 1

--- a/tests/package-contents.sh
+++ b/tests/package-contents.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Build in a temporary checkout fragment, validate the generated plugin XML, and
+# prove the archive contains the complete runtime tree (including provider files).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+RUNTIME="src/usr/local/emhttp/plugins/ci-runner-farm"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/build" "$tmp/extracted"
+tar -cf - build-plg.sh VERSION CHANGELOG.md "$RUNTIME" | tar -xf - -C "$tmp/build"
+(
+  cd "$tmp/build"
+  DATE=2026.01.02.0304 BUILD_NUMBER=7 INTERNAL_VERSION=0.0.0 REPO=unraid/ci-runner-farm \
+    bash ./build-plg.sh >/dev/null
+  python3 -c 'import xml.etree.ElementTree as ET; ET.parse("ci-runner-farm.plg")'
+  plg_md5="$(sed -n 's/^<!ENTITY packageMD5[[:space:]]*"\([0-9a-f]*\)">$/\1/p' ci-runner-farm.plg)"
+  if command -v md5sum >/dev/null 2>&1; then
+    tgz_md5="$(md5sum ci-runner-farm.tgz | cut -d' ' -f1)"
+  else
+    tgz_md5="$(md5 -q ci-runner-farm.tgz)"
+  fi
+  [ "${#plg_md5}" -eq 32 ] && [ "$plg_md5" = "$tgz_md5" ] || {
+    echo "package-contents: generated packageMD5 ($plg_md5) does not match archive ($tgz_md5)" >&2
+    exit 1
+  }
+  tar -xzf ci-runner-farm.tgz -C "$tmp/extracted"
+)
+
+diff -r "$RUNTIME" "$tmp/extracted" >/dev/null || {
+  echo "package-contents: archive does not exactly match the runtime source tree" >&2
+  diff -r "$RUNTIME" "$tmp/extracted" >&2 || true
+  exit 1
+}
+
+# Validate the actual generated package-manager action, not only its source
+# template: strict error handling must stop before the success banner when fleet
+# stop, runtime deletion, or cached-package deletion fails.
+generated_plg="$tmp/build/ci-runner-farm.plg"
+remove_block="$(awk '
+  /<FILE Run="\/bin\/bash" Method="remove">/ { emit=1 }
+  emit { print }
+  emit && /<\/FILE>/ { exit }
+' "$generated_plg")"
+[ -n "$remove_block" ] || {
+  echo "package-contents: generated plugin has no remove action" >&2
+  exit 1
+}
+for required_remove_line in \
+  'set -euo pipefail' \
+  'if ! "$PLGDIR/include/runner-farm.sh" stop' \
+  'cleanup engine is missing and Docker is unavailable' \
+  'cleanup engine is missing while plugin-owned Docker resources still exist' \
+  'if ! rm -rf -- "$PLGDIR" || [ -e "$PLGDIR" ]; then' \
+  'if ! rm -f -- "$CFGDIR"/ci-runner-farm-*.tgz; then'
+do
+  printf '%s\n' "$remove_block" | grep -qF "$required_remove_line" || {
+    echo "package-contents: generated remove action is missing: $required_remove_line" >&2
+    exit 1
+  }
+done
+cleanup_line="$(printf '%s\n' "$remove_block" | grep -nF 'if ! rm -f -- "$CFGDIR"/ci-runner-farm-*.tgz' | head -1 | cut -d: -f1)"
+success_line="$(printf '%s\n' "$remove_block" | grep -nF 'ci-runner-farm removed. Config + credentials left' | head -1 | cut -d: -f1)"
+[ -n "$cleanup_line" ] && [ -n "$success_line" ] && [ "$cleanup_line" -lt "$success_line" ] || {
+  echo "package-contents: generated remove action can report success before cleanup completes" >&2
+  exit 1
+}
+
+for required in \
+  RunnerFarm.page RunnerFarmDashboard.page RunnerFarmFleet.page RunnerFarmImage.page RunnerFarmSettings.page \
+  default.cfg default.Dockerfile default.github.Dockerfile default.gitlab.Dockerfile \
+  event/docker_started event/stopping_docker include/runner-farm.sh include/exec.php include/crf-core.php \
+  include/providers/github.sh include/providers/gitlab.sh \
+  nchan/ci_runner_farm README.md
+do
+  [ -f "$tmp/extracted/$required" ] || {
+    echo "package-contents: required runtime file missing from archive: $required" >&2
+    exit 1
+  }
+done
+
+echo "package-contents: OK — generated package exactly contains the complete runtime tree"

--- a/tests/provider-contract.sh
+++ b/tests/provider-contract.sh
@@ -184,12 +184,15 @@ for file in default.Dockerfile default.github.Dockerfile default.gitlab.Dockerfi
 done
 cmp -s "$RUNTIME/default.Dockerfile" "$RUNTIME/default.github.Dockerfile" || \
   bad "default.github.Dockerfile must remain byte-identical to legacy default.Dockerfile"
+grep -qF 'Docker did not become ready' "$RUNTIME/default.github.Dockerfile" || \
+  bad "GitHub runner image does not fail closed when nested Docker stays unavailable"
 if grep -Eiq '^[[:space:]]*FROM[[:space:]]+gitlab/gitlab-runner' "$RUNTIME/default.gitlab.Dockerfile"; then
   bad "default.gitlab.Dockerfile must be a job image, not the runner manager"
 fi
 grep -qF 'Dockerfile.$CI_PROVIDER' "$ENGINE" || bad "engine does not select an editable Dockerfile by provider"
 grep -qF 'default.$CI_PROVIDER.Dockerfile' "$ENGINE" || bad "engine does not select a shipped Dockerfile by provider"
-grep -qF 'Dockerfile' "$ENGINE" || bad "engine does not retain the legacy GitHub Dockerfile fallback"
+grep -qF '[ "$CI_PROVIDER" = github ] && [ ! -f "$df" ] && [ -f "$CFGDIR/Dockerfile" ] && df="$CFGDIR/Dockerfile"' "$ENGINE" \
+  || bad "engine does not retain the legacy unsuffixed GitHub Dockerfile fallback"
 grep -qF 'Dockerfile.$suffix' "$EXEC" || bad "endpoint does not select an editable Dockerfile by provider"
 grep -qF 'default.$suffix.Dockerfile' "$EXEC" || bad "endpoint does not select a shipped default by provider"
 grep -qF 'Dockerfile.$crf_provider' "$IMAGE_UI" || bad "image UI does not select the provider-specific editable Dockerfile"

--- a/tests/provider-contract.sh
+++ b/tests/provider-contract.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# Stable, public provider contract checks. These intentionally avoid private
+# helper names so the provider adapters can be refactored without rewriting the
+# test. Runtime behavior belongs in focused mocked tests next to those adapters.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+RUNTIME="src/usr/local/emhttp/plugins/ci-runner-farm"
+CFG="$RUNTIME/default.cfg"
+ENGINE="$RUNTIME/include/runner-farm.sh"
+UI="$RUNTIME/RunnerFarmSettings.page"
+IMAGE_UI="$RUNTIME/RunnerFarmImage.page"
+EXEC="$RUNTIME/include/exec.php"
+CORE="$RUNTIME/include/crf-core.php"
+GITHUB_ADAPTER="$RUNTIME/include/providers/github.sh"
+GITLAB_ADAPTER="$RUNTIME/include/providers/gitlab.sh"
+STOP_EVENT="$RUNTIME/event/stopping_docker"
+
+fail=0
+bad() { printf 'PROVIDER CONTRACT FAIL: %s\n' "$*" >&2; fail=1; }
+
+cfg_value() {
+  sed -n "s/^$1=\"\([^\"]*\)\".*$/\1/p" "$CFG" | head -1
+}
+
+# GitHub is the upgrade-safe default and all public provider settings must be
+# represented in the config, engine, and UI defaults.
+[ "$(cfg_value CI_PROVIDER)" = "github" ] || bad "CI_PROVIDER must default to github"
+for key in CI_PROVIDER GITLAB_URL GITLAB_RUNNER_IMAGE GITLAB_PROJECTS GITLAB_SHUTDOWN_TIMEOUT \
+  GITLAB_ALLOWED_IMAGES GITLAB_ALLOWED_SERVICES GITLAB_PULL_POLICY GITLAB_SHM_SIZE
+do
+  [ -n "$(cfg_value "$key")" ] || {
+    case "$key" in
+      GITLAB_PROJECTS|GITLAB_ALLOWED_IMAGES|GITLAB_ALLOWED_SERVICES) ;;
+      *) bad "$key is missing or empty in default.cfg" ;;
+    esac
+  }
+  grep -q "^${key}=" "$ENGINE" || bad "$key is missing from the engine defaults"
+  grep -q "'$key'[[:space:]]*=>" "$UI" || bad "$key is missing from the UI defaults"
+done
+[ "$(cfg_value GITLAB_SHUTDOWN_TIMEOUT)" = 7200 ] \
+  || bad "GITLAB_SHUTDOWN_TIMEOUT must default to a two-hour graceful drain"
+[ "$(cfg_value GITLAB_PULL_POLICY)" = auto ] \
+  || bad "GITLAB_PULL_POLICY must preserve the existing source-aware behavior by default"
+[ "$(cfg_value GITLAB_SHM_SIZE)" = 0 ] \
+  || bad "GITLAB_SHM_SIZE must preserve Docker's shared-memory default"
+
+case "$(cfg_value GITLAB_URL)" in
+  https://*) ;;
+  *) bad "GITLAB_URL must have a safe HTTPS default" ;;
+esac
+case "$(cfg_value GITLAB_RUNNER_IMAGE)" in
+  gitlab/gitlab-runner:*) ;;
+  *) bad "GITLAB_RUNNER_IMAGE must default to the official manager image" ;;
+esac
+
+# Provider credentials have distinct files and must never be conflated with the
+# legacy GitHub PAT at /token. The API token and custom CA are optional, but their
+# endpoints/storage names remain part of the public operator contract.
+for name in gitlab-runner-token gitlab-api-token gitlab-ca.crt; do
+  grep -qF "$name" "$ENGINE" || bad "credential contract '$name' is missing from the engine"
+  grep -qF "$name" "$UI" || bad "credential contract '$name' is missing from the UI"
+  grep -qF "$name" "$EXEC" || bad "credential contract '$name' is missing from the endpoint"
+done
+for action in \
+  set-gitlab-runner-token clear-gitlab-runner-token \
+  set-gitlab-api-token clear-gitlab-api-token \
+  set-gitlab-ca clear-gitlab-ca
+do
+  grep -q "case '$action'" "$EXEC" || bad "endpoint action is missing: $action"
+done
+grep -qF "strncmp(\$tok, 'glrt-', 5) === 0" "$EXEC" \
+  || bad "runner-token endpoint does not require the exact safe glrt- prefix"
+if grep -qF ')?glrt-' "$EXEC"; then
+  bad "runner-token endpoint accepts instance-prefixed values that official Runner unregister treats as legacy"
+fi
+if grep -qF 'glrtr?-' "$EXEC"; then
+  bad "runner-token endpoint accepts registration-created glrtr- tokens that can delete a shared runner"
+fi
+# GitLab 18 routable runner tokens contain two dots. The UI endpoint, shell
+# readiness/probe/unregister guards, config parser, and diagnostic redactor must
+# all accept the same narrow alphabet and 10..507 post-prefix length contract.
+grep -qF "preg_match('/\A[A-Za-z0-9_.-]+\z/D', \$payload)" "$EXEC" \
+  || bad "runner-token endpoint rejects GitLab routable-token dots"
+grep -qF '$length < 10 || $length > 507' "$EXEC" \
+  || bad "runner-token endpoint does not enforce the shared 10..507 post-prefix bound"
+[ "$(grep -Fc 'glrt-[A-Za-z0-9_.-]{10,507}' "$GITLAB_ADAPTER")" -ge 3 ] \
+  || bad "GitLab readiness/probe/unregister validators do not share the dotted 10..507 token contract"
+grep -qF '\(glrt-[A-Za-z0-9_.-]*\)' "$GITLAB_ADAPTER" \
+  || bad "GitLab saved-probe parser truncates routable runner tokens at the first dot"
+grep -qF 'glrt(r)?-[A-Za-z0-9_.-]{10,507}' "$ENGINE" \
+  || bad "GitLab diagnostic redaction does not consume full routable runner tokens"
+# Self-managed GitLab can customize its PAT prefix. The optional API token must
+# use a narrow token-safe alphabet, but `glpat-` is only the common default.
+grep -qF 'A-Za-z0-9_.@:+\/=~-' "$EXEC" || bad "API-token endpoint does not enforce a narrow token-safe alphabet"
+grep -qF '@chmod($tmp, 0600)' "$EXEC" || bad "atomic secret writes do not lock the temporary file to 0600"
+grep -qF '@chmod($path, 0600)' "$EXEC" || bad "atomic secret writes do not lock the installed file to 0600"
+grep -qF 'Session expired — reload this page' "$UI" \
+  || bad "GitLab runner-token UI hides an actionable stale-session failure"
+grep -qF "Save failed — '+m.slice(0,120)" "$UI" \
+  || bad "GitLab runner-token UI hides the bounded request failure reason"
+grep -qF "parse_ini_file('/var/local/emhttp/var.ini')" "$CORE" \
+  || bad "shared UI core has no server-side CSRF fallback"
+grep -qF 'globalThis.csrf_token' "$CORE" \
+  || bad "shared UI core does not use Unraid 7.3's live browser CSRF token"
+grep -qF 'p.csrf_token = liveCsrf' "$CORE" \
+  || bad "shared UI actions do not submit the resolved CSRF token"
+
+# The authenticated UI endpoint is POST-only and must never accept GET/query or
+# cookie fallbacks through $_REQUEST. Every untrusted scalar reaches a type check
+# before hash_equals/preg_match, and opaque registry passwords retain meaningful
+# edge spaces while remaining bounded, single-line values.
+grep -qF "\$_SERVER['REQUEST_METHOD']" "$EXEC" || bad "endpoint does not inspect the HTTP request method"
+grep -qF "header('Allow: POST')" "$EXEC" || bad "endpoint does not advertise its POST-only action contract"
+if grep -qF '$_REQUEST' "$EXEC"; then
+  bad "endpoint still accepts query/cookie action inputs through \$_REQUEST"
+fi
+grep -qF '!is_string($given)' "$EXEC" || bad "CSRF comparison does not reject non-scalar token input"
+grep -qF "function_exists('csrf_terminate')" "$EXEC" \
+  || bad "endpoint does not recognize Unraid's platform CSRF prevalidation"
+grep -qF "!array_key_exists('csrf_token', \$_POST)" "$EXEC" \
+  || bad "endpoint does not require Unraid's consumed POST-token state"
+grep -qF "!array_key_exists('HTTP_X_CSRF_TOKEN', \$_SERVER)" "$EXEC" \
+  || bad "endpoint does not require Unraid's consumed header-token state"
+grep -qF 'hash_equals($csrf, $csrf_token)' "$EXEC" \
+  || bad "endpoint does not bind Unraid's prevalidated token to current server state"
+grep -qF '$action = is_string($rawAction)' "$EXEC" || bad "endpoint dispatch does not reject a non-scalar action"
+sed -n "/case 'scale':/,/case 'set-token':/p" "$EXEC" | grep -F '!is_string($raw)' >/dev/null \
+  || bad "scale endpoint does not reject non-scalar targets"
+for pair in "recycle:force-forget-gitlab" "runner-log:image-info"; do
+  action="${pair%%:*}"; next="${pair#*:}"
+  sed -n "/case '$action':/,/case '$next':/p" "$EXEC" | grep -F '!is_string($n)' >/dev/null \
+    || bad "$action endpoint does not reject a non-scalar runner name"
+done
+grep -qF "preg_match('/[\\x00-\\x1F\\x7F]/', \$raw)" "$EXEC" \
+  || bad "registry-token endpoint does not reject control characters"
+grep -qF 'strlen($raw) > 8192' "$EXEC" || bad "registry-token endpoint has no explicit size bound"
+if sed -n "/case 'set-registry-token':/,/case 'clear-registry-token':/p" "$EXEC" | grep 'trim(' >/dev/null; then
+  bad "registry-token endpoint trims an opaque password"
+fi
+
+# Credential removal and every derived-file scrub must share the fleet mutex;
+# the endpoint is deliberately only a pass-through for the engine's JSON result.
+for action in credential-clear-github-token credential-clear-gitlab-runner credential-clear-registry-token; do
+  grep -Eq "^[[:space:]]*${action}\\)[[:space:]]+with_fleet_lock wait" "$ENGINE" \
+    || bad "credential engine action is not fleet-locked: $action"
+  grep -qF " $action" "$EXEC" || bad "endpoint does not delegate to credential engine action: $action"
+done
+grep -Eq 'reload_locked_snapshot( \|\| exit 1)?; "\$@"' "$ENGINE" \
+  || bad "fleet-lock wrapper does not reload config/secrets after acquiring the lock"
+grep -qF 'GITLAB_CA_FINGERPRINT' "$GITLAB_ADAPTER" \
+  || bad "GitLab config fingerprint does not use the locked in-memory CA snapshot"
+grep -qF '/etc/gitlab-runner/certs/ca.crt:ro' "$GITLAB_ADAPTER" \
+  || bad "custom GitLab CA is not propagated to Docker-executor helpers/jobs"
+grep -qF '/etc/docker/certs.d/$registry_authority/ca.crt' "$GITLAB_ADAPTER" \
+  || bad "custom GitLab CA is not propagated to the configured DinD registry authority"
+
+# GitLab always creates a clean job container even though its manager persists.
+# Keep the saved GitHub EPHEMERAL value in the submitted form, but replace the
+# selector with an explicit provider-semantic label while GitLab is active.
+grep -qF 'id="crfs-gitlab-ephemeral"' "$UI" \
+  || bad "GitLab always-ephemeral UI status is missing"
+grep -qF 'always ephemeral (clean Docker job container per job)' "$UI" \
+  || bad "GitLab EPHEMERAL semantics are not stated in the UI"
+grep -qF "ephemeral.style.display=provider==='github'?'':'none'" "$UI" \
+  || bad "provider switch does not replace the GitHub EPHEMERAL selector for GitLab"
+
+# Never opt token-bearing manager configs or derived Docker auth into a plugin
+# support bundle. The current runtime has no such bundle manifest; this scan
+# makes a future opt-in fail closed unless it remains an explicit safe allowlist.
+while IFS= read -r manifest; do
+  if grep -Eiq 'gitlab-runners|config\.toml|gitlab-runner-token|gitlab-api-token|registry-token|docker/config\.json' "$manifest"; then
+    bad "diagnostics/support manifest includes a credential-bearing path: $manifest"
+  fi
+done < <(find "$RUNTIME" -maxdepth 2 -type f \( -iname 'diagnostics*.json' -o -iname '*support*bundle*' \) -print)
+grep -qF 'per-slot/probe `config.toml` files' README.md \
+  || bad "operator docs do not warn that per-slot/probe GitLab configs are live credentials"
+
+# Existing installs continue to use default.Dockerfile. The named GitHub default
+# is byte-identical, while GitLab's editable default is a job image—not a second
+# runner-manager image.
+for file in default.Dockerfile default.github.Dockerfile default.gitlab.Dockerfile; do
+  [ -s "$RUNTIME/$file" ] || bad "shipped Dockerfile is missing: $file"
+done
+cmp -s "$RUNTIME/default.Dockerfile" "$RUNTIME/default.github.Dockerfile" || \
+  bad "default.github.Dockerfile must remain byte-identical to legacy default.Dockerfile"
+if grep -Eiq '^[[:space:]]*FROM[[:space:]]+gitlab/gitlab-runner' "$RUNTIME/default.gitlab.Dockerfile"; then
+  bad "default.gitlab.Dockerfile must be a job image, not the runner manager"
+fi
+grep -qF 'Dockerfile.$CI_PROVIDER' "$ENGINE" || bad "engine does not select an editable Dockerfile by provider"
+grep -qF 'default.$CI_PROVIDER.Dockerfile' "$ENGINE" || bad "engine does not select a shipped Dockerfile by provider"
+grep -qF 'Dockerfile' "$ENGINE" || bad "engine does not retain the legacy GitHub Dockerfile fallback"
+grep -qF 'Dockerfile.$suffix' "$EXEC" || bad "endpoint does not select an editable Dockerfile by provider"
+grep -qF 'default.$suffix.Dockerfile' "$EXEC" || bad "endpoint does not select a shipped default by provider"
+grep -qF 'Dockerfile.$crf_provider' "$IMAGE_UI" || bad "image UI does not select the provider-specific editable Dockerfile"
+
+# Provider-specific runtime behavior belongs in explicit adapters; the engine
+# owns only common lifecycle/locking/cache/network orchestration.
+for adapter in "$GITHUB_ADAPTER" "$GITLAB_ADAPTER"; do
+  [ -s "$adapter" ] || bad "provider adapter is missing: $adapter"
+  grep -q '^[a-z]*_remote_image_host_pull_required()' "$adapter" \
+    || bad "provider does not declare where remote job images must be pulled: $adapter"
+done
+grep -q '^provider_remote_image_host_pull_required()' "$ENGINE" \
+  || bad "common provisioning does not dispatch remote-image pull ownership"
+grep -q '^github_build_args()' "$GITHUB_ADAPTER" || bad "GitHub build adapter contract is missing"
+grep -q '^github_queued_refresh()' "$GITHUB_ADAPTER" || bad "GitHub queue adapter contract is missing"
+grep -q '^gitlab_write_config()' "$GITLAB_ADAPTER" || bad "GitLab TOML adapter contract is missing"
+grep -q '^gitlab_start_one()' "$GITLAB_ADAPTER" || bad "GitLab manager adapter contract is missing"
+grep -q '^gitlab_validate_host_socket_manager_version()' "$GITLAB_ADAPTER" \
+  || bad "GitLab host-socket manager version gate is missing"
+grep -q '^gitlab_validate_manager_version()' "$GITLAB_ADAPTER" \
+  || bad "GitLab all-mode Runner 16 manager-only-unregister gate is missing"
+grep -q '^gitlab_verify_manager_token()' "$GITLAB_ADAPTER" \
+  || bad "GitLab token/system-ID verification preflight is missing"
+grep -q '^gitlab_recover_pending_probe()' "$GITLAB_ADAPTER" \
+  || bad "GitLab token-probe recovery transaction is missing"
+sed -n '/^gitlab_assert_no_orphan_manager_configs()/,/^}/p' "$GITLAB_ADAPTER" \
+  | grep 'gitlab_recover_pending_probe || return 1' >/dev/null \
+  || bad "provider lifecycle ignores an ambiguous GitLab token-probe manager"
+sed -n '/^gitlab_start_one()/,/^}/p' "$GITLAB_ADAPTER" \
+  | grep 'gitlab_verify_manager_token "$name"' >/dev/null \
+  || bad "GitLab manager can start without verifying its token/system ID"
+sed -n '/^cmd_logs_tail()/,/^}/p' "$ENGINE" | grep 'managed_runner_snapshot' >/dev/null \
+  || bad "runner log reads are not ownership-gated"
+for fn in gitlab_start_one gitlab_validate; do
+  sed -n "/^${fn}()/,/^}/p" "$GITLAB_ADAPTER" \
+    | grep 'gitlab_validate_host_socket_manager_version' >/dev/null \
+    || bad "$fn bypasses the host-socket Runner 18.5 compatibility gate"
+done
+sed -n '/^gitlab_start_stopped()/,/^}/p' "$GITLAB_ADAPTER" \
+  | grep 'gitlab_validate_manager_version "$image" runtime' >/dev/null \
+  || bad "gitlab_start_stopped does not gate the immutable image it will restart"
+sed -n '/^gitlab_unregister_manager()/,/^}/p' "$GITLAB_ADAPTER" \
+  | grep 'gitlab_validate_manager_version "$image" unregister' >/dev/null \
+  || bad "GitLab unregister can execute through a pre-16 manager image"
+sed -n '/^gitlab_unregister_manager()/,/^}/p' "$GITLAB_ADAPTER" \
+  | grep 'docker run --rm --network "$manager_network"' >/dev/null \
+  || bad "GitLab unregister does not reuse the retired manager's Docker network"
+grep -qF 'v18.5.0' "$UI" \
+  || bad "GitLab host-socket minimum Runner version is missing from the UI"
+grep -qF "['REGISTRY_SERVER','REGISTRY_USERNAME'].forEach(n=>setRow(n,remote||gitlab))" "$UI" \
+  || bad "GitLab built-in defaults hide registry auth needed by job/service overrides"
+if grep -Eq '^(github|gitlab)_[A-Za-z0-9_]+\(\)' "$ENGINE"; then
+  bad "provider-specific function definitions remain in the common engine"
+fi
+grep -qF 'listen_address = "127.0.0.1:9252"' "$GITLAB_ADAPTER" || bad "GitLab metrics endpoint is not loopback-only"
+grep -qF 'executor_host="unix:///runner-services/docker.sock"' "$GITLAB_ADAPTER" \
+  || bad "GitLab DinD manager does not follow socket recreation through a directory mount"
+grep -q '^gitlab_effective_pull_policy()' "$GITLAB_ADAPTER" || bad "source-aware GitLab pull-policy helper is missing"
+grep -qF 'echo if-not-present' "$GITLAB_ADAPTER" || bad "built-in GitLab job image must use if-not-present pull policy"
+grep -qF 'allowed_pull_policies = [%s]' "$GITLAB_ADAPTER" || bad "jobs can override the configured GitLab pull policy"
+grep -qF 'allowed_images = %s' "$GITLAB_ADAPTER" || bad "GitLab allowed-image policy is not emitted"
+grep -qF 'allowed_services = %s' "$GITLAB_ADAPTER" || bad "GitLab allowed-service policy is not emitted"
+grep -qF 'shm_size = %s' "$GITLAB_ADAPTER" || bad "GitLab executor shared-memory policy is not emitted"
+grep -q '^gitlab_ensure_system_id()' "$GITLAB_ADAPTER" || bad "per-slot GitLab system-ID persistence is missing"
+grep -qF -- '--stop-signal SIGQUIT --stop-timeout "$GITLAB_SHUTDOWN_TIMEOUT"' "$GITLAB_ADAPTER" \
+  || bad "GitLab manager does not persist explicit graceful Docker stop semantics"
+grep -qF 'shutdown_timeout = %s' "$GITLAB_ADAPTER" \
+  || bad "generated GitLab TOML does not carry the graceful shutdown timeout"
+grep -qF 'unregister --name "$manager_name"' "$GITLAB_ADAPTER" \
+  || bad "GitLab slot retirement does not target one persisted manager name"
+if grep -qF 'unregister --all-runners' "$GITLAB_ADAPTER"; then
+  bad "GitLab slot retirement can broadly unregister every config entry"
+fi
+grep -q '^cmd_docker_stopping_locked()' "$ENGINE" \
+  || bad "common engine lacks the GitLab pre-Docker-shutdown quiesce path"
+sed -n '/^cmd_docker_stopping_locked()/,/^}/p' "$ENGINE" \
+  | grep -F 'provider_stop_owned_runner "$c" "$id" "$provider" &' >/dev/null \
+  || bad "Docker shutdown does not signal all GitLab managers before waiting"
+sed -n '/^cmd_docker_stopping_locked()/,/^}/p' "$ENGINE" \
+  | grep -F 'for pid in $pids; do wait "$pid"' >/dev/null \
+  || bad "Docker shutdown does not wait for every concurrently signalled manager"
+grep -qF 'docker-stopping)  cmd_docker_stopping' "$ENGINE" \
+  || bad "GitLab Docker-shutdown quiesce verb is not dispatched"
+grep -qF 'runner-farm.sh" docker-stopping' "$STOP_EVENT" \
+  || bad "Unraid stopping_docker event does not quiesce GitLab managers before sidecars"
+grep -q '^github_docker_stopping_timeout()' "$GITHUB_ADAPTER" \
+  || bad "GitHub adapter does not explicitly preserve its Docker-shutdown behavior"
+grep -q '^gitlab_docker_stopping()' "$GITLAB_ADAPTER" \
+  || bad "GitLab adapter does not own its Docker-shutdown drain behavior"
+grep -qF -- '--add-host "host.docker.internal:host-gateway"' "$GITLAB_ADAPTER" \
+  || bad "GitLab DinD sidecars cannot resolve the default shared-mirror endpoint"
+grep -qF -- '--restart=unless-stopped' "$GITLAB_ADAPTER" \
+  || bad "GitLab DinD sidecars do not survive Docker daemon restarts"
+grep -qF 'name="${NAME_PREFIX}-validate-$suffix"' "$GITLAB_ADAPTER" \
+  || bad "GitLab validation still uses a predictable fixed container name"
+grep -qF 'net.unraid.ci-runner-farm.role=validate-job' "$GITLAB_ADAPTER" \
+  || bad "GitLab validation job is not visibly plugin-labelled"
+grep -qF 'firewall_prepare_replacement || return 1' "$GITLAB_ADAPTER" \
+  || bad "GitLab validation clears live-fleet strict firewall policy instead of adding replacement rules"
+if grep -qF 'docker rm -f "$name" "${name}-job"' "$GITLAB_ADAPTER"; then
+  bad "GitLab validation unconditionally removes fixed-name containers"
+fi
+grep -q '^gitlab_prepare_remote_image()' "$GITLAB_ADAPTER" \
+  || bad "GitLab adapter does not own policy-aware remote image preparation"
+grep -q '^gitlab_remote_image_update_allowed()' "$GITLAB_ADAPTER" \
+  || bad "GitLab adapter does not gate remote image-update polling by pull policy"
+grep -q '^gitlab_force_forget_local()' "$GITLAB_ADAPTER" \
+  || bad "GitLab adapter lacks the local-only break-glass cleanup path"
+grep -q '^gitlab_scrub_retired_slot_credentials()' "$GITLAB_ADAPTER" \
+  || bad "successful GitLab retirement does not scrub reusable slot credentials"
+sed -n '/^gitlab_remove_runner()/,/^}/p' "$GITLAB_ADAPTER" \
+  | grep 'gitlab_scrub_retired_slot_credentials' >/dev/null \
+  || bad "GitLab manager removal bypasses post-success credential scrubbing"
+grep -qF 'cmd_stop || return 1' "$ENGINE" \
+  || bad "restart can mask a failed stop/unregister operation"
+grep -qF 'cmd_recycle "$c"' "$ENGINE" \
+  || bad "image auto-update bypasses validated recycle preflight"
+sed -n '/^cmd_reconcile_config()/,/^}/p' "$ENGINE" | grep 'managed="$(managed_names)"' >/dev/null \
+  || bad "config reconcile does not fail closed when fleet enumeration fails"
+sed -n '/^cmd_reconcile_config()/,/^}/p' "$ENGINE" | grep -F 'provider_token_ready' >/dev/null \
+  || bad "config reconcile can launch against an existing fleet without checking provider credentials"
+sed -n '/^cmd_reconcile_config()/,/^}/p' "$ENGINE" | grep -F 'provider_validate_settings' >/dev/null \
+  || bad "config reconcile can launch without validating provider settings"
+sed -n '/^cmd_stop()/,/^}/p' "$ENGINE" | grep -F 'cleanup_orphan_github_validations || return 1' >/dev/null \
+  || bad "Stop does not ownership-check and remove orphaned GitHub validation containers"
+grep -qF "d.source==='remote'" "$IMAGE_UI" \
+  || bad "image UI tells remote-provider users to build an image locally"
+
+if [ "$fail" -ne 0 ]; then exit 1; fi
+echo "provider-contract: OK — provider defaults, credentials, and Dockerfile compatibility are wired"

--- a/tests/provider-mocks.sh
+++ b/tests/provider-mocks.sh
@@ -70,8 +70,10 @@ grep -qF 'POST /repos/example/one/actions/runners/registration-token' "$GH_API_L
   || fail "GitHub repo registration endpoint changed"
 
 GH_SCOPE=repo
-github_build_args 2 ci-runner-2 || fail "GitHub repo argv generation failed"
+github_build_args 2 || fail "GitHub default-name repo argv generation failed"
 github_args="$(printf '%s\n' "${ARGS[@]}")"
+printf '%s\n' "$github_args" | grep -qx 'ci-runner-2' \
+  || fail "GitHub default runner name did not use its function argument"
 printf '%s\n' "$github_args" | grep -qx 'REPO_URL=https://github.com/example/two' \
   || fail "GitHub repo round-robin assignment changed"
 printf '%s\n' "$github_args" | grep -qx 'RUNNER_TOKEN=short-registration-token' \
@@ -385,7 +387,9 @@ fi
 grep -qx corrupt-system-id "$CRF_CFGDIR/gitlab-runners/ci-runner-4/.runner_system_id" \
   || fail "invalid persisted GitLab system ID was mutated"
 
-gitlab_build_manager_args 1 ci-runner-1 || fail "manager argv generation failed"
+gitlab_build_manager_args 1 || fail "default-name manager argv generation failed"
+printf '%s\n' "${ARGS[@]}" | grep -qx 'ci-runner-1' \
+  || fail "GitLab default manager name did not use its function argument"
 if printf '%s\n' "${ARGS[@]}" | grep -qF "$GITLAB_RUNNER_TOKEN"; then fail "runner token leaked into Docker argv"; fi
 printf '%s\n' "${ARGS[@]}" | grep -qF 'wget -qO- http://127.0.0.1:9252/metrics' \
   || fail "GitLab manager health check is not a local metrics probe"
@@ -1183,9 +1187,9 @@ grep -q "^DOCKER inspect -f {{.Image}} $LIFECYCLE_MANAGER_ID$" "$LIFECYCLE_LOG" 
   || fail "stopped manager image validation did not use its immutable ID"
 grep -q "^DOCKER start $LIFECYCLE_MANAGER_ID$" "$LIFECYCLE_LOG" \
   || fail "stopped manager was not started by immutable ID"
-job_image_line="$(grep -n '^JOB_IMAGE ci-runner-1$' "$LIFECYCLE_LOG" | head -1 | cut -d: -f1)"
-manager_start_line="$(grep -n "^DOCKER start $LIFECYCLE_MANAGER_ID$" "$LIFECYCLE_LOG" | head -1 | cut -d: -f1)"
-[ "$job_image_line" -lt "$manager_start_line" ] \
+job_image_line="$(grep -n '^JOB_IMAGE ci-runner-1$' "$LIFECYCLE_LOG" | head -1 | cut -d: -f1 || true)"
+manager_start_line="$(grep -n "^DOCKER start $LIFECYCLE_MANAGER_ID$" "$LIFECYCLE_LOG" | head -1 | cut -d: -f1 || true)"
+[ -n "$job_image_line" ] && [ -n "$manager_start_line" ] && [ "$job_image_line" -lt "$manager_start_line" ] \
   || fail "stopped manager resumed before its default job image was prepared"
 if grep -q unregister "$LIFECYCLE_LOG"; then fail "ordinary stopped-manager restart attempted unregister"; fi
 
@@ -1331,8 +1335,8 @@ gitlab_remove_sidecar() { :; }
 mkdir -p "$slot_dir/docker"
 printf '%s\n' retired-registry-auth > "$slot_dir/docker/config.json"
 if gitlab_remove_runner ci-runner-1 false; then fail "GitLab removal ignored a local Docker-rm failure"; fi
-stop_line="$(grep -n '^DOCKER stop --signal SIGQUIT --timeout 7200 ci-runner-1$' "$LIFECYCLE_LOG" | head -1 | cut -d: -f1)"
-unregister_line="$(grep -n 'DOCKER run --rm .* unregister --name persisted-host-ci-runner-1$' "$LIFECYCLE_LOG" | head -1 | cut -d: -f1)"
+stop_line="$(grep -n '^DOCKER stop --signal SIGQUIT --timeout 7200 ci-runner-1$' "$LIFECYCLE_LOG" | head -1 | cut -d: -f1 || true)"
+unregister_line="$(grep -n 'DOCKER run --rm .* unregister --name persisted-host-ci-runner-1$' "$LIFECYCLE_LOG" | head -1 | cut -d: -f1 || true)"
 [ -n "$stop_line" ] && [ -n "$unregister_line" ] && [ "$stop_line" -lt "$unregister_line" ] \
   || fail "GitLab manager did not drain before manager-only unregister"
 [ -s "$slot_dir/.remote-unregister-complete" ] \

--- a/tests/provider-mocks.sh
+++ b/tests/provider-mocks.sh
@@ -517,6 +517,12 @@ docker() {
 gitlab_start_sidecar 1 ci-runner-1 || fail "custom-CA GitLab DinD sidecar generation failed"
 grep -qx -- '--restart=unless-stopped' "$SIDECAR_ARGS" \
   || fail "GitLab DinD sidecar does not survive Docker daemon restarts"
+expected_dind_suffix="$(printf '%s\n' "$GITLAB_DIND_IMAGE" dockerd --host=unix:///runner-services/docker.sock)"
+[ "$(tail -n 3 "$SIDECAR_ARGS")" = "$expected_dind_suffix" ] \
+  || fail "GitLab DinD sidecar does not retain the stock entrypoint with exactly one private Unix listener"
+if grep -qF 'tcp://' "$SIDECAR_ARGS"; then
+  fail "GitLab DinD sidecar exposes a TCP Docker API"
+fi
 grep -qx "type=bind,src=$slot_ca,dst=$slot_ca,readonly" "$SIDECAR_ARGS" \
   || fail "DinD cannot resolve the executor's custom-CA bind source"
 grep -qx "type=bind,src=$slot_ca,dst=/etc/docker/certs.d/registry.gitlab.example.test:5443/ca.crt,readonly" "$SIDECAR_ARGS" \

--- a/tests/provider-mocks.sh
+++ b/tests/provider-mocks.sh
@@ -1,0 +1,1539 @@
+#!/usr/bin/env bash
+# Focused provider-adapter tests with mocked Docker/curl. These exercise the
+# generated GitLab TOML and status/API mappings without an Unraid host or daemon.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export CRF_CFGDIR="$tmp/config"
+export CRF_RUNDIR="$tmp/run"
+export CRF_SOURCE_ONLY=1
+mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+# shellcheck source=/dev/null
+source src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+# Keep the real implementation available after transaction-specific mocks replace
+# cmd_stop later in this single-process test harness.
+eval "$(declare -f cmd_stop | sed '1s/^cmd_stop /engine_cmd_stop /')"
+
+fail() { printf 'PROVIDER MOCK FAIL: %s\n' "$*" >&2; exit 1; }
+mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+
+# Upgrade/default contract and supported runner-auth token variants.
+[ "$CI_PROVIDER" = github ] || fail "GitHub is not the source-only default"
+[ "$(builtin_image)" = ci-runner-farm-runner:latest ] || fail "GitHub built-in image changed"
+
+# GitHub adapter regression coverage: preserve the legacy repo/org argv,
+# registration lifecycle, queue/stat mappings, status metadata, and GHCR PAT
+# fallback while keeping the long-lived PAT out of runner argv.
+CACHE_ROOT="$tmp/cache"; CACHE_MOUNTS=''; mkdir -p "$CACHE_ROOT"
+ACCESS_TOKEN='github_pat_long_lived_secret_1234567890'
+GH_OWNER='example-owner'; GH_REPOS='example/one example/two'
+RUNNER_LABELS='self-hosted,unraid,build'; RUNNER_GROUP='secure-group'
+RUNNER_CPUS='2'; RUNNER_MEMORY='4g'; IMAGE_SOURCE=builtin
+WORK_TMPFS_SIZE='2g'; DIND=true; SHARE_DOCKER_SOCK=false
+SHARED_IMAGE_CACHE=true; NETWORK_ISOLATION=off; EPHEMERAL=false; RUN_AS_ROOT=false
+host() { printf 'mockhost\n'; }
+legacy_confgen="$(printf '%s\0' "$GH_SCOPE" "$GH_OWNER" "$GH_REPOS" "$RUNNER_GROUP" "$RUNNER_LABELS" \
+  "$EPHEMERAL" "$RUNNER_CPUS" "$RUNNER_MEMORY" "$WORK_TMPFS_SIZE" "$CACHE_MOUNTS" \
+  "$DIND" "$SHARE_DOCKER_SOCK" "$RUN_AS_ROOT" "$IMAGE_SOURCE" "$IMAGE" \
+  "$REGISTRY_SERVER" "$REGISTRY_USERNAME" "$SHARED_IMAGE_CACHE" "$MIRROR_PORT" \
+  "$NETWORK_ISOLATION" "$RUNNER_NETWORK" "$CACHE_ROOT" | sha256sum | cut -c1-12)"
+[ "$(crf_confgen)" = "$legacy_confgen" ] || fail "GitHub upgrade-safe config fingerprint changed"
+
+# Exercise the REAL adapter transport before replacing gh_api with the response
+# fixture below. The long-lived PAT must enter curl through config stdin and must
+# never be present in argv (where it would be visible via /proc).
+GH_CURL_ARGV="$tmp/github-curl.argv"; GH_CURL_STDIN="$tmp/github-curl.stdin"
+curl() {
+  printf '%s\n' "$*" > "$GH_CURL_ARGV"
+  cat > "$GH_CURL_STDIN"
+  printf '%s\n' '{"login":"mock-user"}'
+}
+[ "$(gh_api GET /user)" = '{"login":"mock-user"}' ] || fail "real GitHub API transport did not return curl response"
+grep -qF "Authorization: Bearer $ACCESS_TOKEN" "$GH_CURL_STDIN" || fail "GitHub PAT was not sent through curl config stdin"
+if grep -qF "$ACCESS_TOKEN" "$GH_CURL_ARGV"; then fail "GitHub PAT leaked into curl argv"; fi
+unset -f curl
+
+GH_API_LOG="$tmp/github-api.log"; : > "$GH_API_LOG"
+gh_api() {
+  printf '%s %s\n' "$1" "$2" >> "$GH_API_LOG"
+  case "$1 $2" in
+    POST*) printf '%s\n' '{"token":"short-registration-token"}' ;;
+    GET*)  printf '%s\n' '{' '"id": 77,' '"name": "mockhost-ci-runner-1",' '"os": "linux"' '}' ;;
+    DELETE*) return 0 ;;
+  esac
+}
+[ "$(github_registration_token 'repo:example/one')" = short-registration-token ] \
+  || fail "GitHub repo registration-token response mapping changed"
+grep -qF 'POST /repos/example/one/actions/runners/registration-token' "$GH_API_LOG" \
+  || fail "GitHub repo registration endpoint changed"
+
+GH_SCOPE=repo
+github_build_args 2 ci-runner-2 || fail "GitHub repo argv generation failed"
+github_args="$(printf '%s\n' "${ARGS[@]}")"
+printf '%s\n' "$github_args" | grep -qx 'REPO_URL=https://github.com/example/two' \
+  || fail "GitHub repo round-robin assignment changed"
+printf '%s\n' "$github_args" | grep -qx 'RUNNER_TOKEN=short-registration-token' \
+  || fail "short-lived GitHub registration token missing from runner argv"
+if printf '%s\n' "$github_args" | grep -qF "$ACCESS_TOKEN"; then fail "GitHub PAT leaked into runner argv"; fi
+printf '%s\n' "$github_args" | grep -qx -- '--privileged' || fail "GitHub DinD privilege flag missing"
+printf '%s\n' "$github_args" | grep -qx 'START_DOCKER_SERVICE=true' || fail "GitHub DinD environment missing"
+printf '%s\n' "$github_args" | grep -qx '/_work:rw,exec,size=2g' || fail "GitHub workspace tmpfs changed"
+
+GH_SCOPE=org
+github_build_args 1 ci-runner-1 || fail "GitHub org argv generation failed"
+github_args="$(printf '%s\n' "${ARGS[@]}")"
+for expected in 'RUNNER_SCOPE=org' 'ORG_NAME=example-owner' 'RUNNER_GROUP=secure-group'; do
+  printf '%s\n' "$github_args" | grep -qx "$expected" || fail "GitHub org argv missing $expected"
+done
+grep -qF 'POST /orgs/example-owner/actions/runners/registration-token' "$GH_API_LOG" \
+  || fail "GitHub org registration endpoint changed"
+
+GH_SCOPE=repo; DIND=false; SHARE_DOCKER_SOCK=true; WORK_TMPFS_SIZE=''
+github_build_args 1 ci-runner-1 || fail "GitHub host-socket argv generation failed"
+github_args="$(printf '%s\n' "${ARGS[@]}")"
+printf '%s\n' "$github_args" | grep -qx '/var/run/docker.sock:/var/run/docker.sock' \
+  || fail "GitHub host-socket mount changed"
+printf '%s\n' "$github_args" | grep -qx "$CACHE_ROOT/work/ci-runner-1:/_work" \
+  || fail "GitHub bind-workspace fallback changed"
+
+# GitHub removal must stop the listener before deleting its registration.
+: > "$GH_API_LOG"
+provider_stop_remove_container() { printf 'STOP %s\n' "$1" >> "$GH_API_LOG"; }
+github_remove_runner ci-runner-1 false || fail "GitHub non-purge recycle removal failed"
+[ "$(sed -n '1p' "$GH_API_LOG")" = 'STOP ci-runner-1' ] || fail "GitHub deregistration ran before container stop"
+grep -qF 'GET /repos/example/one/actions/runners?per_page=100' "$GH_API_LOG" \
+  || fail "GitHub runner discovery endpoint changed"
+grep -qF 'DELETE /repos/example/one/actions/runners/77' "$GH_API_LOG" \
+  || fail "GitHub runner deletion endpoint changed"
+
+github_fetch_all() {
+  case "$1" in
+    *status=queued*) printf '%s' '{"total_count":2}' > "$2/1"; printf '%s' '{"total_count":3}' > "$2/2" ;;
+    *) printf '%s' '{"workflow_runs":[{"conclusion":"success"},{"conclusion":"failure"}]}' > "$2/1"
+       printf '%s' '{"workflow_runs":[{"conclusion":"cancelled"},{"conclusion":"timed_out"}]}' > "$2/2" ;;
+  esac
+}
+github_queued_refresh
+read -r ghq_provider _ ghq_count < "$CRF_RUNDIR/queued.cache"
+[ "$ghq_provider" = github ] && [ "$ghq_count" = 5 ] || fail "GitHub queue mapping changed"
+github_stats_refresh
+read -r ghs_provider _ ghs_ok ghs_fail ghs_cancel ghs_other ghs_total < "$CRF_RUNDIR/stats.cache"
+[ "$ghs_provider" = github ] && [ "$ghs_ok" = 1 ] && [ "$ghs_fail" = 2 ] \
+  && [ "$ghs_cancel" = 1 ] && [ "$ghs_other" = 0 ] && [ "$ghs_total" = 4 ] \
+  || fail "GitHub stats mapping changed"
+
+docker() {
+  case "$1" in
+    logs) printf '%s\n' '2026-08-03T12:00:00Z Running job: compile' ;;
+    exec) printf '%s\n' 'GITHUB_REPOSITORY=example/one' 'GITHUB_RUN_ID=123' 'GITHUB_REF_NAME=42/merge' ;;
+  esac
+}
+job=''; jstarted='_'; project=''; job_id='_'; job_url=''; ref=''; ref_url=''
+jrepo=''; jpr='_'; jbranch=''; jrun='_'
+github_usage_context ci-runner-1
+[ "$project" = example/one ] && [ "$job_id" = 123 ] && [ "$ref" = 'PR #42' ] \
+  && [ "$job_url" = 'https://github.com/example/one/actions/runs/123' ] \
+  || fail "GitHub provider-neutral job/status mapping changed"
+
+REGISTRY_SERVER=ghcr.io; REGISTRY_USERNAME=''; REGISTRY_TOKEN=''
+github_registry_probe() { local user="$REGISTRY_USERNAME" pass="$REGISTRY_TOKEN"; github_registry_credentials; printf '%s|%s\n' "$user" "$pass"; }
+[ "$(github_registry_probe)" = "example-owner|$ACCESS_TOKEN" ] || fail "GitHub GHCR PAT fallback changed"
+
+CI_PROVIDER=gitlab
+# GitLab 18 routable runner tokens carry a base64url payload plus version,
+# encoded-length, and CRC fields separated by two literal dots. Keep one fully
+# synthetic but structurally realistic value throughout config/probe/retirement
+# coverage so every credential parser proves that the complete token survives.
+ROUTABLE_GITLAB_RUNNER_TOKEN='glrt-AAECAwQFBgcICQoLDA0OD286MQpwOjIKdTozCnQ6Mw8.01.170z6aiyq'
+ROUTABLE_GITLAB_RUNNER_PAYLOAD="${ROUTABLE_GITLAB_RUNNER_TOKEN#glrt-}"
+GITLAB_RUNNER_TOKEN="$ROUTABLE_GITLAB_RUNNER_TOKEN"
+provider_token_ready || fail "routable exact-prefix glrt- token rejected"
+
+# The endpoint and every runtime parser share a 507-character post-prefix cap.
+printf -v max_runner_payload '%*s' 507 ''
+max_runner_payload="${max_runner_payload// /a}"
+GITLAB_RUNNER_TOKEN="glrt-$max_runner_payload"
+provider_token_ready || fail "maximum-length glrt- token rejected"
+GITLAB_RUNNER_TOKEN="glrt-${max_runner_payload}a"
+if provider_token_ready; then fail "overlength glrt- token accepted"; fi
+
+GITLAB_RUNNER_TOKEN="glrtr-$ROUTABLE_GITLAB_RUNNER_PAYLOAD"
+if provider_token_ready; then fail "registration-created glrtr- token accepted for shared-manager lifecycle"; fi
+GITLAB_RUNNER_TOKEN="acme-glrt-$ROUTABLE_GITLAB_RUNNER_PAYLOAD"
+if provider_token_ready; then fail "instance-prefixed token accepted despite unsafe unregister dispatch"; fi
+GITLAB_RUNNER_TOKEN=$'glrt-bad\nheader'
+if provider_token_ready; then fail "control characters accepted in runner token"; fi
+
+# UI/CLI log streams redact both the exact locked credential snapshot and common
+# provider token shapes. Registry passwords may contain sed/shell punctuation and
+# must still be treated literally.
+redact_access='loaded-access-secret-1234'
+redact_runner='loaded-glrt-runner-secret-1234'
+redact_api='loaded-api-secret-5678'
+redact_registry='reg[]/.*&\punct$token-9012'
+redact_routable="$ROUTABLE_GITLAB_RUNNER_TOKEN"
+redact_routable_legacy="glrtr-$ROUTABLE_GITLAB_RUNNER_PAYLOAD"
+redact_routable_custom="acme-glrt-$ROUTABLE_GITLAB_RUNNER_PAYLOAD"
+redacted_log="$(
+  ACCESS_TOKEN="$redact_access"
+  GITLAB_RUNNER_TOKEN="$redact_runner"
+  GITLAB_API_TOKEN="$redact_api"
+  REGISTRY_TOKEN="$redact_registry"
+  printf '%s\n' \
+    "loaded $ACCESS_TOKEN $GITLAB_RUNNER_TOKEN $GITLAB_API_TOKEN $REGISTRY_TOKEN" \
+    'shape glrt-abcdefghijklmnop glrtr-abcdefghijklmnop acme-glrt-abcdefghijklmnop' \
+    "shape $redact_routable $redact_routable_legacy $redact_routable_custom" \
+    'shape glpat-abcdefghijklmnop github_pat_abcdefghijklmnop ghp_abcdefghijklmnop' \
+    | redact_log_stream
+)"
+for leaked in "$redact_access" "$redact_runner" "$redact_api" "$redact_registry" \
+  glrt-abcdefghijklmnop glrtr-abcdefghijklmnop acme-glrt-abcdefghijklmnop \
+  "$redact_routable" "$redact_routable_legacy" "$redact_routable_custom" \
+  glpat-abcdefghijklmnop github_pat_abcdefghijklmnop ghp_abcdefghijklmnop
+do
+  if printf '%s\n' "$redacted_log" | grep -Fq -- "$leaked"; then fail "log redaction leaked $leaked"; fi
+done
+printf '%s\n' "$redacted_log" | grep -q '\[REDACTED\]' \
+  || fail "loaded-secret redaction marker is missing"
+printf '%s\n' "$redacted_log" | grep -q '\[REDACTED_GITLAB_TOKEN\]' \
+  || fail "GitLab shape redaction marker is missing"
+printf '%s\n' "$redacted_log" \
+  | grep -Fx 'shape [REDACTED_GITLAB_TOKEN] [REDACTED_GITLAB_TOKEN] [REDACTED_GITLAB_TOKEN]' >/dev/null \
+  || fail "routable GitLab token redaction left a dotted suffix visible"
+printf '%s\n' "$redacted_log" | grep -q '\[REDACTED_GITHUB_TOKEN\]' \
+  || fail "GitHub shape redaction marker is missing"
+
+GITLAB_RUNNER_TOKEN="$ROUTABLE_GITLAB_RUNNER_TOKEN"
+GITLAB_URL='https://gitlab.example.test///'
+[ "$(gitlab_url)" = 'https://gitlab.example.test' ] || fail "GitLab URL was not normalized"
+GITLAB_RUNNER_IMAGE='gitlab/gitlab-runner:alpine'
+
+# Every mode needs Runner 16+ for manager-only unregister; host-socket cleanup
+# additionally depends on exact service labels fixed in 18.5. Probe the selected
+# image, cache a successful result, and fail closed on old/prerelease/malformed
+# output.
+MANAGER_VERSION_LOG="$tmp/gitlab-manager-version.log"; : > "$MANAGER_VERSION_LOG"
+(
+  MOCK_MANAGER_VERSION='18.4.1'
+  docker() {
+    printf '%s\n' "$*" >> "$MANAGER_VERSION_LOG"
+    if [ "$*" = "run --rm $GITLAB_RUNNER_IMAGE --version" ]; then
+      case "$MOCK_MANAGER_VERSION" in
+        fail) return 1 ;;
+        *) printf 'Version:      %s\nGit revision: mock\n' "$MOCK_MANAGER_VERSION" ;;
+      esac
+    fi
+  }
+
+  DIND=true; MOCK_MANAGER_VERSION='15.11.1'; GITLAB_MANAGER_VERSION_VALIDATED_KEY=''
+  if gitlab_validate_host_socket_manager_version >/dev/null 2>&1; then exit 1; fi
+  MOCK_MANAGER_VERSION='18.4.1'; GITLAB_MANAGER_VERSION_VALIDATED_KEY=''
+  gitlab_validate_host_socket_manager_version || exit 1
+  probes="$(grep -c -- '--version' "$MANAGER_VERSION_LOG")"
+  gitlab_validate_host_socket_manager_version || exit 1
+  [ "$(grep -c -- '--version' "$MANAGER_VERSION_LOG")" -eq "$probes" ] || exit 1
+
+  DIND=false; MOCK_MANAGER_VERSION='18.4.1'; GITLAB_MANAGER_VERSION_VALIDATED_KEY=''
+  if gitlab_validate_host_socket_manager_version >/dev/null 2>&1; then exit 1; fi
+  MOCK_MANAGER_VERSION='18.5.0'; GITLAB_MANAGER_VERSION_VALIDATED_KEY=''
+  gitlab_validate_host_socket_manager_version || exit 1
+  gitlab_validate_host_socket_manager_version || exit 1
+
+  MOCK_MANAGER_VERSION='19.0.0'; GITLAB_MANAGER_VERSION_VALIDATED_KEY=''
+  gitlab_validate_host_socket_manager_version || exit 1
+  MOCK_MANAGER_VERSION='18.5.0-rc1'; GITLAB_MANAGER_VERSION_VALIDATED_KEY=''
+  if gitlab_validate_host_socket_manager_version >/dev/null 2>&1; then exit 1; fi
+  MOCK_MANAGER_VERSION='not-a-version'; GITLAB_MANAGER_VERSION_VALIDATED_KEY=''
+  if gitlab_validate_host_socket_manager_version >/dev/null 2>&1; then exit 1; fi
+  MOCK_MANAGER_VERSION=fail; GITLAB_MANAGER_VERSION_VALIDATED_KEY=''
+  if gitlab_validate_host_socket_manager_version >/dev/null 2>&1; then exit 1; fi
+) || fail "GitLab host-socket manager version gate failed"
+
+DIND=true; SHARE_DOCKER_SOCK=false; NETWORK_ISOLATION=off
+GITLAB_URL='http://gitlab.example.test'
+if gitlab_validate_settings >/dev/null 2>&1; then fail "insecure HTTP GitLab URL accepted"; fi
+for invalid_url in \
+  'https://user@gitlab.example.test' \
+  'https://gitlab.example.test?token=x' \
+  'https://gitlab.example.test/#fragment' \
+  'https://gitlab.example.test:70000' \
+  'https://gitlab.example.test:bad' \
+  'https://gitlab.example.test bad'
+do
+  GITLAB_URL="$invalid_url"
+  if gitlab_validate_settings >/dev/null 2>&1; then fail "unsafe GitLab URL accepted: $invalid_url"; fi
+done
+GITLAB_URL='https://gitlab.example.test:8443/gitlab/'
+gitlab_validate_settings >/dev/null 2>&1 || fail "valid self-managed GitLab subpath/port rejected"
+[ "$(gitlab_url)" = 'https://gitlab.example.test:8443/gitlab' ] || fail "self-managed GitLab URL normalization changed"
+for isolated_mode in isolate strict; do
+  DIND=false; SHARE_DOCKER_SOCK=true; NETWORK_ISOLATION="$isolated_mode"
+  if gitlab_validate_settings >/dev/null 2>&1; then
+    fail "GitLab host-socket mode accepted unenforceable $isolated_mode networking"
+  fi
+done
+DIND=true; SHARE_DOCKER_SOCK=false; NETWORK_ISOLATION=off
+GITLAB_SHUTDOWN_TIMEOUT=29
+if gitlab_validate_settings >/dev/null 2>&1; then fail "too-short GitLab graceful shutdown timeout accepted"; fi
+GITLAB_SHUTDOWN_TIMEOUT=7200
+
+# Generate a real per-slot config without Docker. The reusable token must exist
+# only in the protected TOML—not manager argv—and system IDs must survive writes.
+CACHE_ROOT="$tmp/cache"
+CACHE_MOUNTS=''
+IMAGE_SOURCE=builtin
+mkdir -p "$CACHE_ROOT"
+gitlab_write_config 1 ci-runner-1 || fail "GitLab TOML generation failed"
+cfg="$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml"
+[ "$(mode_of "$cfg")" = 600 ] || fail "config.toml is not mode 0600"
+grep -q '^concurrent = 1$' "$cfg" || fail "global concurrency missing"
+grep -q '^shutdown_timeout = 7200$' "$cfg" || fail "GitLab graceful shutdown timeout missing from TOML"
+grep -q '^  limit = 1$' "$cfg" || fail "per-manager limit missing"
+grep -q '^  executor = "docker"$' "$cfg" || fail "Docker executor missing"
+grep -q 'FF_NETWORK_PER_BUILD=1' "$cfg" || fail "per-build networks missing"
+grep -q 'image = "ci-runner-farm-gitlab-job:latest"' "$cfg" || fail "default GitLab job image missing"
+grep -q 'pull_policy = "if-not-present"' "$cfg" || fail "built-in GitLab image pull policy is not if-not-present"
+grep -q 'host = "unix:///runner-services/docker.sock"' "$cfg" \
+  || fail "GitLab DinD manager does not use the restart-safe socket-directory path"
+grep -q 'net.unraid.ci-runner-farm.slot' "$cfg" || fail "per-slot executor label missing"
+grep -qF "$GITLAB_RUNNER_TOKEN" "$cfg" || fail "runner token not written to protected manager config"
+[ "$(mode_of "$CRF_CFGDIR/gitlab-runners/ci-runner-1/.runner_system_id")" = 600 ] \
+  || fail "generated system ID is not mode 0600"
+first_system_id="$(cat "$CRF_CFGDIR/gitlab-runners/ci-runner-1/.runner_system_id")"
+printf '%s' "$first_system_id" | grep -qE '^r_[a-f0-9]{12}$' || fail "generated GitLab system ID has an invalid shape"
+gitlab_write_config 2 ci-runner-2 || fail "second-slot TOML generation failed"
+second_system_id="$(cat "$CRF_CFGDIR/gitlab-runners/ci-runner-2/.runner_system_id")"
+[ "$first_system_id" != "$second_system_id" ] || fail "fresh GitLab slots received the same system ID"
+printf 's_c2d22f638c25\n' > "$CRF_CFGDIR/gitlab-runners/ci-runner-1/.runner_system_id"
+gitlab_write_config 1 ci-runner-1 || fail "TOML rewrite failed"
+grep -qx 's_c2d22f638c25' "$CRF_CFGDIR/gitlab-runners/ci-runner-1/.runner_system_id" || fail "system ID was not preserved"
+
+# Verify the real reusable token through a dedicated manager identity before a
+# slot can start. Because GitLab's verify endpoint creates that manager row, the
+# transaction must immediately manager-unregister it and preserve retry material
+# across ambiguous transport or cleanup failures.
+VERIFY_CURL_ARGS="$tmp/gitlab-verify.argv"; VERIFY_CURL_BODY="$tmp/gitlab-verify.body"
+VERIFY_DOCKER_ARGS="$tmp/gitlab-verify.docker"; : > "$VERIFY_DOCKER_ARGS"
+VERIFY_HTTP=200; VERIFY_TRANSPORT_FAIL=0; VERIFY_UNREGISTER_FAIL=0
+curl() {
+  printf '%s\n' "$*" > "$VERIFY_CURL_ARGS"
+  cat > "$VERIFY_CURL_BODY"
+  [ "$VERIFY_TRANSPORT_FAIL" = 0 ] || return 7
+  printf '%s' "$VERIFY_HTTP"
+}
+docker() {
+  printf '%s\n' "$*" >> "$VERIFY_DOCKER_ARGS"
+  case "$*" in
+    "run --rm $GITLAB_RUNNER_IMAGE --version") printf 'Version:      18.5.0\nGit revision: mock\n' ;;
+    'network inspect bridge') return 0 ;;
+    *' unregister --name ci-runner-farm-token-probe') [ "$VERIFY_UNREGISTER_FAIL" = 0 ] ;;
+  esac
+}
+GITLAB_MANAGER_VERSION_VALIDATED_KEY=''
+GITLAB_TOKEN_PROBE_VALIDATED_TARGET=''
+gitlab_verify_manager_token ci-runner-1 || fail "valid GitLab runner token/system ID verification failed"
+probe_dir="$CRF_CFGDIR/gitlab-token-probe"
+probe_system_id="$(cat "$probe_dir/.runner_system_id")"
+grep -qx "token=$GITLAB_RUNNER_TOKEN&system_id=$probe_system_id" "$VERIFY_CURL_BODY" \
+  || fail "GitLab verification omitted the dedicated probe token/system ID body"
+grep -qF 'https://gitlab.example.test:8443/gitlab/api/v4/runners/verify' "$VERIFY_CURL_ARGS" \
+  || fail "GitLab verification used the wrong normalized endpoint"
+if grep -qF "$GITLAB_RUNNER_TOKEN" "$VERIFY_CURL_ARGS"; then fail "GitLab runner token leaked into curl argv"; fi
+grep -q 'run --rm --network bridge .* unregister --name ci-runner-farm-token-probe' "$VERIFY_DOCKER_ARGS" \
+  || fail "successful GitLab token verification left its temporary manager registered"
+[ ! -e "$probe_dir/config.toml" ] || fail "successful GitLab token probe retained token-bearing retry config"
+
+printf '%s\n' '-----BEGIN CERTIFICATE-----' 'YWJj' '-----END CERTIFICATE-----' > "$GITLAB_CA_FILE"
+printf '%s' "$GITLAB_RUNNER_TOKEN" > "$GITLAB_RUNNER_TOKEN_FILE"
+reload_secret_files
+GITLAB_TOKEN_PROBE_VALIDATED_TARGET=''
+gitlab_verify_manager_token ci-runner-1 || fail "GitLab token verification ignored the configured CA"
+grep -qF -- "--cacert $probe_dir/certs/gitlab-ca.crt" "$VERIFY_CURL_ARGS" \
+  || fail "GitLab verification omitted its protected self-managed CA snapshot"
+rm -f "$GITLAB_CA_FILE"
+reload_secret_files
+
+VERIFY_HTTP=403
+GITLAB_TOKEN_PROBE_VALIDATED_TARGET=''
+if gitlab_verify_manager_token ci-runner-1 >/dev/null 2>&1; then fail "rejected GitLab runner token was accepted"; fi
+[ ! -e "$probe_dir/config.toml" ] || fail "definitive 403 retained unnecessary probe credentials"
+
+VERIFY_HTTP=200; VERIFY_TRANSPORT_FAIL=1
+GITLAB_TOKEN_PROBE_VALIDATED_TARGET=''
+if gitlab_verify_manager_token ci-runner-1 >/dev/null 2>&1; then fail "unreachable GitLab verification was accepted"; fi
+[ -s "$probe_dir/config.toml" ] || fail "ambiguous GitLab verify transport failure discarded manager cleanup material"
+VERIFY_TRANSPORT_FAIL=0
+gitlab_verify_manager_token ci-runner-1 || fail "ambiguous GitLab token probe could not recover on retry"
+[ ! -e "$probe_dir/config.toml" ] || fail "recovered GitLab token probe retained token-bearing config"
+
+VERIFY_UNREGISTER_FAIL=1
+GITLAB_TOKEN_PROBE_VALIDATED_TARGET=''
+if gitlab_verify_manager_token ci-runner-1 >/dev/null 2>&1; then fail "GitLab token probe ignored manager-unregister failure"; fi
+[ -s "$probe_dir/config.toml" ] || fail "failed probe unregister discarded exact retry material"
+VERIFY_UNREGISTER_FAIL=0
+gitlab_verify_manager_token ci-runner-1 || fail "GitLab token probe unregister did not recover on retry"
+[ ! -e "$probe_dir/config.toml" ] || fail "recovered probe unregister retained token-bearing config"
+unset -f curl
+
+mkdir -p "$CRF_CFGDIR/gitlab-runners/ci-runner-4"
+printf '%s\n' corrupt-system-id > "$CRF_CFGDIR/gitlab-runners/ci-runner-4/.runner_system_id"
+if gitlab_ensure_system_id "$CRF_CFGDIR/gitlab-runners/ci-runner-4" >/dev/null 2>&1; then
+  fail "invalid persisted GitLab system ID was silently replaced"
+fi
+grep -qx corrupt-system-id "$CRF_CFGDIR/gitlab-runners/ci-runner-4/.runner_system_id" \
+  || fail "invalid persisted GitLab system ID was mutated"
+
+gitlab_build_manager_args 1 ci-runner-1 || fail "manager argv generation failed"
+if printf '%s\n' "${ARGS[@]}" | grep -qF "$GITLAB_RUNNER_TOKEN"; then fail "runner token leaked into Docker argv"; fi
+printf '%s\n' "${ARGS[@]}" | grep -qF 'wget -qO- http://127.0.0.1:9252/metrics' \
+  || fail "GitLab manager health check is not a local metrics probe"
+printf '%s\n' "${ARGS[@]}" | grep -qx -- '--stop-signal' \
+  || fail "GitLab manager does not explicitly use SIGQUIT stop semantics"
+printf '%s\n' "${ARGS[@]}" | grep -qx 'SIGQUIT' \
+  || fail "GitLab manager SIGQUIT value is missing"
+printf '%s\n' "${ARGS[@]}" | grep -qx -- '--stop-timeout' \
+  || fail "GitLab manager Docker stop timeout is missing"
+printf '%s\n' "${ARGS[@]}" | grep -qx '7200' \
+  || fail "GitLab manager Docker stop timeout value is missing"
+printf '%s\n' "${ARGS[@]}" | grep -qx "$CACHE_ROOT/gitlab-sockets/ci-runner-1:/runner-services" \
+  || fail "GitLab manager bind-mounts a stale socket inode instead of its socket directory"
+if printf '%s\n' "${ARGS[@]}" | grep -qx "$CACHE_ROOT/gitlab-sockets/ci-runner-1/docker.sock:/var/run/docker.sock"; then
+  fail "GitLab manager still bind-mounts the replaceable DinD socket file"
+fi
+
+# GitLab Runner's current receipt message is `Checking for jobs... received`,
+# while completion messages begin with a capitalized `Job`. Normalize the log
+# line before classifying it, but keep executor containers and metrics as the
+# higher-confidence signals.
+(
+  STATE_JOB=''; STATE_METRICS=''; STATE_LOG=''
+  gitlab_job_container() { printf '%s\n' "$STATE_JOB"; }
+  docker() {
+    case "${1:-}" in
+      inspect) printf 'running\n' ;;
+      exec) printf '%s\n' "$STATE_METRICS" ;;
+      logs) printf '%s\n' "$STATE_LOG" ;;
+    esac
+  }
+
+  STATE_JOB=runner-build-123
+  STATE_METRICS='gitlab_runner_jobs 0'
+  STATE_LOG='Job succeeded duration_s=4.2 job=123 project=456 runner=abc'
+  [ "$(gitlab_runner_state ci-runner-1)" = busy ] \
+    || exit 1
+
+  STATE_JOB=''
+  STATE_METRICS='gitlab_runner_jobs{runner="abc"} 1'
+  STATE_LOG='Job succeeded duration_s=4.2 job=123 project=456 runner=abc'
+  [ "$(gitlab_runner_state ci-runner-1)" = busy ] \
+    || exit 1
+
+  STATE_METRICS='gitlab_runner_jobs 0'
+  STATE_LOG='Checking for jobs... received job=124 repo_url=https://gitlab.example.test/group/project.git runner=abc'
+  [ "$(gitlab_runner_state ci-runner-1)" = busy ] \
+    || exit 1
+
+  STATE_LOG='Job succeeded duration_s=4.2 job=124 project=456 runner=abc'
+  [ "$(gitlab_runner_state ci-runner-1)" = idle ] \
+    || exit 1
+
+  STATE_LOG='Checking for jobs... no jobs runner=abc status=204 No Content'
+  [ "$(gitlab_runner_state ci-runner-1)" = idle ] \
+    || exit 1
+) || fail "GitLab manager state mapping did not recognize real Runner log messages"
+
+# Official images without `lint` use `list`; require a clean schema diagnostic,
+# the exact generated manager name, and Docker executor identity.
+valid_list_output=$'Runtime platform arch=amd64 os=linux\nmockhost-ci-runner-1 Executor=docker Token=redacted URL=https://gitlab.example.test'
+gitlab_list_output_valid mockhost-ci-runner-1 "$valid_list_output" \
+  || fail "valid GitLab list fallback output was rejected"
+if gitlab_list_output_valid mockhost-ci-runner-1 $'mockhost-ci-runner-1 Executor=docker\njsonschema: additionalProperties'; then
+  fail "GitLab list fallback accepted jsonschema diagnostics"
+fi
+if gitlab_list_output_valid mockhost-ci-runner-1 $'There might be a problem with your config\nmockhost-ci-runner-1 Executor=docker'; then
+  fail "GitLab list fallback accepted Runner config warning"
+fi
+if gitlab_list_output_valid wrong-name 'mockhost-ci-runner-1 Executor=docker'; then
+  fail "GitLab list fallback accepted a missing generated manager"
+fi
+if gitlab_list_output_valid mockhost-ci-runner-1 'mockhost-ci-runner-1 Executor=shell'; then
+  fail "GitLab list fallback accepted a non-Docker executor"
+fi
+
+printf '%s\n' '-----BEGIN CERTIFICATE-----' 'YWJj' '-----END CERTIFICATE-----' > "$CRF_CFGDIR/gitlab-ca.crt"
+reload_secret_files
+GITLAB_CA_FINGERPRINT='mock-ca-fingerprint'
+gitlab_build_manager_args 1 ci-runner-1 || fail "custom-CA manager argv generation failed"
+slot_ca="$CRF_CFGDIR/gitlab-runners/ci-runner-1/certs/gitlab-ca.crt"
+grep -q 'tls-ca-file = "/etc/gitlab-runner/certs/gitlab-ca.crt"' "$cfg" || fail "custom CA is absent from GitLab TOML"
+[ -d "$CRF_CFGDIR/gitlab-runners/ci-runner-1/certs" ] || fail "custom-CA bind target directory is missing"
+cmp -s "$CRF_CFGDIR/gitlab-ca.crt" "$slot_ca" || fail "active CA was not snapshotted into the slot"
+[ "$(mode_of "$slot_ca")" = 600 ] || fail "per-slot CA snapshot is not mode 0600"
+printf '%s\n' "${ARGS[@]}" | grep -qx "$slot_ca:/etc/gitlab-runner/certs/gitlab-ca.crt:ro" \
+  || fail "custom CA is absent from manager mounts"
+grep -qF "$slot_ca:/etc/gitlab-runner/certs/ca.crt:ro" "$cfg" \
+  || fail "custom CA is absent from Docker-executor helper/job mounts"
+# Publishing any replacement config invalidates the completion marker associated
+# with the prior manager identity, even if the rendered settings are identical.
+unregister_marker="$CRF_CFGDIR/gitlab-runners/ci-runner-1/.remote-unregister-complete"
+printf '%s\n' stale-manager-fingerprint > "$unregister_marker"
+gitlab_write_config 1 ci-runner-1 || fail "GitLab config rewrite with stale unregister marker failed"
+[ ! -e "$unregister_marker" ] || fail "new GitLab manager config retained a prior unregister completion marker"
+
+# A nested Docker daemon must see the host-side CA bind source used by the
+# generated executor config. It also needs Docker's exact certs.d authority for
+# private registry image pulls; a port is part of that authority.
+REGISTRY_SERVER='https://registry.gitlab.example.test:5443'
+[ "$(gitlab_registry_authority)" = 'registry.gitlab.example.test:5443' ] \
+  || fail "private registry CA authority normalization failed"
+# A locally built default does not make job/service image overrides public. The
+# configured registry credential must still reach each GitLab manager.
+IMAGE_SOURCE=builtin
+REGISTRY_USERNAME='gitlab-override-user'
+REGISTRY_TOKEN='gitlab-override-registry-secret'
+gitlab_write_docker_auth ci-runner-1 || fail "built-in-default GitLab registry auth generation failed"
+slot_auth="$CRF_CFGDIR/gitlab-runners/ci-runner-1/docker/config.json"
+[ -s "$slot_auth" ] && [ "$(mode_of "$slot_auth")" = 600 ] \
+  || fail "built-in-default GitLab registry auth was not protected"
+grep -qF 'registry.gitlab.example.test:5443' "$slot_auth" \
+  || fail "built-in-default GitLab registry auth omitted the configured authority"
+if grep -qF 'https://registry.gitlab.example.test:5443' "$slot_auth"; then
+  fail "GitLab registry auth retained a URL scheme that cannot match image authorities"
+fi
+gitlab_build_manager_args 1 ci-runner-1 || fail "built-in-default GitLab manager auth mount generation failed"
+printf '%s\n' "${ARGS[@]}" | grep -qx "$CRF_CFGDIR/gitlab-runners/ci-runner-1/docker:/root/.docker:ro" \
+  || fail "built-in-default GitLab manager did not receive registry auth"
+SIDECAR_ARGS="$tmp/gitlab-sidecar.args"
+docker() {
+  case "${1:-}" in
+    inspect) return 1 ;;
+    run) printf '%s\n' "$@" > "$SIDECAR_ARGS"; return 0 ;;
+    --host) return 0 ;;
+  esac
+  return 0
+}
+gitlab_start_sidecar 1 ci-runner-1 || fail "custom-CA GitLab DinD sidecar generation failed"
+grep -qx -- '--restart=unless-stopped' "$SIDECAR_ARGS" \
+  || fail "GitLab DinD sidecar does not survive Docker daemon restarts"
+grep -qx "type=bind,src=$slot_ca,dst=$slot_ca,readonly" "$SIDECAR_ARGS" \
+  || fail "DinD cannot resolve the executor's custom-CA bind source"
+grep -qx "type=bind,src=$slot_ca,dst=/etc/docker/certs.d/registry.gitlab.example.test:5443/ca.crt,readonly" "$SIDECAR_ARGS" \
+  || fail "custom CA is absent from the configured DinD registry trust path"
+grep -qx 'host.docker.internal:host-gateway' "$SIDECAR_ARGS" \
+  || fail "GitLab DinD cannot resolve the shared mirror through the default host-gateway endpoint"
+
+# GitLab DinD must not authenticate or pull the remote job image through the
+# Unraid host daemon: that would bypass the per-slot CA and credential files.
+# Host-socket mode still requires the legacy host login/pull path.
+IMAGE_SOURCE=remote; IMAGE='registry.gitlab.example.test:5443/team/job:latest'
+PREFLIGHT_LOG="$tmp/remote-preflight.log"; : > "$PREFLIGHT_LOG"
+(
+  check_cache_root() { :; }
+  ensure_dirs() { :; }
+  ensure_network() { :; }
+  ensure_mirror() { :; }
+  registry_login() { printf 'host-login\n' >> "$PREFLIGHT_LOG"; }
+  host_docker_pull() { printf 'host-pull %s\n' "$1" >> "$PREFLIGHT_LOG"; }
+  DIND=true; SHARE_DOCKER_SOCK=false
+  provision_base
+) || fail "GitLab DinD provider-aware preflight failed"
+[ ! -s "$PREFLIGHT_LOG" ] || fail "GitLab DinD preflight touched host registry auth/pull"
+# Recycle has an additional image guard before removing the old manager. A
+# remote DinD image must pass that guard without either a host pull or a host
+# image inspection; the replacement sidecar performs the real pull on start.
+(
+  host_docker_pull() { printf 'recycle-host-pull %s\n' "$1" >> "$PREFLIGHT_LOG"; return 1; }
+  docker() { printf 'recycle-host-docker %s\n' "$*" >> "$PREFLIGHT_LOG"; return 1; }
+  DIND=true; SHARE_DOCKER_SOCK=false
+  recycle_image_preflight "$IMAGE"
+) || fail "GitLab DinD remote recycle image preflight failed"
+[ ! -s "$PREFLIGHT_LOG" ] || fail "GitLab DinD remote recycle inspected/pulled the job image on the host"
+(
+  check_cache_root() { :; }
+  ensure_dirs() { :; }
+  ensure_network() { :; }
+  ensure_mirror() { :; }
+  registry_login() { printf 'host-login\n' >> "$PREFLIGHT_LOG"; }
+  host_docker_pull() { printf 'host-pull %s\n' "$1" >> "$PREFLIGHT_LOG"; }
+  DIND=false; SHARE_DOCKER_SOCK=true
+  provision_base
+) || fail "GitLab host-socket provider-aware preflight failed"
+grep -qx 'host-login' "$PREFLIGHT_LOG" || fail "GitLab host-socket preflight skipped host registry login"
+grep -qx "host-pull $IMAGE" "$PREFLIGHT_LOG" || fail "GitLab host-socket preflight skipped host image pull"
+
+# Common provisioning delegates before auth: a cached if-not-present image
+# remains usable offline and does not require credentials that will not be used.
+: > "$PREFLIGHT_LOG"
+(
+  check_cache_root() { :; }
+  ensure_dirs() { :; }
+  ensure_network() { :; }
+  ensure_mirror() { :; }
+  registry_login() { printf 'unexpected-login\n' >> "$PREFLIGHT_LOG"; return 1; }
+  host_docker_pull() { printf 'unexpected-pull\n' >> "$PREFLIGHT_LOG"; return 1; }
+  docker() { [ "$*" = "image inspect $IMAGE" ]; }
+  DIND=false; SHARE_DOCKER_SOCK=true; GITLAB_PULL_POLICY=if-not-present
+  provision_base
+) || fail "cached GitLab if-not-present provisioning required unused registry credentials"
+[ ! -s "$PREFLIGHT_LOG" ] || fail "cached GitLab if-not-present provisioning touched registry auth/pull"
+
+# Pull-policy ownership is adapter-specific. DinD never touches the host daemon;
+# host-socket mode refreshes host auth and honors always/if-not-present.
+POLICY_LOG="$tmp/gitlab-pull-policy.log"; : > "$POLICY_LOG"
+(
+  registry_login() { printf 'login\n' >> "$POLICY_LOG"; }
+  host_docker_pull() { printf 'pull %s\n' "$1" >> "$POLICY_LOG"; }
+  docker() {
+    printf 'docker %s\n' "$*" >> "$POLICY_LOG"
+    case "$*" in image\ inspect*) [ "${POLICY_IMAGE_PRESENT:-0}" = 1 ] ;; esac
+  }
+  DIND=true; GITLAB_PULL_POLICY=always
+  gitlab_prepare_remote_image "$IMAGE" || exit 1
+  [ ! -s "$POLICY_LOG" ] || exit 1
+
+  DIND=false; GITLAB_PULL_POLICY=always
+  gitlab_prepare_remote_image "$IMAGE" || exit 1
+  grep -qx login "$POLICY_LOG" && grep -qx "pull $IMAGE" "$POLICY_LOG" || exit 1
+  gitlab_remote_image_update_allowed || exit 1
+
+  : > "$POLICY_LOG"; POLICY_IMAGE_PRESENT=1; GITLAB_PULL_POLICY=if-not-present
+  gitlab_prepare_remote_image "$IMAGE" || exit 1
+  grep -q '^docker image inspect ' "$POLICY_LOG" || exit 1
+  ! grep -q '^login$' "$POLICY_LOG" || exit 1
+  ! grep -q '^pull ' "$POLICY_LOG" || exit 1
+  if gitlab_remote_image_update_allowed; then exit 1; fi
+
+  : > "$POLICY_LOG"; POLICY_IMAGE_PRESENT=0
+  gitlab_prepare_remote_image "$IMAGE" || exit 1
+  grep -qx login "$POLICY_LOG" || exit 1
+  grep -qx "pull $IMAGE" "$POLICY_LOG" || exit 1
+
+) || fail "GitLab remote-image host/DinD pull-policy contract failed"
+
+# The slot daemon applies the same policy after DinD starts. In particular,
+# `if-not-present` avoids needless network pulls.
+SLOT_POLICY_LOG="$tmp/gitlab-slot-pull-policy.log"; : > "$SLOT_POLICY_LOG"
+(
+  docker() {
+    printf '%s\n' "$*" >> "$SLOT_POLICY_LOG"
+    case "$*" in
+      *' image inspect '*) [ "${SLOT_IMAGE_PRESENT:-0}" = 1 ]; return ;;
+      *' pull '*) return 0 ;;
+    esac
+    return 0
+  }
+  DIND=true; IMAGE_SOURCE=remote; IMAGE='registry.gitlab.example.test:5443/team/job:latest'
+  GITLAB_PULL_POLICY=always; SLOT_IMAGE_PRESENT=1
+  gitlab_ensure_job_image ci-runner-1 || exit 1
+  grep -q ' pull registry.gitlab.example.test:5443/team/job:latest$' "$SLOT_POLICY_LOG" || exit 1
+
+  : > "$SLOT_POLICY_LOG"; GITLAB_PULL_POLICY=if-not-present; SLOT_IMAGE_PRESENT=1
+  gitlab_ensure_job_image ci-runner-1 || exit 1
+  ! grep -q ' pull ' "$SLOT_POLICY_LOG" || exit 1
+
+  : > "$SLOT_POLICY_LOG"; SLOT_IMAGE_PRESENT=0
+  gitlab_ensure_job_image ci-runner-1 || exit 1
+  grep -q ' pull registry.gitlab.example.test:5443/team/job:latest$' "$SLOT_POLICY_LOG" || exit 1
+
+) || fail "GitLab per-slot Docker pull policy failed"
+
+# For the editable built-in image, `auto` tracks rebuilds. Explicit
+# if-not-present preserves an existing nested image instead of silently
+# overwriting it with the host's newer image.
+BUILTIN_POLICY_LOG="$tmp/gitlab-builtin-policy.log"; : > "$BUILTIN_POLICY_LOG"
+(
+  docker() {
+    printf '%s\n' "$*" >> "$BUILTIN_POLICY_LOG"
+    if [ "${1:-}" = image ] && [ "${2:-}" = inspect ] && [ "${3:-}" = -f ]; then
+      printf '%s\n' sha256:new-host-image; return 0
+    fi
+    if [ "${1:-}" = --host ] && [ "${3:-}" = image ] && [ "${4:-}" = inspect ]; then
+      [ -n "${BUILTIN_NESTED_ID:-}" ] || return 1
+      printf '%s\n' "$BUILTIN_NESTED_ID"; return 0
+    fi
+    return 0
+  }
+  DIND=true; IMAGE_SOURCE=builtin; IMAGE=''
+  GITLAB_PULL_POLICY=if-not-present; BUILTIN_NESTED_ID=sha256:old-nested-image
+  gitlab_ensure_job_image ci-runner-1 || exit 1
+  ! grep -q '^image save ' "$BUILTIN_POLICY_LOG" || exit 1
+
+  : > "$BUILTIN_POLICY_LOG"; BUILTIN_NESTED_ID=''
+  gitlab_ensure_job_image ci-runner-1 || exit 1
+  grep -q '^image save ' "$BUILTIN_POLICY_LOG" && grep -q ' image load$' "$BUILTIN_POLICY_LOG" || exit 1
+
+  : > "$BUILTIN_POLICY_LOG"; GITLAB_PULL_POLICY=auto; BUILTIN_NESTED_ID=sha256:old-nested-image
+  gitlab_ensure_job_image ci-runner-1 || exit 1
+  grep -q '^image save ' "$BUILTIN_POLICY_LOG" || exit 1
+) || fail "GitLab built-in image pull-policy semantics failed"
+
+# Host-socket cleanup is deliberately broader than busy-job discovery: every
+# plugin-owned build, helper, and service container for the slot must be removed.
+HOST_JOB_LOG="$tmp/gitlab-host-jobs.log"; : > "$HOST_JOB_LOG"
+(
+  docker() {
+    printf '%s\n' "$*" >> "$HOST_JOB_LOG"
+    case "$*" in
+      'ps -aq '*) printf '%s\n' build-id helper-id service-id ;;
+    esac
+  }
+  gitlab_remove_host_jobs ci-runner-1 || exit 1
+) || fail "GitLab host-socket job/helper/service cleanup failed"
+grep -q 'provider=gitlab' "$HOST_JOB_LOG" && grep -q 'slot=ci-runner-1' "$HOST_JOB_LOG" \
+  || fail "GitLab host cleanup did not scope discovery to its provider and slot"
+grep -q 'com.gitlab.gitlab-runner.managed=true' "$HOST_JOB_LOG" \
+  || fail "GitLab host cleanup can select containers not owned by GitLab Runner"
+if grep -q 'gitlab-runner.type=build' "$HOST_JOB_LOG"; then fail "GitLab host cleanup still filters out helper/service containers"; fi
+grep -q '^rm -f build-id helper-id service-id$' "$HOST_JOB_LOG" \
+  || fail "GitLab host cleanup did not remove all plugin-owned slot containers"
+
+IMAGE_SOURCE=builtin; IMAGE=''; REGISTRY_SERVER=''; DIND=true; SHARE_DOCKER_SOCK=false
+
+# The UI warning is a security contract, not marketing: per-slot Docker scope
+# limits ordinary sibling access but privileged DinD is not a host boundary.
+rm -f "$SECURITY_CACHE"
+GITLAB_API_TOKEN=''; GITLAB_PROJECTS=''; DIND=true; SHARE_DOCKER_SOCK=false
+security_warning="$(provider_public_problem)"
+printf '%s' "$security_warning" | grep -qF 'job, helper, and service containers' \
+  || fail "GitLab DinD warning omits the slot sibling-container blast radius"
+printf '%s' "$security_warning" | grep -qF 'not a security boundary against the Unraid host' \
+  || fail "GitLab DinD warning implies privileged DinD is a host boundary"
+gitlab_gen_before="$(crf_confgen)"
+GITLAB_RUNNER_TOKEN='glrt-memory-snapshot-changed-1234567890'
+[ "$(crf_confgen)" != "$gitlab_gen_before" ] || fail "GitLab confgen ignores the in-memory runner token"
+GITLAB_RUNNER_TOKEN="$ROUTABLE_GITLAB_RUNNER_TOKEN"
+gitlab_gen_before="$(crf_confgen)"; REGISTRY_TOKEN='registry-memory-snapshot-changed'
+[ "$(crf_confgen)" != "$gitlab_gen_before" ] || fail "GitLab confgen ignores the in-memory registry token"
+REGISTRY_TOKEN=''
+
+# Mock GitLab API pagination and a Jobs response containing nested pipeline and
+# runner status fields. Tokens arrive through curl config stdin and must never
+# appear in argv/logs.
+export MOCK_CURL_ARGS="$tmp/curl.argv"
+: > "$MOCK_CURL_ARGS"
+curl() {
+  local headers='' output='' url='' arg input
+  printf '%s\n' "$*" >> "$MOCK_CURL_ARGS"
+  input="$(cat)"
+  case "$input" in 'header = "PRIVATE-TOKEN: '*'"') ;; *) return 22 ;; esac
+  while [ "$#" -gt 0 ]; do
+    arg="$1"; shift
+    case "$arg" in
+      -D) headers="$1"; shift ;;
+      -o) output="$1"; shift ;;
+      http*) url="$arg" ;;
+    esac
+  done
+  if [ -n "$headers" ]; then
+    printf 'HTTP/2 200\r\nx-total: 3\r\n\r\n' > "$headers"
+    printf '[{"id":101,"status":"pending","pipeline":{"id":9},"runner":{"id":4}}]' > "$output"
+  elif printf '%s' "$url" | grep -q '/jobs?per_page=50'; then
+    printf '%s' '[{"id":1,"status":"success","pipeline":{"id":2,"status":"failed"},"runner":{"id":3,"status":"online"}},{"id":4,"status":"failed","pipeline":{"id":5,"status":"success"},"runner":{"id":6,"status":"offline"}}]'
+  else
+    printf '%s' '{"visibility":"private"}'
+  fi
+}
+
+GITLAB_API_TOKEN='custom@prefix-token_1234567890'
+GITLAB_PROJECTS='group/project'
+gitlab_queued_refresh
+read -r qprovider _ qcount < "$CRF_RUNDIR/queued.cache"
+[ "$qprovider" = gitlab ] && [ "$qcount" = 3 ] || fail "GitLab queue pagination mapping is wrong"
+gitlab_stats_refresh
+read -r sprovider _ sok sfail scancel sother stotal < "$CRF_RUNDIR/stats.cache"
+[ "$sprovider" = gitlab ] && [ "$sok" = 1 ] && [ "$sfail" = 1 ] \
+  && [ "$scancel" = 0 ] && [ "$sother" = 0 ] && [ "$stotal" = 2 ] \
+  || fail "GitLab stats counted nested status fields"
+if grep -qF "$GITLAB_API_TOKEN" "$MOCK_CURL_ARGS"; then fail "API token leaked into curl argv"; fi
+GITLAB_API_TOKEN=''
+gitlab_queued_refresh
+read -r _ _ qcount < "$CRF_RUNDIR/queued.cache"
+[ "$qcount" = -1 ] || fail "missing API token did not produce unavailable queue sentinel"
+gitlab_stats_refresh
+read -r _ _ _ _ _ _ stotal < "$CRF_RUNDIR/stats.cache"
+[ "$stotal" = -1 ] || fail "missing API token did not produce unavailable stats sentinel"
+
+# Feed one neutral GitLab cache row into status-json and mock its single batched
+# inspect. This proves the public mapping without exposing any CI environment.
+GITLAB_RUNNER_TOKEN="$ROUTABLE_GITLAB_RUNNER_TOKEN"
+GITLAB_API_TOKEN=''
+cur_gen="$(crf_confgen)"
+printf '%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\n' \
+  ci-runner-1 12.5 256 busy "$(_b64 compile)" 2026-08-03T12:00:00Z gitlab \
+  "$(_b64 group/project)" 42 "$(_b64 'https://gitlab.example.test/group/project/-/jobs/42')" \
+  "$(_b64 main)" "$(_b64 'https://gitlab.example.test/group/project/-/tree/main')" _ _ _ _ \
+  > "$CRF_RUNDIR/usage.cache"
+: > "$CRF_RUNDIR/warn.cache"; : > "$CRF_RUNDIR/sec.cache"
+managed_names() { printf 'ci-runner-1\n'; }
+docker() {
+  if [ "${1:-}" = inspect ]; then
+    printf '/ci-runner-1|running|2000000000|4294967296|%s|gitlab\n' "$cur_gen"
+    return 0
+  fi
+  return 0
+}
+status_json="$(cmd_status_json)"
+STATUS_JSON="$status_json" python3 -c '
+import json, os
+d = json.loads(os.environ["STATUS_JSON"])
+r = (d.get("runners") or [{}])[0]
+assert d.get("provider") == "gitlab" and d.get("token") is True
+assert r.get("provider") == "gitlab" and r.get("project") == "group/project"
+assert r.get("job_id") == "42" and r.get("ref") == "main"
+assert r.get("repo") == "" and r.get("run_id") == ""
+' || fail "provider-neutral status JSON mapping failed"
+if printf '%s' "$status_json" | grep -qF "$GITLAB_RUNNER_TOKEN"; then fail "runner token leaked into status JSON"; fi
+
+# A cache row must agree with the live container provider. This prevents stale
+# provider-switch data from being presented as the new provider's current job.
+printf '%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\n' \
+  ci-runner-1 99 999 busy "$(_b64 stale-job)" 2026-08-03T11:00:00Z github \
+  "$(_b64 wrong/project)" 999 "$(_b64 'https://wrong.invalid/job')" \
+  "$(_b64 wrong-ref)" "$(_b64 'https://wrong.invalid/ref')" "$(_b64 wrong/repo)" 9 "$(_b64 wrong)" 999 \
+  > "$CRF_RUNDIR/usage.cache"
+status_json="$(cmd_status_json)"
+STATUS_JSON="$status_json" python3 -c '
+import json, os
+r = (json.loads(os.environ["STATUS_JSON"]).get("runners") or [{}])[0]
+assert r.get("provider") == "gitlab"
+assert r.get("phase") == "starting" and r.get("project") == ""
+assert r.get("job_id") == "" and r.get("repo") == ""
+' || fail "provider-mismatched status cache row was consumed"
+
+# Pre-provider ten-field cache rows remain upgrade-compatible for a live GitHub
+# container only; they also populate the new neutral URL/ref fields.
+printf '%s %s %s %s %s %s %s %s %s %s\n' \
+  ci-runner-1 6.25 128 busy "$(_b64 legacy-build)" 2026-08-03T10:00:00Z \
+  "$(_b64 example/legacy)" 17 "$(_b64 feature/legacy)" 321 \
+  > "$CRF_RUNDIR/usage.cache"
+status_json="$(cmd_status_json)"
+STATUS_JSON="$status_json" python3 -c '
+import json, os
+r = (json.loads(os.environ["STATUS_JSON"]).get("runners") or [{}])[0]
+assert r.get("provider") == "gitlab" and r.get("phase") == "starting"
+assert r.get("project") == "" and r.get("run_id") == ""
+' || fail "legacy GitHub cache row was accepted for a live GitLab manager"
+
+docker() {
+  if [ "${1:-}" = inspect ]; then
+    printf '/ci-runner-1|running|2000000000|4294967296|%s|github\n' "$cur_gen"
+    return 0
+  fi
+  return 0
+}
+status_json="$(cmd_status_json)"
+STATUS_JSON="$status_json" python3 -c '
+import json, os
+r = (json.loads(os.environ["STATUS_JSON"]).get("runners") or [{}])[0]
+assert r.get("provider") == "github" and r.get("project") == "example/legacy"
+assert r.get("job_id") == "321" and r.get("job_url") == "https://github.com/example/legacy/actions/runs/321"
+assert r.get("ref") == "PR #17" and r.get("ref_url") == "https://github.com/example/legacy/pull/17"
+assert r.get("repo") == "example/legacy" and r.get("run_id") == "321"
+' || fail "legacy GitHub status cache compatibility/neutral URL mapping failed"
+
+# A manager removed outside the lifecycle must not cause its only exact
+# unregister identity to be silently scrubbed. Once a matching completion
+# marker proves the remote manager deletion succeeded, the interrupted local
+# credential cleanup is safe to finish while preserving the system ID.
+saved_cfgdir="$CFGDIR"
+CFGDIR="$tmp/orphan-cfg"
+orphan_dir="$CFGDIR/gitlab-runners/ci-runner-7"
+mkdir -p "$orphan_dir/docker" "$orphan_dir/certs"
+printf '%s\n' '[[runners]]' '  name = "host-ci-runner-7"' \
+  '  token = "glrt-orphan-manager-token-123456"' > "$orphan_dir/config.toml"
+printf '%s\n' s_c2d22f638c25 > "$orphan_dir/.runner_system_id"
+printf '%s\n' registry-auth > "$orphan_dir/docker/config.json"
+printf '%s\n' saved-ca > "$orphan_dir/certs/gitlab-ca.crt"
+docker() { return 1; }
+if gitlab_assert_no_orphan_manager_configs >/dev/null 2>&1; then
+  fail "missing GitLab manager credentials were silently accepted without unregister proof"
+fi
+[ -s "$orphan_dir/config.toml" ] && [ -s "$orphan_dir/docker/config.json" ] \
+  || fail "orphan-manager check discarded unregister retry material"
+orphan_identity="$(gitlab_unregister_identity "$orphan_dir")"
+gitlab_mark_unregister_complete "$orphan_dir" "$orphan_identity" \
+  || fail "could not create completed-unregister test marker"
+gitlab_assert_no_orphan_manager_configs \
+  || fail "completed unregister marker did not permit local credential scrub"
+[ ! -e "$orphan_dir/config.toml" ] && [ ! -e "$orphan_dir/docker/config.json" ] \
+  && [ ! -e "$orphan_dir/certs/gitlab-ca.crt" ] \
+  || fail "completed unregister cleanup retained reusable credential material"
+grep -qx s_c2d22f638c25 "$orphan_dir/.runner_system_id" \
+  || fail "completed unregister cleanup removed the stable system ID"
+CFGDIR="$saved_cfgdir"
+docker() { return 0; }
+
+# Credential clears are engine-owned fleet-lock transactions. Exercise the
+# inner commands directly here (dispatch locking has a static contract check),
+# with Docker/stop/reconcile mocked so no host daemon is required.
+mkdir -p "$HOST_DOCKER_CONFIG" "$CRF_CFGDIR/docker-auth" \
+  "$CRF_CFGDIR/gitlab-runners/ci-runner-1/docker"
+
+ACCESS_TOKEN='github_pat_clear_transaction_secret_1234567890'
+printf '%s' "$ACCESS_TOKEN" > "$TOKEN_FILE"
+printf '%s' host-auth > "$HOST_DOCKER_CONFIG/config.json"
+printf '%s' fallback-auth > "$CRF_CFGDIR/docker-auth/config.json"
+cmd_credential_clear_github_token > "$tmp/clear-github.json" \
+  || fail "GitHub credential clear transaction failed"
+grep -q '"ok":true' "$tmp/clear-github.json" || fail "GitHub clear did not report success"
+grep -q '"token_removed":true' "$tmp/clear-github.json" || fail "GitHub clear token result is missing"
+grep -q '"host_auth_removed":true' "$tmp/clear-github.json" || fail "GitHub clear host-auth result is missing"
+[ ! -e "$TOKEN_FILE" ] && [ ! -e "$HOST_DOCKER_CONFIG/config.json" ] \
+  && [ ! -e "$CRF_CFGDIR/docker-auth/config.json" ] || fail "GitHub clear left a credential copy"
+[ -z "$ACCESS_TOKEN" ] || fail "GitHub clear retained the in-memory PAT"
+if grep -qF 'github_pat_clear_transaction_secret' "$tmp/clear-github.json"; then
+  fail "GitHub PAT leaked into clear response"
+fi
+
+CI_PROVIDER=gitlab
+GITLAB_RUNNER_TOKEN='glrt-clear-transaction-secret-1234567890'
+printf '%s' "$GITLAB_RUNNER_TOKEN" > "$GITLAB_RUNNER_TOKEN_FILE"
+printf '%s' token-bearing-toml > "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml"
+printf '%s' interrupted-toml > "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml.tmp"
+printf '%s\n' s_c2d22f638c25 > "$CRF_CFGDIR/gitlab-runners/ci-runner-1/.runner_system_id"
+cmd_credential_clear_gitlab_runner 0 > "$tmp/clear-gitlab-unconfirmed.json" \
+  || fail "unconfirmed GitLab clear response failed"
+grep -q '"confirmation_required":true' "$tmp/clear-gitlab-unconfirmed.json" \
+  || fail "active GitLab token clear did not require confirmation"
+[ -e "$GITLAB_RUNNER_TOKEN_FILE" ] && [ -e "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml" ] \
+  || fail "unconfirmed GitLab clear changed credentials"
+
+cmd_stop() { printf '%s\n' 'mock GitLab fleet stopped and managers unregistered'; }
+gitlab_assert_no_orphan_manager_configs() { return 0; }
+gitlab_recover_pending_probe() { return 1; }
+if cmd_credential_clear_gitlab_runner 1 > "$tmp/clear-gitlab-probe-blocked.json"; then
+  fail "GitLab token clear ignored a pending probe-manager cleanup failure"
+fi
+[ -e "$GITLAB_RUNNER_TOKEN_FILE" ] \
+  || fail "blocked GitLab token clear removed the only bootstrap credential before probe recovery"
+grep -q '"token_removed":false' "$tmp/clear-gitlab-probe-blocked.json" \
+  || fail "blocked GitLab token clear did not report credential preservation"
+gitlab_recover_pending_probe() { return 0; }
+cmd_credential_clear_gitlab_runner 1 > "$tmp/clear-gitlab-confirmed.json" \
+  || fail "confirmed GitLab credential clear transaction failed"
+grep -q '"ok":true' "$tmp/clear-gitlab-confirmed.json" || fail "confirmed GitLab clear did not report success"
+grep -q '"fleet_stop_requested":true' "$tmp/clear-gitlab-confirmed.json" \
+  || fail "confirmed GitLab clear did not report the stop request"
+grep -q '"fleet_stopped":true' "$tmp/clear-gitlab-confirmed.json" \
+  || fail "confirmed GitLab clear did not report a stopped fleet"
+grep -q '"slot_configs_removed":true' "$tmp/clear-gitlab-confirmed.json" \
+  || fail "confirmed GitLab clear did not report per-slot cleanup"
+[ ! -e "$GITLAB_RUNNER_TOKEN_FILE" ] \
+  && [ ! -e "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml" ] \
+  && [ ! -e "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml.tmp" ] \
+  || fail "confirmed GitLab clear left a token-bearing config"
+grep -qx s_c2d22f638c25 "$CRF_CFGDIR/gitlab-runners/ci-runner-1/.runner_system_id" \
+  || fail "GitLab clear removed or changed the persistent manager system ID"
+[ -z "$GITLAB_RUNNER_TOKEN" ] || fail "GitLab clear retained the in-memory runner token"
+if grep -qF 'glrt-clear-transaction-secret' "$tmp/clear-gitlab-confirmed.json"; then
+  fail "GitLab runner token leaked into clear response"
+fi
+
+REGISTRY_TOKEN='registry-clear-transaction-secret'
+printf '%s' "$REGISTRY_TOKEN" > "$REGISTRY_TOKEN_FILE"
+printf '%s' slot-auth > "$CRF_CFGDIR/gitlab-runners/ci-runner-1/docker/config.json"
+printf '%s' interrupted-auth > "$CRF_CFGDIR/gitlab-runners/ci-runner-1/docker/config.json.tmp"
+printf '%s' host-auth > "$HOST_DOCKER_CONFIG/config.json"
+printf '%s' fallback-auth > "$CRF_CFGDIR/docker-auth/config.json"
+cmd_reconcile_config() { printf '%s\n' 'mock reconcile queued'; }
+cmd_credential_clear_registry_token > "$tmp/clear-registry.json" \
+  || fail "registry credential clear transaction failed"
+for field in token_removed slot_auth_removed host_auth_removed reconcile_requested reconcile_started; do
+  grep -q "\"$field\":true" "$tmp/clear-registry.json" || fail "registry clear result is missing $field=true"
+done
+[ ! -e "$REGISTRY_TOKEN_FILE" ] \
+  && [ ! -e "$CRF_CFGDIR/gitlab-runners/ci-runner-1/docker/config.json" ] \
+  && [ ! -e "$CRF_CFGDIR/gitlab-runners/ci-runner-1/docker/config.json.tmp" ] \
+  && [ ! -e "$HOST_DOCKER_CONFIG/config.json" ] \
+  && [ ! -e "$CRF_CFGDIR/docker-auth/config.json" ] \
+  || fail "registry clear left a credential or derived Docker auth copy"
+[ -z "$REGISTRY_TOKEN" ] || fail "registry clear retained the in-memory token"
+if grep -qF 'registry-clear-transaction-secret' "$tmp/clear-registry.json"; then
+  fail "registry token leaked into clear response"
+fi
+
+# A failed manager `docker run` may scrub its freshly rendered reusable token
+# only when Docker positively proves no manager exists, or after an owned
+# Created residue is removed by immutable ID. Any inspection/enumeration
+# ambiguity must retain the complete identity for operator-safe recovery.
+(
+  START_FAIL_CFGDIR="$tmp/start-failure-config"
+  START_FAIL_LOG="$tmp/start-failure.log"
+  START_FAIL_NAME=ci-runner-8
+  START_FAIL_ID=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  CRF_CFGDIR="$START_FAIL_CFGDIR"
+  mkdir -p "$CRF_CFGDIR"
+
+  gitlab_validate_host_socket_manager_version() { return 0; }
+  gitlab_verify_manager_token() { return 0; }
+  gitlab_build_args() { ARGS=(--detach --name "$2" "$GITLAB_RUNNER_IMAGE"); }
+  gitlab_start_sidecar() { return 0; }
+  gitlab_ensure_job_image() { return 0; }
+  gitlab_remove_sidecar() { printf 'SIDECAR_REMOVE %s\n' "$1" >> "$START_FAIL_LOG"; }
+  managed_runner_snapshot() {
+    case "$START_FAIL_MODE" in
+      created) printf '%s|gitlab|manager|8|mock-generation\n' "$START_FAIL_ID" ;;
+      unverified-created) printf '%s|github|runner|8|mock-generation\n' "$START_FAIL_ID" ;;
+      *) return 1 ;;
+    esac
+  }
+  docker() {
+    printf 'DOCKER %s\n' "$*" >> "$START_FAIL_LOG"
+    case "${1:-}" in
+      image) return 0 ;;
+      run) return 1 ;;
+      inspect)
+        if [ "${2:-}" = -f ]; then
+          case "$START_FAIL_MODE" in
+            created|unverified-created) printf 'created\n'; return 0 ;;
+            *) return 1 ;;
+          esac
+        fi
+        case "$START_FAIL_MODE" in
+          created|unverified-created) return 0 ;;
+          *) return 1 ;;
+        esac
+        ;;
+      ps)
+        case "$START_FAIL_MODE" in
+          absent) return 0 ;;
+          listed-but-uninspectable) printf '%s\n' "$START_FAIL_NAME"; return 0 ;;
+          ambiguous) return 1 ;;
+        esac
+        ;;
+      rm)
+        [ "$START_FAIL_MODE" = created ] && [ "${2:-}" = "$START_FAIL_ID" ]
+        return
+        ;;
+    esac
+    return 1
+  }
+  prepare_start_failure_identity() {
+    local dir
+    dir="$(gitlab_slot_config_dir "$START_FAIL_NAME")"
+    mkdir -p "$dir"
+    printf '%s\n' token-bearing-config > "$dir/config.toml"
+    printf '%s\n' s_c2d22f638c25 > "$dir/.runner_system_id"
+  }
+  start_failure_config() {
+    printf '%s/config.toml\n' "$(gitlab_slot_config_dir "$START_FAIL_NAME")"
+  }
+
+  START_FAIL_MODE=absent; : > "$START_FAIL_LOG"; prepare_start_failure_identity
+  if gitlab_start_one 8 "$START_FAIL_NAME" >/dev/null 2>&1; then
+    fail "failed GitLab manager start unexpectedly succeeded"
+  fi
+  [ ! -e "$(start_failure_config)" ] \
+    || fail "successful Docker enumeration proving manager absence retained credentials"
+  grep -q '^DOCKER ps -a --format {{.Names}}$' "$START_FAIL_LOG" \
+    || fail "failed manager start did not enumerate all containers before scrubbing"
+  grep -q "^SIDECAR_REMOVE $START_FAIL_NAME$" "$START_FAIL_LOG" \
+    || fail "proven-absent manager start failure retained its sidecar"
+
+  START_FAIL_MODE=ambiguous; : > "$START_FAIL_LOG"; prepare_start_failure_identity
+  if gitlab_start_one 8 "$START_FAIL_NAME" >/dev/null 2>&1; then
+    fail "ambiguous failed GitLab manager start unexpectedly succeeded"
+  fi
+  [ -s "$(start_failure_config)" ] \
+    || fail "Docker enumeration failure discarded protected manager identity"
+  if grep -q '^SIDECAR_REMOVE ' "$START_FAIL_LOG"; then
+    fail "Docker enumeration failure removed the protected manager sidecar"
+  fi
+
+  START_FAIL_MODE=listed-but-uninspectable; : > "$START_FAIL_LOG"; prepare_start_failure_identity
+  if gitlab_start_one 8 "$START_FAIL_NAME" >/dev/null 2>&1; then
+    fail "listed-but-uninspectable failed GitLab manager start unexpectedly succeeded"
+  fi
+  [ -s "$(start_failure_config)" ] \
+    || fail "listed-but-uninspectable manager discarded protected identity"
+  if grep -q '^SIDECAR_REMOVE ' "$START_FAIL_LOG"; then
+    fail "listed-but-uninspectable manager removed its protected sidecar"
+  fi
+
+  START_FAIL_MODE=created; : > "$START_FAIL_LOG"; prepare_start_failure_identity
+  if gitlab_start_one 8 "$START_FAIL_NAME" >/dev/null 2>&1; then
+    fail "Created-residue GitLab manager start unexpectedly succeeded"
+  fi
+  grep -q "^DOCKER rm $START_FAIL_ID$" "$START_FAIL_LOG" \
+    || fail "owned Created residue was not removed by immutable container ID"
+  [ ! -e "$(start_failure_config)" ] \
+    || fail "removed owned Created residue retained reusable credentials"
+  grep -q "^SIDECAR_REMOVE $START_FAIL_NAME$" "$START_FAIL_LOG" \
+    || fail "removed owned Created residue retained its sidecar"
+
+  START_FAIL_MODE=unverified-created; : > "$START_FAIL_LOG"; prepare_start_failure_identity
+  if gitlab_start_one 8 "$START_FAIL_NAME" >/dev/null 2>&1; then
+    fail "unverified Created-residue GitLab manager start unexpectedly succeeded"
+  fi
+  [ -s "$(start_failure_config)" ] \
+    || fail "unverified Created residue discarded protected manager identity"
+  if grep -Eq '^DOCKER rm |^SIDECAR_REMOVE ' "$START_FAIL_LOG"; then
+    fail "unverified Created residue triggered destructive local cleanup"
+  fi
+)
+
+# The common stopped-slot loop must carry the immutable ID from its ownership
+# snapshot into the provider adapter; a later fixed-name lookup is not an
+# authority to restart whichever container happens to hold that name.
+(
+  DISPATCH_LOG="$tmp/start-stopped-dispatch.log"
+  DISPATCH_MANAGER_ID=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  CI_PROVIDER=gitlab
+  managed_names() { printf '%s\n' ci-runner-1; }
+  managed_runner_snapshot() {
+    printf '%s|gitlab|manager|1|dispatch-generation\n' "$DISPATCH_MANAGER_ID"
+  }
+  crf_confgen() { printf '%s\n' dispatch-generation; }
+  docker() {
+    [ "$*" = "inspect -f {{.State.Running}} $DISPATCH_MANAGER_ID" ] || return 1
+    printf 'false\n'
+  }
+  gitlab_start_stopped() { printf '%s|%s|%s\n' "$1" "$2" "$3" > "$DISPATCH_LOG"; }
+  start_stopped_managed || fail "stopped-manager dispatch rejected an owned GitLab slot"
+  grep -qx "ci-runner-1|1|$DISPATCH_MANAGER_ID" "$DISPATCH_LOG" \
+    || fail "stopped-manager dispatch dropped its ownership-verified immutable ID"
+)
+
+# An unchanged stopped manager restarts in place (preserving system ID) without
+# remote unregister. A retired manager drains before manager-only unregister,
+# using its exact persisted name, old image, token, config, and system ID.
+LIFECYCLE_LOG="$tmp/gitlab-lifecycle.log"; : > "$LIFECYCLE_LOG"
+LIFECYCLE_STOP_FAIL=0
+LIFECYCLE_UNREGISTER_FAIL=0
+LIFECYCLE_RM_FAIL=0
+LIFECYCLE_JOB=''
+LIFECYCLE_JOB_IMAGE_FAIL=0
+LIFECYCLE_MANAGER_ID=dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+LIFECYCLE_NAME_MANAGER_ID="$LIFECYCLE_MANAGER_ID"
+LIFECYCLE_SIDE_ID=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+UNREGISTER_MOUNT_FILE="$tmp/gitlab-unregister.mount"
+UNREGISTER_CONFIG_CAPTURE="$tmp/gitlab-unregister.config"
+UNREGISTER_CA_CAPTURE="$tmp/gitlab-unregister.ca"
+gitlab_start_sidecar() { printf 'SIDECAR %s %s\n' "$1" "$2" >> "$LIFECYCLE_LOG"; }
+gitlab_ensure_job_image() {
+  printf 'JOB_IMAGE %s\n' "$1" >> "$LIFECYCLE_LOG"
+  [ "$LIFECYCLE_JOB_IMAGE_FAIL" = 0 ]
+}
+docker() {
+  local mount='' source='' arg fmt='' target=''
+  printf 'DOCKER %s\n' "$*" >> "$LIFECYCLE_LOG"
+  if [ "${1:-}" = stop ] && [ "$LIFECYCLE_STOP_FAIL" = 1 ]; then return 1; fi
+  if [ "${1:-}" = rm ] && [ "${2:-}" = ci-runner-1 ] && [ "$LIFECYCLE_RM_FAIL" = 1 ]; then return 1; fi
+  if [ "${1:-}" = inspect ]; then
+    if [ "${2:-}" != -f ]; then return 0; fi
+    fmt="${3:-}"; target="${4:-}"
+    case "$fmt" in
+      '{{.Id}}')
+        [ "$target" = ci-runner-1 ] && printf '%s\n' "$LIFECYCLE_NAME_MANAGER_ID" \
+          || { [ "$target" = ci-runner-1-dind ] && printf '%s\n' "$LIFECYCLE_SIDE_ID"; }
+        ;;
+      *State.Running*) printf 'false\n' ;;
+      *'.Image'*) printf 'sha256:old-gitlab-runner-image\n' ;;
+      *NetworkSettings.Networks*) printf 'bridge\n' ;;
+      *ci-runner-farm.sidecar*) [ "$target" = "$LIFECYCLE_SIDE_ID" ] && printf 'true\n' ;;
+      *ci-runner-farm.provider*) [ "$target" = "$LIFECYCLE_SIDE_ID" ] && printf 'gitlab\n' ;;
+      *ci-runner-farm.role*) [ "$target" = "$LIFECYCLE_SIDE_ID" ] && printf 'dind\n' ;;
+    esac
+  fi
+  if [ "${1:-}" = ps ] && printf '%s' "$*" | grep -q -- '--format {{.Names}}'; then
+    printf '%s\n' ci-runner-1-dind
+  fi
+  if [ "${1:-}" = --host ] && printf '%s' "$*" | grep -q ' ps -q '; then
+    [ -z "$LIFECYCLE_JOB" ] || printf '%s\n' "$LIFECYCLE_JOB"
+  fi
+  if [ "${1:-}" = run ] && printf '%s' "$*" | grep -q ' unregister --name '; then
+    [ "$LIFECYCLE_UNREGISTER_FAIL" = 0 ] || return 1
+    while [ "$#" -gt 0 ]; do
+      arg="$1"; shift
+      if [ "$arg" = -v ] && [ "$#" -gt 0 ]; then mount="$1"; break; fi
+    done
+    source="${mount%%:*}"
+    [ -n "$source" ] && [ -s "$source/config.toml" ] || return 1
+    printf '%s\n' "$source" > "$UNREGISTER_MOUNT_FILE"
+    cp "$source/config.toml" "$UNREGISTER_CONFIG_CAPTURE"
+    [ ! -s "$source/certs/gitlab-ca.crt" ] \
+      || cp "$source/certs/gitlab-ca.crt" "$UNREGISTER_CA_CAPTURE"
+    # The official command rewrites its mounted config on success. Simulate that
+    # behavior to prove the adapter mounted a disposable copy, not the live slot.
+    printf '%s\n' '# rewritten by gitlab-runner unregister' > "$source/config.toml"
+  fi
+  if [ "$*" = 'run --rm sha256:old-gitlab-runner-image --version' ]; then
+    printf 'Version:      18.5.0\nGit revision: mock\n'
+  fi
+  return 0
+}
+if gitlab_start_stopped ci-runner-1 1 invalid-id >/dev/null 2>&1; then
+  fail "stopped GitLab manager accepted an invalid immutable container ID"
+fi
+[ ! -s "$LIFECYCLE_LOG" ] \
+  || fail "invalid stopped-manager ID reached Docker or sidecar preparation"
+gitlab_start_stopped ci-runner-1 1 "$LIFECYCLE_MANAGER_ID" \
+  || fail "unchanged stopped GitLab manager did not restart in place"
+grep -q '^SIDECAR 1 ci-runner-1$' "$LIFECYCLE_LOG" || fail "stopped manager restart skipped its private Docker sidecar"
+grep -q '^JOB_IMAGE ci-runner-1$' "$LIFECYCLE_LOG" || fail "stopped manager restart skipped default job-image preparation"
+grep -q "^DOCKER inspect -f {{.Image}} $LIFECYCLE_MANAGER_ID$" "$LIFECYCLE_LOG" \
+  || fail "stopped manager image validation did not use its immutable ID"
+grep -q "^DOCKER start $LIFECYCLE_MANAGER_ID$" "$LIFECYCLE_LOG" \
+  || fail "stopped manager was not started by immutable ID"
+job_image_line="$(grep -n '^JOB_IMAGE ci-runner-1$' "$LIFECYCLE_LOG" | head -1 | cut -d: -f1)"
+manager_start_line="$(grep -n "^DOCKER start $LIFECYCLE_MANAGER_ID$" "$LIFECYCLE_LOG" | head -1 | cut -d: -f1)"
+[ "$job_image_line" -lt "$manager_start_line" ] \
+  || fail "stopped manager resumed before its default job image was prepared"
+if grep -q unregister "$LIFECYCLE_LOG"; then fail "ordinary stopped-manager restart attempted unregister"; fi
+
+: > "$LIFECYCLE_LOG"
+start_slot_dir="$CRF_CFGDIR/gitlab-runners/ci-runner-1"
+printf '%s\n' completed-identity > "$start_slot_dir/.remote-unregister-complete"
+if gitlab_start_stopped ci-runner-1 1 "$LIFECYCLE_MANAGER_ID" >/dev/null 2>&1; then
+  fail "remotely unregistered stopped GitLab manager restarted"
+fi
+if grep -Eq '^SIDECAR |^JOB_IMAGE |^DOCKER start ' "$LIFECYCLE_LOG"; then
+  fail "unregister completion marker allowed stopped-manager restart preparation"
+fi
+rm -f "$start_slot_dir/.remote-unregister-complete"
+
+: > "$LIFECYCLE_LOG"
+LIFECYCLE_NAME_MANAGER_ID=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+if gitlab_start_stopped ci-runner-1 1 "$LIFECYCLE_MANAGER_ID" >/dev/null 2>&1; then
+  fail "stopped GitLab manager restarted after its stable name was reused"
+fi
+if grep -Eq '^SIDECAR |^JOB_IMAGE |^DOCKER start ' "$LIFECYCLE_LOG"; then
+  fail "manager name-reuse race reached stopped-manager restart preparation"
+fi
+LIFECYCLE_NAME_MANAGER_ID="$LIFECYCLE_MANAGER_ID"
+
+: > "$LIFECYCLE_LOG"; LIFECYCLE_JOB_IMAGE_FAIL=1
+if gitlab_start_stopped ci-runner-1 1 "$LIFECYCLE_MANAGER_ID" >/dev/null 2>&1; then
+  fail "stopped GitLab manager restarted after default job-image preparation failed"
+fi
+grep -q '^SIDECAR 1 ci-runner-1$' "$LIFECYCLE_LOG" \
+  || fail "job-image failure test did not reach sidecar preparation"
+grep -q '^JOB_IMAGE ci-runner-1$' "$LIFECYCLE_LOG" \
+  || fail "job-image failure test did not exercise image preparation"
+if grep -q '^DOCKER start ' "$LIFECYCLE_LOG"; then
+  fail "stopped manager resumed despite default job-image preparation failure"
+fi
+LIFECYCLE_JOB_IMAGE_FAIL=0
+
+: > "$LIFECYCLE_LOG"; LIFECYCLE_JOB=surviving-build-container
+[ "$(gitlab_runner_state ci-runner-1)" = busy ] \
+  || fail "stopped GitLab manager did not report its surviving executor job as busy"
+if gitlab_start_stopped ci-runner-1 1 "$LIFECYCLE_MANAGER_ID"; then
+  fail "stopped GitLab manager restarted over a surviving job"
+fi
+if grep -q '^SIDECAR 1 ci-runner-1$' "$LIFECYCLE_LOG"; then
+  fail "surviving-job guard ran after sidecar replacement was already allowed"
+fi
+if grep -q '^JOB_IMAGE ci-runner-1$' "$LIFECYCLE_LOG"; then
+  fail "surviving-job guard ran after default job-image preparation was already allowed"
+fi
+if grep -q '^DOCKER start ' "$LIFECYCLE_LOG"; then
+  fail "surviving-job guard still restarted the manager"
+fi
+LIFECYCLE_JOB=''
+
+# Ordinary retirement must preserve that same surviving workload. A running
+# manager's SIGQUIT normally drains it first; for an already-stopped manager,
+# fail closed after the stop probe and leave interruption to force-forget.
+: > "$LIFECYCLE_LOG"; LIFECYCLE_JOB=surviving-build-container
+container_provider() { printf 'gitlab\n'; }
+if gitlab_remove_runner ci-runner-1 false; then fail "GitLab retirement removed a surviving executor job"; fi
+grep -q '^DOCKER stop --signal SIGQUIT --timeout 7200 ci-runner-1$' "$LIFECYCLE_LOG" \
+  || fail "surviving-job retirement did not attempt the graceful manager stop"
+if grep -Eq 'unregister|^DOCKER rm ' "$LIFECYCLE_LOG"; then
+  fail "surviving-job retirement unregistered or removed the slot"
+fi
+LIFECYCLE_JOB=''
+
+: > "$LIFECYCLE_LOG"
+slot_dir="$CRF_CFGDIR/gitlab-runners/ci-runner-1"
+mkdir -p "$slot_dir/certs"
+printf '%s\n' \
+  'concurrent = 1' \
+  '[[runners]]' \
+  '  name = "persisted-host-ci-runner-1"' \
+  '  url = "https://old.gitlab.example.test/root"' \
+  "  token = \"$ROUTABLE_GITLAB_RUNNER_TOKEN\"" \
+  '  tls-ca-file = "/etc/gitlab-runner/certs/gitlab-ca.crt"' \
+  > "$slot_dir/config.toml"
+printf '%s\n' 's_c2d22f638c25' > "$slot_dir/.runner_system_id"
+printf '%s\n' old-slot-ca > "$slot_dir/certs/gitlab-ca.crt"
+printf '%s\n' old-slot-ca > "$tmp/old-slot-ca.expected"
+printf '%s\n' new-global-ca > "$GITLAB_CA_FILE"
+GITLAB_URL='https://new.gitlab.example.test'
+cp "$slot_dir/config.toml" "$tmp/live-config.before-unregister"
+gitlab_unregister_manager ci-runner-1 || fail "stopped manager one-shot unregister failed"
+grep -q 'DOCKER run --rm --network bridge .*sha256:old-gitlab-runner-image unregister --name persisted-host-ci-runner-1' "$LIFECYCLE_LOG" \
+  || fail "stopped manager did not unregister its exact persisted manager identity"
+if grep -q -- '--all-runners' "$LIFECYCLE_LOG"; then fail "slot retirement used broad --all-runners unregister"; fi
+if grep -q '^DOCKER exec ' "$LIFECYCLE_LOG"; then fail "stopped manager attempted docker exec unregister"; fi
+unregister_mount="$(cat "$UNREGISTER_MOUNT_FILE")"
+[ "$unregister_mount" != "$slot_dir" ] || fail "unregister mounted the live token-bearing slot directory"
+[ ! -e "$unregister_mount" ] || fail "secure unregister workspace survived completion"
+cmp -s "$slot_dir/config.toml" "$tmp/live-config.before-unregister" \
+  || fail "official unregister rewrite changed the live slot config"
+grep -q 'url = "https://old.gitlab.example.test/root"' "$UNREGISTER_CONFIG_CAPTURE" \
+  || fail "unregister did not use the retired manager's persisted URL"
+grep -qF "token = \"$ROUTABLE_GITLAB_RUNNER_TOKEN\"" "$UNREGISTER_CONFIG_CAPTURE" \
+  || fail "unregister did not use the retired manager's persisted token"
+cmp -s "$UNREGISTER_CA_CAPTURE" "$tmp/old-slot-ca.expected" \
+  || fail "unregister used the replacement/global CA instead of the slot snapshot"
+[ -s "$slot_dir/.remote-unregister-complete" ] \
+  && [ "$(mode_of "$slot_dir/.remote-unregister-complete")" = 600 ] \
+  || fail "successful manager unregister did not atomically persist a protected completion marker"
+grep -qx 's_c2d22f638c25' "$slot_dir/.runner_system_id" \
+  || fail "stopped manager unregister changed the persisted system ID"
+
+# A repeated call for the same config/system-ID identity must not hit GitLab a
+# second time, even if the remote command would now fail.
+: > "$LIFECYCLE_LOG"; LIFECYCLE_UNREGISTER_FAIL=1
+gitlab_unregister_manager ci-runner-1 || fail "completed manager unregister was not retry-safe"
+if grep -q ' unregister --name ' "$LIFECYCLE_LOG"; then fail "completion marker allowed duplicate remote unregister"; fi
+LIFECYCLE_UNREGISTER_FAIL=0
+
+# The registration-created token form can delete the shared runner entity. Even
+# a stale/tampered persisted config must fail closed without invoking unregister.
+sed 's/token = "glrt-/token = "glrtr-/' "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml" \
+  > "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml.swap"
+mv "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml.swap" "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml"
+: > "$LIFECYCLE_LOG"
+if gitlab_unregister_manager ci-runner-1; then fail "glrtr- config reached unregister"; fi
+if grep -q unregister "$LIFECYCLE_LOG"; then fail "unsafe token invoked GitLab unregister command"; fi
+sed 's/token = "glrtr-/token = "glrt-/' "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml" \
+  > "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml.swap"
+mv "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml.swap" "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml"
+
+# A slot config is generated with exactly one runner entry. Refuse broad or
+# tampered multi-entry configs even when every token happens to be modern.
+cp "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml" \
+  "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml.one"
+printf '%s\n' '[[runners]]' '  name = "unexpected-second-manager"' \
+  '  token = "glrt-zyxwvutsrqponmlkjihgfedcba123456"' \
+  >> "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml"
+: > "$LIFECYCLE_LOG"
+if gitlab_unregister_manager ci-runner-1; then fail "multi-entry config reached unregister"; fi
+if grep -q unregister "$LIFECYCLE_LOG"; then fail "multi-entry config invoked GitLab unregister command"; fi
+mv "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml.one" \
+  "$CRF_CFGDIR/gitlab-runners/ci-runner-1/config.toml"
+
+# Explicit removal sends SIGQUIT and waits before unregistering this manager.
+: > "$LIFECYCLE_LOG"; gitlab_clear_unregister_complete "$slot_dir"; LIFECYCLE_RM_FAIL=1
+container_provider() { printf 'gitlab\n'; }
+gitlab_remove_sidecar() { :; }
+mkdir -p "$slot_dir/docker"
+printf '%s\n' retired-registry-auth > "$slot_dir/docker/config.json"
+if gitlab_remove_runner ci-runner-1 false; then fail "GitLab removal ignored a local Docker-rm failure"; fi
+stop_line="$(grep -n '^DOCKER stop --signal SIGQUIT --timeout 7200 ci-runner-1$' "$LIFECYCLE_LOG" | head -1 | cut -d: -f1)"
+unregister_line="$(grep -n 'DOCKER run --rm .* unregister --name persisted-host-ci-runner-1$' "$LIFECYCLE_LOG" | head -1 | cut -d: -f1)"
+[ -n "$stop_line" ] && [ -n "$unregister_line" ] && [ "$stop_line" -lt "$unregister_line" ] \
+  || fail "GitLab manager did not drain before manager-only unregister"
+[ -s "$slot_dir/.remote-unregister-complete" ] \
+  || fail "Docker-rm failure lost the successful remote-unregister marker"
+for retry_file in "$slot_dir/config.toml" "$slot_dir/docker/config.json" \
+  "$slot_dir/certs/gitlab-ca.crt" "$slot_dir/.remote-unregister-complete"; do
+  [ -s "$retry_file" ] || fail "failed retirement prematurely scrubbed retry material: $retry_file"
+done
+
+# Retrying local removal uses the marker and must succeed without a duplicate API
+# call, even when the unregister transport is deliberately broken. Only after
+# every remote/local step succeeds may reusable credentials, CA, and marker be
+# scrubbed; the stable system ID remains.
+: > "$LIFECYCLE_LOG"; LIFECYCLE_RM_FAIL=0; LIFECYCLE_UNREGISTER_FAIL=1
+gitlab_remove_runner ci-runner-1 false || fail "GitLab local cleanup retry failed after successful remote unregister"
+if grep -q ' unregister --name ' "$LIFECYCLE_LOG"; then fail "Docker-rm retry repeated the remote unregister API call"; fi
+grep -q '^DOCKER rm ci-runner-1$' "$LIFECYCLE_LOG" || fail "Docker-rm retry did not remove the stopped manager"
+for retired_file in \
+  "$slot_dir/config.toml" "$slot_dir/config.toml.tmp" \
+  "$slot_dir/docker/config.json" "$slot_dir/docker/config.json.tmp" \
+  "$slot_dir/.remote-unregister-complete" "$slot_dir/.remote-unregister-complete.tmp" \
+  "$slot_dir/certs/gitlab-ca.crt" "$slot_dir/certs/gitlab-ca.crt.tmp"; do
+  [ ! -e "$retired_file" ] || fail "successful retirement retained credential/CA state: $retired_file"
+done
+grep -qx s_c2d22f638c25 "$slot_dir/.runner_system_id" \
+  || fail "successful retirement removed or changed the stable system ID"
+LIFECYCLE_UNREGISTER_FAIL=0
+
+# A failed stop must leave the live manager, its job containers, and its sidecar
+# untouched so a cleanup attempt cannot break a manager that is still serving.
+: > "$LIFECYCLE_LOG"; LIFECYCLE_STOP_FAIL=1
+if gitlab_remove_runner ci-runner-1 false; then fail "GitLab removal ignored a manager stop failure"; fi
+grep -q '^DOCKER stop --signal SIGQUIT --timeout 7200 ci-runner-1$' "$LIFECYCLE_LOG" \
+  || fail "GitLab failed-stop path did not attempt the graceful stop"
+if grep -Eq 'unregister|^DOCKER rm ' "$LIFECYCLE_LOG"; then
+  fail "GitLab failed-stop path unregistered or removed a still-live manager"
+fi
+
+# A failed manager-only API unregister keeps the stopped container, its exact
+# persisted token/system ID, and sidecar available for a safe retry.
+: > "$LIFECYCLE_LOG"
+mkdir -p "$slot_dir/certs" "$slot_dir/docker"
+cp "$tmp/live-config.before-unregister" "$slot_dir/config.toml"
+printf '%s\n' old-slot-ca > "$slot_dir/certs/gitlab-ca.crt"
+printf '%s\n' retired-registry-auth > "$slot_dir/docker/config.json"
+gitlab_clear_unregister_complete "$slot_dir"
+LIFECYCLE_STOP_FAIL=0; LIFECYCLE_UNREGISTER_FAIL=1
+if gitlab_remove_runner ci-runner-1 false; then fail "GitLab removal ignored manager unregister failure"; fi
+grep -q 'unregister --name persisted-host-ci-runner-1' "$LIFECYCLE_LOG" \
+  || fail "GitLab removal did not attempt exact manager unregister"
+if grep -q '^DOCKER rm ' "$LIFECYCLE_LOG"; then
+  fail "GitLab unregister failure discarded the persisted manager needed for retry"
+fi
+for retry_file in "$slot_dir/config.toml" "$slot_dir/docker/config.json" \
+  "$slot_dir/certs/gitlab-ca.crt" "$slot_dir/.runner_system_id"; do
+  [ -s "$retry_file" ] || fail "unregister failure scrubbed retry material: $retry_file"
+done
+LIFECYCLE_UNREGISTER_FAIL=0
+
+# Break-glass force-forget is local-only. It verifies manager/sidecar ownership,
+# removes every labelled slot workload, scrubs reusable credentials and retry
+# markers, and preserves the stable non-secret system ID for retry/diagnostics.
+FORCE_LOG="$tmp/gitlab-force-forget.log"; : > "$FORCE_LOG"
+FORCE_MANAGER_EXISTS=1; FORCE_SIDE_EXISTS=1; FORCE_UNOWNED=0; FORCE_JOBS=1
+FORCE_MANAGER_ID=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+FORCE_SIDE_ID=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+crf_safe_cache_root() { printf '%s\n' "$CACHE_ROOT"; }
+docker() {
+  local fmt='' target=''
+  printf '%s\n' "$*" >> "$FORCE_LOG"
+  case "${1:-}" in
+    inspect)
+      if [ "${2:-}" != -f ]; then
+        case "${2:-}" in
+          ci-runner-1|$FORCE_MANAGER_ID) [ "$FORCE_MANAGER_EXISTS" = 1 ] ;;
+          ci-runner-1-dind|$FORCE_SIDE_ID) [ "$FORCE_SIDE_EXISTS" = 1 ] ;;
+          *) return 1 ;;
+        esac
+        return
+      fi
+      fmt="${3:-}"; target="${4:-}"
+      case "$fmt" in
+        '{{.Id}}')
+          [ "$target" = ci-runner-1 ] && printf '%s\n' "$FORCE_MANAGER_ID" \
+            || { [ "$target" = ci-runner-1-dind ] && printf '%s\n' "$FORCE_SIDE_ID"; }
+          ;;
+        *ci-runner-farm.managed*) [ "$FORCE_UNOWNED" = 0 ] && printf 'true\n' ;;
+        *ci-runner-farm.sidecar*) printf 'true\n' ;;
+        *ci-runner-farm.provider*) printf 'gitlab\n' ;;
+        *ci-runner-farm.role*)
+          [ "$target" = "$FORCE_SIDE_ID" ] && printf 'dind\n' || printf '%s\n' "$([ "$FORCE_UNOWNED" = 0 ] && echo manager || echo foreign)" ;;
+      esac
+      ;;
+    ps)
+      [ "$FORCE_JOBS" = 1 ] && printf '%s\n' force-build force-helper force-service
+      ;;
+    rm) return 0 ;;
+  esac
+  return 0
+}
+mkdir -p "$slot_dir/docker"
+mkdir -p "$slot_dir/certs" "$CACHE_ROOT/docker/ci-runner-1" \
+  "$CACHE_ROOT/gitlab-sockets/ci-runner-1" "$CACHE_ROOT/gitlab-cache/ci-runner-1"
+printf '%s\n' live-token-config > "$slot_dir/config.toml"
+printf '%s\n' interrupted-config > "$slot_dir/config.toml.tmp"
+printf '%s\n' derived-registry-auth > "$slot_dir/docker/config.json"
+printf '%s\n' interrupted-auth > "$slot_dir/docker/config.json.tmp"
+printf '%s\n' completed-identity > "$slot_dir/.remote-unregister-complete"
+printf '%s\n' interrupted-marker > "$slot_dir/.remote-unregister-complete.tmp"
+printf '%s\n' retired-ca > "$slot_dir/certs/gitlab-ca.crt"
+printf '%s\n' s_c2d22f638c25 > "$slot_dir/.runner_system_id"
+gitlab_force_forget_local ci-runner-1 || fail "local GitLab force-forget failed"
+for removed in \
+  "rm -f $FORCE_MANAGER_ID" \
+  'rm -f force-build force-helper force-service' \
+  "rm -f $FORCE_SIDE_ID"
+do
+  grep -qx "$removed" "$FORCE_LOG" || fail "force-forget missed local removal: $removed"
+done
+if grep -q unregister "$FORCE_LOG"; then fail "force-forget contacted the GitLab unregister path"; fi
+for secret_copy in \
+  "$slot_dir/config.toml" "$slot_dir/config.toml.tmp" \
+  "$slot_dir/docker/config.json" "$slot_dir/docker/config.json.tmp" \
+  "$slot_dir/.remote-unregister-complete" "$slot_dir/.remote-unregister-complete.tmp" \
+  "$slot_dir/certs/gitlab-ca.crt"
+do
+  [ ! -e "$secret_copy" ] || fail "force-forget retained local credential/retry state: $secret_copy"
+done
+for purged_root in "$CACHE_ROOT/docker/ci-runner-1" \
+  "$CACHE_ROOT/gitlab-sockets/ci-runner-1" "$CACHE_ROOT/gitlab-cache/ci-runner-1"; do
+  [ ! -e "$purged_root" ] || fail "force-forget retained slot runtime data: $purged_root"
+done
+grep -qx s_c2d22f638c25 "$slot_dir/.runner_system_id" \
+  || fail "force-forget removed or changed the persistent system ID"
+
+# The action is retryable after the manager has already disappeared. Conversely,
+# an unowned name collision must fail before any destructive Docker command.
+: > "$FORCE_LOG"; FORCE_MANAGER_EXISTS=0; FORCE_SIDE_EXISTS=0; FORCE_JOBS=0
+gitlab_force_forget_local ci-runner-1 || fail "force-forget was not retryable after local manager removal"
+: > "$FORCE_LOG"; FORCE_MANAGER_EXISTS=1; FORCE_SIDE_EXISTS=0; FORCE_UNOWNED=1
+if gitlab_force_forget_local ci-runner-1 >/dev/null 2>&1; then fail "force-forget accepted an unowned manager collision"; fi
+if grep -q '^rm ' "$FORCE_LOG"; then fail "force-forget mutated Docker after an ownership-check failure"; fi
+if gitlab_force_forget_local ../ci-runner-1 >/dev/null 2>&1; then fail "force-forget accepted an unsafe slot name"; fi
+
+# Before Unraid stops Docker, every running GitLab manager must receive its
+# graceful stop concurrently while the DinD sidecars are still alive. GitHub
+# containers and all remote/local unregister/remove paths remain untouched.
+(
+SHUTDOWN_LOG="$tmp/gitlab-docker-shutdown.log"; : > "$SHUTDOWN_LOG"
+managed_names() { printf '%s\n' ci-runner-1 ci-runner-2 ci-runner-3; }
+managed_runner_snapshot() {
+  case "$1" in
+    ci-runner-1) printf '%064d|gitlab|manager|1|mock-generation\n' 1 ;;
+    ci-runner-2) printf '%064d|gitlab|manager|2|mock-generation\n' 2 ;;
+    ci-runner-3) printf '%064d|github|runner|3|mock-generation\n' 3 ;;
+    *) return 1 ;;
+  esac
+}
+docker() {
+  if [ "${1:-}" = inspect ] && [ "${2:-}" = -f ]; then printf 'true\n'; fi
+}
+provider_stop_container() { printf 'QUIESCE %s\n' "$1" >> "$SHUTDOWN_LOG"; }
+cmd_docker_stopping_locked || fail "GitLab Docker-shutdown quiesce failed"
+grep -qx 'QUIESCE ci-runner-1' "$SHUTDOWN_LOG" || fail "first GitLab manager was not quiesced"
+grep -qx 'QUIESCE ci-runner-2' "$SHUTDOWN_LOG" || fail "second GitLab manager was not quiesced"
+if grep -q 'ci-runner-3\|unregister\|DOCKER rm' "$SHUTDOWN_LOG"; then
+  fail "Docker-shutdown quiesce touched GitHub or removed/unregistered a manager"
+fi
+)
+
+# Restart must not hide a failed stop/unregister behind a successful subsequent
+# start, and image auto-update must use the validated recycle preflight instead
+# of directly removing capacity before credentials/settings are checked.
+ACTION_LOG="$tmp/action-safety.log"; : > "$ACTION_LOG"
+cmd_stop() { printf 'stop\n' >> "$ACTION_LOG"; return 1; }
+cmd_start() { printf 'start\n' >> "$ACTION_LOG"; }
+if cmd_restart; then fail "restart masked a stop/unregister failure"; fi
+grep -qx stop "$ACTION_LOG" || fail "restart did not attempt stop"
+if grep -q start "$ACTION_LOG"; then fail "restart started replacements after stop failed"; fi
+
+: > "$ACTION_LOG"
+runner_busy() { return 1; }
+managed_names() { printf '%s\n' ci-runner-1; }
+docker() {
+  case "$*" in
+    'ps -a --format {{.Names}}') printf '%s\n' ci-runner-1 ;;
+  esac
+}
+cmd_recycle() { printf 'recycle %s\n' "$1" >> "$ACTION_LOG"; return 1; }
+if drain_and_recreate ci-runner-1; then fail "image update ignored validated recycle failure"; fi
+grep -qx 'recycle ci-runner-1' "$ACTION_LOG" || fail "image update bypassed cmd_recycle preflight"
+
+# A failed manager removal leaves its workload intact. Global Stop must then
+# preserve host-socket jobs, mirrors, and strict firewall/network policy rather
+# than weakening isolation underneath the survivor.
+: > "$ACTION_LOG"
+managed_names() { printf '%s\n' ci-runner-1; }
+remove_runner() { printf 'remove %s\n' "$1" >> "$ACTION_LOG"; return 1; }
+autoscale_stop() { :; }; imageupdate_stop() { :; }
+quiesce_gitlab_managers_for_stop() { :; }
+gitlab_stop_cleanup() { printf 'job-cleanup\n' >> "$ACTION_LOG"; }
+gitlab_cleanup_orphan_sidecars() { printf 'sidecar-cleanup\n' >> "$ACTION_LOG"; }
+firewall_clear() { printf 'firewall-clear\n' >> "$ACTION_LOG"; }
+if engine_cmd_stop >/dev/null 2>&1; then fail "global Stop ignored a surviving manager"; fi
+grep -qx 'remove ci-runner-1' "$ACTION_LOG" || fail "global Stop did not try the manager removal"
+if grep -Eq 'job-cleanup|sidecar-cleanup|firewall-clear' "$ACTION_LOG"; then
+  fail "global Stop tore down jobs/sidecars/isolation underneath a surviving manager"
+fi
+
+echo "provider-mocks: OK — adapters, lifecycle, TOML, API/status mappings, and credential clears"

--- a/tests/release-guard.sh
+++ b/tests/release-guard.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Publishing belongs exclusively to the canonical upstream repository. Forks
+# retain these workflows for easy rebasing but a main push/tag must be a no-op.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+RP=".github/workflows/release-please.yml"
+REL=".github/workflows/release.yml"
+
+assert_all_jobs_guarded() {
+  local file="$1" jobs job block found=0
+  jobs="$(awk '
+    /^jobs:[[:space:]]*$/ { in_jobs=1; next }
+    in_jobs && /^[^[:space:]#]/ { in_jobs=0 }
+    in_jobs && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+      line=$0; sub(/^  /,"",line); sub(/:.*/,"",line); print line
+    }
+  ' "$file")"
+  [ -n "$jobs" ] || { echo "release-guard: no jobs found in $file" >&2; return 1; }
+  while IFS= read -r job; do
+    [ -n "$job" ] || continue; found=$((found+1))
+    block="$(awk -v want="$job" '
+      $0 == "  " want ":" { emit=1; next }
+      emit && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
+      emit { print }
+    ' "$file")"
+    printf '%s\n' "$block" \
+      | grep -Eq "^    if:.*github\.repository == 'unraid/ci-runner-farm'" || {
+        echo "release-guard: unguarded job '$job' in $file" >&2
+        return 1
+      }
+  done <<< "$jobs"
+  [ "$found" -gt 0 ]
+}
+
+assert_all_jobs_guarded "$RP"
+assert_all_jobs_guarded "$REL"
+
+if [ -e .gitlab-ci.yml ]; then
+  echo "release-guard: this fork keeps its own CI on GitHub; .gitlab-ci.yml is out of scope" >&2
+  exit 1
+fi
+
+echo "release-guard: OK — fork branches/tags cannot run upstream release jobs"

--- a/tests/resource-ownership.sh
+++ b/tests/resource-ownership.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Shared fixed-name resources and strict firewall state must be removed only
+# after positive ownership checks, and cleanup failures must propagate.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ENGINE="src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() { printf 'RESOURCE OWNERSHIP FAIL: %s\n' "$*" >&2; exit 1; }
+
+(
+  export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/cfg" CRF_RUNDIR="$tmp/run"
+  mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR" "$tmp/cache"
+  # shellcheck source=/dev/null
+  source "$ENGINE"
+
+  MIRROR_NAME=ci-runner-cache
+  CACHE_ROOT="$tmp/cache"
+  SHARED_IMAGE_CACHE=true
+  DIND=true
+  NETWORK_ISOLATION=off
+  mirror_id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  mirror_exists=1
+  mirror_owned=0
+  mirror_legacy=0
+  mutation_log="$tmp/mirror-mutations.log"
+  : > "$mutation_log"
+
+  docker() {
+    local cmd="${1:-}" fmt="" target=""
+    shift || true
+    case "$cmd" in
+      inspect)
+        if [ "${1:-}" = -f ]; then
+          fmt="$2"; target="$3"
+          case "$fmt" in
+            '{{.Id}}') [ "$mirror_exists" -eq 1 ] && printf '%s\n' "$mirror_id" || return 1 ;;
+            '{{.Name}}') [ "$mirror_legacy" -eq 1 ] && printf '/%s\n' "$MIRROR_NAME" ;;
+            '{{.Config.Image}}') [ "$mirror_legacy" -eq 1 ] && printf 'registry:2\n' ;;
+            *'.Destination "/var/lib/registry"'*) [ "$mirror_legacy" -eq 1 ] && printf '%s\n' "$CACHE_ROOT/registry-mirror" ;;
+            *'range .Config.Env'*) [ "$mirror_legacy" -eq 1 ] && printf 'REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io\n' ;;
+            *ci-runner-farm.resource*) [ "$mirror_owned" -eq 1 ] && printf 'true\n' ;;
+            *ci-runner-farm.role*) [ "$mirror_owned" -eq 1 ] && printf 'mirror\n' ;;
+          esac
+        else
+          target="${1:-}"
+          [ "$mirror_exists" -eq 1 ] && { [ "$target" = "$MIRROR_NAME" ] || [ "$target" = "$mirror_id" ]; }
+        fi
+        ;;
+      rm)
+        printf 'rm %s\n' "$*" >> "$mutation_log"
+        [ "${*: -1}" = "$mirror_id" ] || return 1
+        mirror_exists=0
+        ;;
+      ps) return 0 ;;
+      *) return 0 ;;
+    esac
+  }
+
+  if ensure_mirror >/dev/null 2>&1; then
+    fail "shared mirror accepted an unowned fixed-name collision"
+  fi
+  [ ! -s "$mutation_log" ] || fail "unowned shared mirror was removed"
+
+  mirror_legacy=1
+  mirror_remove_owned || fail "upgrade-compatible legacy mirror was not recognized"
+  grep -qx "rm -f $mirror_id" "$mutation_log" \
+    || fail "legacy shared mirror was not removed by immutable ID"
+
+  : > "$mutation_log"
+  mirror_exists=1
+  mirror_legacy=0
+  mirror_owned=1
+  mirror_remove_owned || fail "owned shared mirror removal failed"
+  grep -qx "rm -f $mirror_id" "$mutation_log" \
+    || fail "shared mirror was not removed by immutable ID"
+
+  network_owned_flag=0
+  docker() {
+    case "$*" in
+      'network inspect ci-runner-net') return 0 ;;
+      *'index .Labels "net.unraid.ci-runner-farm"'*ci-runner-net) [ "$network_owned_flag" -eq 1 ] && printf '1\n' ;;
+      'network create '*) printf 'network-create\n' >> "$mutation_log" ;;
+      *) return 1 ;;
+    esac
+  }
+  RUNNER_NETWORK=ci-runner-net
+  NETWORK_ISOLATION=strict
+  if ensure_network >/dev/null 2>&1; then
+    fail "strict mode accepted an unowned network and could firewall foreign containers"
+  fi
+  if grep -q network-create "$mutation_log"; then
+    fail "strict mode replaced an unowned network"
+  fi
+  NETWORK_ISOLATION=isolate
+  ensure_network >/dev/null \
+    || fail "isolate mode did not preserve an explicitly pre-existing network"
+
+  iptables() {
+    case "$*" in
+      '-w -L DOCKER-USER --line-numbers -n') printf '7 DROP all -- anywhere anywhere /* %s:test */\n' "$FW_TAG" ;;
+      '-w -L INPUT --line-numbers -n') return 0 ;;
+      '-w -D DOCKER-USER 7') return 1 ;;
+      *) return 0 ;;
+    esac
+  }
+  if firewall_clear >/dev/null 2>&1; then
+    fail "firewall cleanup hid a tagged-rule deletion failure"
+  fi
+)
+
+grep -qF 'boot_autostart_stop || return 1' "$ENGINE" \
+  || fail "Stop does not cancel the delayed boot worker before mutation"
+grep -qF 'docker network rm "$network_id"' "$ENGINE" \
+  || fail "owned runner network is not removed through its immutable ID"
+grep -qF 'mirror_remove_owned || stop_failed=1' "$ENGINE" \
+  || fail "Stop does not propagate shared-mirror cleanup failure"
+grep -qF 'gitlab_assert_no_orphan_manager_configs || return 1' "$ENGINE" \
+  || fail "Stop can discard a manually orphaned GitLab manager identity"
+grep -qF 'cleanup_orphan_github_validations || return 1' "$ENGINE" \
+  || fail "Stop can tear down shared resources before orphaned GitHub validation cleanup succeeds"
+
+echo "resource-ownership: OK — shared resources and cleanup failures are ownership-gated"

--- a/tests/run-linux-checks.sh
+++ b/tests/run-linux-checks.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Run the same checks as CI in a small Linux image. This is the recommended
+# local entry point on macOS, where Bash 3, BSD tar, and BSD realpath differ from
+# the Unraid/GitHub Actions environment.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+command -v docker >/dev/null 2>&1 || {
+  echo "Docker is required for the Linux check environment." >&2
+  exit 1
+}
+docker info >/dev/null 2>&1 || {
+  echo "The Docker daemon is not reachable. Start Docker, then retry." >&2
+  exit 1
+}
+
+if docker buildx version >/dev/null 2>&1; then
+  docker build --progress=plain -f tests/linux-checks.Dockerfile .
+else
+  # Docker Engine's legacy builder has no --progress flag. It is still enough
+  # for this disposable syntax/package check image (and is common on Unraid or
+  # when a developer uses an isolated DOCKER_CONFIG without Desktop plugins).
+  docker build -f tests/linux-checks.Dockerfile .
+fi
+
+# The repository checks run inside the Linux build above.  Config validation
+# needs a real Docker daemon to launch the pinned official Runner image, so run
+# that gate on the host after the portable suite succeeds.
+bash tests/gitlab-runner-lint.sh

--- a/tests/safe-paths.sh
+++ b/tests/safe-paths.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
-# Behavioral tests for the CACHE_ROOT / cache-mount path guards
-# (crf_safe_cache_root, crf_safe_mount_subdir) in include/runner-farm.sh.
+# Behavioral tests for the CACHE_ROOT / cache-mount path guards and filesystem
+# classifier (crf_safe_cache_root, crf_safe_mount_subdir, cache_root_problem,
+# and check_cache_root) in include/runner-farm.sh.
 #
-# These two functions gate every destructive/expensive operation the plugin runs
+# These guards gate every destructive/expensive operation the plugin runs
 # under CACHE_ROOT — rm -rf (cmd_prune_cache / cmd_cache_clear_pkg), chown -R
 # (ensure_dirs), and the bind mount of a web-settable CACHE_MOUNTS entry into every
 # runner (build_args). A regression that let a share/device/system root or a `../`
 # escape slip through would be high-consequence, so they earn a unit test.
 #
-# They are pure functions of CACHE_ROOT (env) plus, for the mount guard, one
-# argument — no Docker, no filesystem writes — so we extract just the two functions
-# from the engine (avoiding the script's dispatch side effects) and table-test them.
+# They are functions of CACHE_ROOT (env) plus, for the mount guard, one argument.
+# Extract only those functions from the engine (avoiding dispatch side effects),
+# then mock df for deterministic filesystem classification without requiring an
+# Unraid pool on the test host.
 # Requires GNU realpath (realpath -m); skips loudly where that is unavailable.
 set -u
 cd "$(dirname "$0")/.."
@@ -23,6 +25,8 @@ tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
 # column 0 (their inner case blocks close with `esac`, not a bare `}`).
 sed -n '/^crf_safe_cache_root()/,/^}/p'   "$ENGINE" >  "$tmp"
 sed -n '/^crf_safe_mount_subdir()/,/^}/p' "$ENGINE" >> "$tmp"
+sed -n '/^cache_root_problem()/,/^}/p'     "$ENGINE" >> "$tmp"
+sed -n '/^check_cache_root()/,/^}/p'       "$ENGINE" >> "$tmp"
 # shellcheck disable=SC1090  # sourcing an extracted-at-runtime snippet by design
 . "$tmp"
 
@@ -79,6 +83,96 @@ mount_case /mnt/cache/github-runner a/b          ok        # nested subdir stays
 mount_case /mnt/cache/github-runner ../../etc    reject    # escapes the root
 mount_case /mnt/cache/github-runner ..           reject    # parent of the root
 mount_case /mnt/cache/github-runner ../sibling   reject    # sibling of the root
+
+# --- cache_root_problem / check_cache_root -------------------------------
+# Keep lexical validation ahead of filesystem probing. Even if the filesystem
+# classifier would report a persistent pool, a normalized system/share path
+# must remain rejected and df must never be consulted for it.
+df_log="$(mktemp)"
+fs_tmp=""
+trap 'rm -f "$tmp" "$df_log"; [ -z "$fs_tmp" ] || rm -rf -- "$fs_tmp"' EXIT
+DF_FSTYPE=xfs
+DF_TARGET=/mnt/mock-pool
+df() {
+  local path="${!#}"
+  printf '%s\n' "$path" >> "$df_log"
+  [ -e "$path" ] || return 1
+  printf '%s\n' \
+    'Filesystem Type 1024-blocks Used Available Capacity Mounted on' \
+    "mockfs $DF_FSTYPE 1000 1 999 1% $DF_TARGET"
+}
+err() { printf '%s\n' "$*" >&2; }
+
+check_case() { # <cache-root> <ok|reject>
+  CACHE_ROOT="$1"
+  if check_cache_root >/dev/null 2>&1; then got=ok; else got=reject; fi
+  if [ "$got" = "$2" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    printf 'FAIL  check_cache_root %-32s expected %-6s got %s\n' "$1" "$2" "$got"
+  fi
+}
+problem_case() { # <cache-root> <ok|reject>
+  local problem
+  CACHE_ROOT="$1"
+  problem="$(cache_root_problem)"
+  if [ -z "$problem" ]; then got=ok; else got=reject; fi
+  if [ "$got" = "$2" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    printf 'FAIL  cache_root_problem %-32s expected %-6s got %s\n' "$1" "$2" "$got"
+  fi
+}
+
+: > "$df_log"
+DIND=true
+check_case /etc/ci-runner-farm-cache reject
+check_case /mnt/cache/../../etc/ci-runner-farm-cache reject
+check_case /mnt/user/ci-runner-farm-cache reject
+if [ -s "$df_log" ]; then
+  fail=$((fail+1))
+  echo 'FAIL  unsafe lexical CACHE_ROOT reached filesystem classification'
+else
+  pass=$((pass+1))
+fi
+
+# Isolate filesystem classification from the /mnt-only lexical guard so this
+# works as an unprivileged test on both GitHub Actions and local Linux. The
+# configured dedicated cache child does not exist yet (normal before first
+# Start); df itself rejects nonexistent paths, so cache_root_problem must probe
+# the nearest existing ancestor instead.
+crf_safe_cache_root() { printf '%s' "$CACHE_ROOT"; }
+fs_tmp="$(mktemp -d)"
+pool="$fs_tmp/pool"
+cache_child="$pool/ci-runner-farm"
+mkdir -p "$pool"
+: > "$df_log"
+DF_FSTYPE=xfs
+DF_TARGET="$pool"
+DIND=true
+problem_case "$cache_child" ok
+check_case "$cache_child" ok
+
+# Existing rootfs/tmpfs/overlay storage remains unsafe regardless of DinD.
+# FUSE remains unsafe when DinD would place an overlay2 data root on it.
+for fstype in rootfs tmpfs overlay; do
+  fs_path="$fs_tmp/$fstype"
+  mkdir -p "$fs_path"
+  DF_FSTYPE="$fstype"
+  DF_TARGET="$fs_path"
+  DIND=false
+  problem_case "$fs_path" reject
+  check_case "$fs_path" reject
+done
+fs_path="$fs_tmp/fuse"
+mkdir -p "$fs_path"
+DF_FSTYPE=fuse.shfs
+DF_TARGET="$fs_path"
+DIND=true
+problem_case "$fs_path" reject
+check_case "$fs_path" reject
 
 echo "safe-paths: $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Add GitLab as a second CI provider while preserving the existing GitHub Actions runner behavior and keeping GitHub as the default.

The implementation consumes the official GitLab Runner image and uses the modern reusable `glrt-` authentication-token workflow. Each farm slot gets a persistent runner manager identity and an isolated Docker executor backed by a private, per-slot DinD daemon over a Unix socket.

## What changed

- Add `CI_PROVIDER=github|gitlab` and extract provider-specific behavior into GitHub and GitLab adapters.
- Preserve the existing GitHub credentials, lifecycle, status, scaling, and runner-image behavior.
- Add per-slot GitLab Runner managers with persistent `config.toml` and `.runner_system_id` files.
- Generate Docker-executor configuration with per-build networks, resource limits, cache mounts, registry-mirror support, image/service allowlists, pull policy, shared-memory sizing, and job timeout controls.
- Keep the Unraid Docker socket private by default. Isolated GitLab slots use privileged DinD sidecars over a shared Unix socket and publish no Docker TCP API.
- Support an explicitly selected host-socket mode, while rejecting GitLab configurations where both DinD and socket sharing are disabled.
- Add GitLab URL, runner image, monitored projects, runner token, optional API token, and self-managed CA settings to the Dynamix UI and request handlers.
- Add provider-neutral fleet status fields while retaining existing GitHub fields for compatibility.
- Update deployment and packaging so the complete runtime tree, including provider adapters, is synchronized.
- Guard release automation so pushes from forks cannot publish upstream releases.
- Add a Linux-based validation environment and mocked provider/security/configuration tests.

## Why

CI Runner Farm currently manages only GitHub Actions runners. This adds GitLab.com and self-managed GitLab support without forking GitLab Runner itself or duplicating the farm's Docker, cache, locking, scaling, reconciliation, and image-update lifecycle.

The private DinD design reduces exposure compared with mounting Unraid's Docker socket into jobs. It deliberately limits the remaining privileged-Docker blast radius to one single-concurrency farm slot and surfaces that limitation in the UI.

## Compatibility and security

- GitHub remains the upgrade-safe default and retains the legacy PAT path and actions.
- GitLab requires a modern authentication token beginning with `glrt-`; an API token is optional and is used only for advisory dashboard data.
- Runner scope, tags, protected status, and untagged-job policy remain controlled in GitLab.
- Credential and per-slot configuration files are mode-restricted and excluded from diagnostics.
- GitLab DinD uses only `/runner-services/docker.sock`; the sidecar has no host bindings and no listeners on ports 2375 or 2376.
- Graceful manager shutdown uses `SIGQUIT` with a configurable stop timeout.

## Validation

- `bash tests/run-linux-checks.sh`
  - Bash and PHP syntax
  - configuration parity and safe-path checks
  - XML, MD5, package-content, ownership, CSRF, firewall-transition, and release-guard checks
  - mocked GitHub/GitLab provider contracts, policy, token-redaction, URL-normalization, and generated-TOML tests
  - official GitLab Runner configuration parse validation
- Real privileged `docker:27-dind` validation confirmed the private Unix socket works and ports 2375/2376 are not listening.
- Installed the development package on an Unraid host while preserving existing configuration and credentials.
- Completed a private GitLab project smoke test through the new runner:
  - 5,301 backend tests passed
  - 179 frontend test files passed
  - autoscaling created additional slots as demand increased
  - build, helper, service, and DinD containers received the configured 8 CPU / 8 GiB limits
  - no OOMs, container restarts, Docker TCP exposure, or residual executor containers were observed

## Operational notes

- GitLab queue counts are advisory and limited to configured monitored projects because GitLab does not expose a complete eligible-runner queue through a public API.
- A privileged DinD sidecar does not provide a hard security boundary from the Unraid host; the UI and documentation call this out explicitly.
- `EPHEMERAL`, `RUN_AS_ROOT`, and workspace tmpfs controls remain GitHub-specific because the GitLab Docker executor provides different job-isolation semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitLab CI/CD support alongside GitHub Actions, including provider selection, tokens, project monitoring, Docker execution, autoscaling, caching, and registry settings.
  * Added provider-specific runner images, job metadata, status reporting, and lifecycle controls.
  * Added GitLab force-forget and graceful shutdown options.
* **Security & Reliability**
  * Strengthened credential handling, request validation, resource ownership checks, deployment safety, rollback protection, and release safeguards.
* **Documentation**
  * Updated installation, configuration, security, provider behavior, and Community Applications documentation for GitHub and GitLab fleets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->