### PR TITLE
fix: pin release-please-action to a commit, bump actions/checkout, annotate all pins

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/package-plugins.yml
+++ b/.github/workflows/package-plugins.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
@@ -62,7 +62,7 @@ jobs:
           echo "Plugin built and validated (package md5 $tgz_md5)."
 
       - name: Upload built .plg + .tgz (CI artifact)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ci-runner-farm-plg
           path: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout release PR
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
           token: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN || github.token }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - id: release
         name: Release Please
-        uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5.0.0
         with:
           token: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN || github.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 


### PR DESCRIPTION
## Summary

Fixes #51.

`release-please-action` was pinned to `0dfd8538…`, which is the annotated tag object for the floating `v5` tag, not a commit — `gh api repos/googleapis/release-please-action/commits/0dfd8538…` 422s. Once upstream re-points `v5` to a new release, this tag object becomes unreachable from any ref and GitHub can garbage-collect it, silently breaking the release workflow. It also defeats any tooling (Dependabot, audit scripts) that resolves pins by looking up the commit.

- Repin `release-please-action` to `45996ed1f6d02564a971a2fa1b5860e934307cf7`, the commit the tag object dereferences to (v5.0.0) — no behavior change, same release actually running today.
- Bump `actions/checkout` from v7.0.0 to v7.0.1 (one patch release behind) across all four workflows it appears in.
- Add a `# vX.Y.Z` comment to every third-party action pin, including the existing `actions/upload-artifact` pin, so a future SHA bump is reviewable without resolving it by hand.

All SHAs were verified against the GitHub API before applying (tag → commit dereference for `release-please-action`, tag → commit for `actions/checkout`).

## Test plan

- [x] `./tests/run-linux-checks.sh` — full check suite passes
- [x] YAML syntax validated for all four modified workflow files
- [x] Each pinned SHA verified against `gh api .../git/refs/tags/...` and `.../git/tags/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow actions to newer pinned versions.
  * Improved version labeling for workflow action references.
  * Release, packaging, and validation workflows retain their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->