### PR TITLE
fix: add .gitattributes to pin line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Normalise all text to LF in the repository and in the working tree.
+* text=auto eol=lf
+
+# Shell and Unraid plugin sources — always LF; these are executed on Linux.
+*.sh            text eol=lf
+*.php           text eol=lf
+*.page          text eol=lf
+*.plg           text eol=lf
+*.cfg           text eol=lf
+*.Dockerfile    text eol=lf
+
+# Extensionless scripts shipped into the plugin tree.
+src/usr/local/emhttp/plugins/ci-runner-farm/event/*  text eol=lf
+src/usr/local/emhttp/plugins/ci-runner-farm/nchan/*  text eol=lf
+
+# Common text formats.
+*.md   text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.xml  text eol=lf
+*.svg  text eol=lf
+
+# Binary — never diff or convert.
+*.png binary


### PR DESCRIPTION
## Summary

- Adds a `.gitattributes` at the repo root pinning all text sources — shell scripts, PHP/`.page` files, the `.plg`/`.cfg`/Dockerfiles, the extensionless `event/` and `nchan/` scripts, and common text formats — to `eol=lf`, and marks PNGs binary.
- Everything in the repo is already committed as LF, so this is purely preventative: it stops Git for Windows' default `core.autocrlf=true` from checking the tree out as CRLF.

## Why

Without a `.gitattributes`, a Windows checkout has a clean LF index but a CRLF working tree. That has two consequences:

1. `deploy.sh`/`install-dev.sh` copy the plugin tree from the *working tree* onto the Unraid host. A CRLF checkout would ship shell scripts with `#!/bin/bash\r` shebangs, which fail on Linux with a "bad interpreter" error — affecting `include/runner-farm.sh`, `include/providers/*.sh`, `event/docker_started`, `event/stopping_docker`, and `nchan/ci_runner_farm`.
2. Local shellcheck/php-cs-fixer runs against a CRLF tree produce thousands of findings (`SC1017`, `SC1073`, `SC1072`, `SC1009`, `line_ending`) that don't exist in the actual repo, making local linting unusable on Windows.

## Test plan

- [x] `git add --renormalize .` is a no-op for tracked content (confirms the fix is purely preventative — nothing was actually CRLF in the index).
- [x] `git check-attr -a` confirms `eol=lf` is applied to `.sh`, `.page`, `.plg`, extensionless `event`/`nchan` scripts, and `VERSION`/`LICENSE`.
- [x] `./tests/run-linux-checks.sh` (containerized `check.sh` suite) passes: `All repository checks passed.`

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized text file line endings across the repository.
  * Ensured shell and plugin scripts use LF formatting.
  * Marked common text formats appropriately and preserved PNG files as binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->