### PR TITLE
chore: add Dependabot config for github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github_actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Related to #51 (opened as a separate PR from the pin fix — see below).

There's no `.github/dependabot.yml`, so nothing surfaces updates to pinned actions, including security fixes to `actions/checkout`. This adds a `github-actions`-only config:

- Weekly schedule, `dependencies` + `github_actions` labels.
- All actions grouped into a single PR per bump — `actions/checkout` appears in four workflows, so ungrouped this would open four PRs for one update.
- No `docker` ecosystem block. The shipped starter Dockerfiles (`default.Dockerfile`, `default.github.Dockerfile`, `default.gitlab.Dockerfile`) are user-facing editable templates rather than the plugin's own runtime dependencies, so automated PRs bumping their base image tags don't obviously make sense — happy to add it if you'd rather have it.

Opened separately from #53 (the tag-object pin fix) on purpose: that one's a bug fix, this is a tooling/process addition, and splitting them lets you merge the fix independently of deciding whether you want automated action updates at all.

One thing worth a second pair of eyes: Dependabot's PRs land as commits on `main` and feed release-please. With the `chore:` prefix used here (and release-please's default conventional-commit handling), a `chore:`-only commit shouldn't trigger a version bump — but worth confirming that assumption holds once real Dependabot PRs start landing.

## Test plan

- [x] `.github/dependabot.yml` validated with `yaml.safe_load`
- [ ] Confirm Dependabot picks up the config and opens grouped PRs as expected once merged