### PR TITLE
fix: Remove invalid include-commit-authors from release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
     }
   },
   "include-component-in-tag": false,
-  "include-commit-authors": true,
   "changelog-path": "CHANGELOG.md",
   "draft": false
 }


### PR DESCRIPTION
## Summary

Removes the invalid `include-commit-authors` key from `release-please-config.json`. This key is not part of release-please's config schema, which explicitly declares `additionalProperties: false`, causing schema validation to fail. Release-please has no built-in support for this option and was ignoring it anyway.

## Changes

- Removes the invalid `include-commit-authors: true` line from `release-please-config.json`
- Resolves schema validation error without affecting functionality

## Testing

- JSON schema validation now passes
- Config file remains valid and all other keys are preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the release configuration by removing an obsolete setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->