### PR TITLE
fix(config): validate numeric config values at parse time

### DIFF
--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -126,6 +126,16 @@ AUTOSCALE_MAX AUTOSCALE_MIN_IDLE AUTOSCALE_STEP AUTOSCALE_INTERVAL \
 AUTOSCALE_IDLE_GRACE IMAGE_AUTOUPDATE IMAGE_AUTOUPDATE_INTERVAL IMAGE_DRAIN_TIMEOUT \
 DASHBOARD_WIDGET_ENABLE"
 
+# The subset of the allowlist whose values reach arithmetic contexts ($(( )), seq,
+# sleep, integer tests). Bash EVALUATES the contents of a variable used inside
+# $(( )), so a cfg value like 'a[$(cmd)]' would not merely be wrong there — it
+# would run. Shape-check these at parse time so nothing else has to. Keys whose
+# values are legitimately non-integer stay off this list: RUNNER_CPUS (decimal),
+# RUNNER_MEMORY and WORK_TMPFS_SIZE (unit-suffixed).
+CFG_NUMERIC_KEYS="RUNNER_COUNT MIRROR_PORT AUTOSCALE_MIN AUTOSCALE_MAX AUTOSCALE_MIN_IDLE \
+AUTOSCALE_STEP AUTOSCALE_INTERVAL AUTOSCALE_IDLE_GRACE IMAGE_AUTOUPDATE_INTERVAL \
+IMAGE_DRAIN_TIMEOUT GITLAB_SHUTDOWN_TIMEOUT GITLAB_SHM_SIZE"
+
 # Read ci-runner-farm.cfg WITHOUT sourcing it (the file is written by the web form, so
 # sourcing would execute anything a crafted value smuggled in). Parse KEY="value"
 # lines ourselves and assign via printf -v — a literal string set, never eval'd —
@@ -141,6 +151,14 @@ load_cfg() {
     case "$key" in *[!A-Za-z0-9_]*|'') continue;; esac
     case " $CFG_KEYS " in *" $key "*) ;; *) continue;; esac
     val="${val%\"}"; val="${val#\"}"; val="${val%\'}"; val="${val#\'}"
+    case " $CFG_NUMERIC_KEYS " in *" $key "*)
+      case "$val" in
+        # A rejected key keeps its built-in default. log() is defined below and
+        # load_cfg already runs at source time, so it is not callable here; the
+        # key is named but the value is never echoed back.
+        ''|*[!0-9]*|0[0-9]*) printf '%s\n' "load_cfg: ignoring non-numeric $key" >&2; continue ;;
+      esac ;;
+    esac
     printf -v "$key" '%s' "$val"
   done < "$CFG"
 }
@@ -501,6 +519,9 @@ autoscale_tick() {
   esac
   statef="${RUNDIR}/autoscale.state"; over=0
   [ -f "$statef" ] && over=$(cat "$statef" 2>/dev/null || echo 0)
+  # over feeds $(( over + 1 )) below, which evaluates whatever the file held; a
+  # truncated or tampered state file restarts the anti-flap counter instead.
+  case "$over" in ''|*[!0-9]*|0[0-9]*) over=0 ;; esac
 
   # runner churn (crash, reap, or ephemeral exit) can drop the fleet below the
   # floor between ticks; the grow branch below only ever adds STEP to the

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -29,6 +29,7 @@ done < <(find "$RUNTIME" -type f \( -name '*.php' -o -name '*.page' \) -print | 
 
 echo "== Contracts and package =="
 bash tests/config-parity.sh
+bash tests/numeric-config.sh
 bash tests/safe-paths.sh
 bash tests/provider-contract.sh
 bash tests/exec-csrf.sh

--- a/tests/numeric-config.sh
+++ b/tests/numeric-config.sh
@@ -78,8 +78,41 @@ fail() { printf 'NUMERIC CONFIG FAIL: %s\n' "$*" >&2; exit 1; }
 ) || exit 1
 
 # The autoscale anti-flap counter is read back from a file into the same kind of
-# arithmetic context, so it carries the identical guard.
-grep -qF "case \"\$over\" in ''|*[!0-9]*|0[0-9]*) over=0 ;; esac" "$ENGINE" \
-  || fail "autoscale_tick no longer shape-checks the persisted 'over' counter"
+# arithmetic context, so it carries the identical guard — proven here by driving
+# autoscale_tick itself rather than grepping for the guard's source text.
+(
+  export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/autoscale-cfg" CRF_RUNDIR="$tmp/autoscale-run"
+  mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+  # shellcheck source=/dev/null
+  source "$ENGINE"
+
+  # Shape the fleet so the shrink branch runs every tick: idle comfortably above
+  # the min+step buffer, current above the floor. That's the only branch that
+  # reads the persisted counter into `over + 1` arithmetic.
+  AUTOSCALE=true AUTOSCALE_MIN=1 AUTOSCALE_MAX=10 AUTOSCALE_MIN_IDLE=1 \
+    AUTOSCALE_STEP=1 AUTOSCALE_IDLE_GRACE=5
+  reap_dead_runners() { return 0; }
+  provider_call() { cur=3; busy=0; idle=3; return 0; }
+  reconcile_stale_runners() { :; }
+
+  statef="$CRF_RUNDIR/autoscale.state"
+  canary="$tmp/autoscale-canary"
+
+  printf 'not-a-number\n' > "$statef"
+  autoscale_tick || fail "autoscale_tick rejected a malformed persisted counter"
+  [ "$(cat "$statef")" = 1 ] || fail "malformed 'over' counter did not restart at 0: '$(cat "$statef")'"
+
+  # Leading zeros are rejected the same as in load_cfg (bash treats them as octal).
+  printf '007\n' > "$statef"
+  autoscale_tick || fail "autoscale_tick rejected a leading-zero persisted counter"
+  [ "$(cat "$statef")" = 1 ] || fail "leading-zero 'over' counter did not restart at 0: '$(cat "$statef")'"
+
+  # An array-subscript shape is what turns 'over + 1' into code execution: bash
+  # runs a $(...) inside an array subscript even in an otherwise-arithmetic context.
+  printf 'a[$(touch %s)]\n' "$canary" > "$statef"
+  autoscale_tick || fail "autoscale_tick rejected a crafted persisted counter"
+  [ "$(cat "$statef")" = 1 ] || fail "crafted 'over' counter did not restart at 0: '$(cat "$statef")'"
+  if [ -e "$canary" ]; then fail "crafted 'over' counter reached an arithmetic context"; fi
+) || exit 1
 
 echo "numeric-config: OK — numeric cfg keys are shape-checked before assignment."

--- a/tests/numeric-config.sh
+++ b/tests/numeric-config.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# The web-written cfg is untrusted input, and most of its numeric keys land in
+# arithmetic contexts where bash evaluates the variable's contents. load_cfg must
+# shape-check those keys, keep the built-in default when a value fails, and leave
+# every non-numeric key assigned verbatim.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ENGINE="src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() { printf 'NUMERIC CONFIG FAIL: %s\n' "$*" >&2; exit 1; }
+
+(
+  export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/cfg" CRF_RUNDIR="$tmp/run"
+  mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+  # shellcheck source=/dev/null
+  source "$ENGINE"
+
+  # $CFG resolves under CRF_CFGDIR, so load_cfg can be driven directly.
+  write_cfg() { printf '%s\n' "$@" > "$CFG"; }
+
+  # A command substitution in an array-subscript shape is what makes this a code
+  # execution bug rather than a typo: $(( RUNNER_COUNT + 1 )) would run it. The
+  # value must be rejected and the built-in default must survive.
+  canary="$tmp/canary"
+  write_cfg "RUNNER_COUNT=\"a[\$(touch $canary)]\""
+  load_cfg 2>/dev/null
+  [ "$RUNNER_COUNT" = 4 ] || fail "crafted RUNNER_COUNT was assigned: '$RUNNER_COUNT'"
+  [ "$(( RUNNER_COUNT + 1 ))" = 5 ] || fail "RUNNER_COUNT is not usable as an integer"
+  if [ -e "$canary" ]; then fail "crafted RUNNER_COUNT reached an arithmetic context"; fi
+
+  # The diagnostic names the key on stderr and never echoes the value back. It
+  # cannot go through log(), which is defined after load_cfg's first invocation.
+  write_cfg 'MIRROR_PORT="$(id -u)"'
+  load_cfg 2>"$tmp/diag"
+  [ "$(cat "$tmp/diag")" = "load_cfg: ignoring non-numeric MIRROR_PORT" ] \
+    || fail "unexpected load_cfg diagnostic: '$(cat "$tmp/diag")'"
+  [ "$MIRROR_PORT" = 5000 ] || fail "crafted MIRROR_PORT was assigned: '$MIRROR_PORT'"
+
+  # Every numeric key is guarded, not just the two probed above.
+  for key in $CFG_NUMERIC_KEYS; do
+    printf -v "$key" '%s' sentinel
+    write_cfg "$key=\"a[\$(id -u)]\""
+    load_cfg 2>/dev/null
+    [ "${!key}" = sentinel ] || fail "$key accepted a non-numeric value: '${!key}'"
+  done
+
+  # Leading zeros are rejected (invalid in the generated GitLab TOML, and octal
+  # to some arithmetic paths), but a bare 0 is a shipped default and must load.
+  AUTOSCALE_MIN=2; GITLAB_SHM_SIZE=1
+  write_cfg 'AUTOSCALE_MIN="07"' 'GITLAB_SHM_SIZE="0"'
+  load_cfg 2>/dev/null
+  [ "$AUTOSCALE_MIN" = 2 ] || fail "leading-zero AUTOSCALE_MIN was assigned: '$AUTOSCALE_MIN'"
+  [ "$GITLAB_SHM_SIZE" = 0 ] || fail "a bare 0 must remain a valid numeric value"
+
+  # Well-formed values still load, and the autoscale_tick arithmetic is unchanged.
+  write_cfg \
+    'RUNNER_COUNT="6"' \
+    'AUTOSCALE_MIN_IDLE="3"' \
+    'AUTOSCALE_STEP="2"' \
+    'AUTOSCALE_MAX="16"' \
+    'AUTOSCALE_IDLE_GRACE="5"'
+  load_cfg 2>/dev/null || fail "a well-formed numeric cfg was rejected"
+  [ "$RUNNER_COUNT" = 6 ] || fail "RUNNER_COUNT did not load: '$RUNNER_COUNT'"
+  [ "$(( RUNNER_COUNT + AUTOSCALE_STEP ))" = 8 ] \
+    || fail "autoscale grow-target arithmetic changed"
+  [ "$(( AUTOSCALE_MIN_IDLE + AUTOSCALE_STEP ))" = 5 ] \
+    || fail "autoscale shrink-threshold arithmetic changed"
+
+  # Non-numeric keys are untouched by the guard and still assigned verbatim.
+  write_cfg 'RUNNER_LABELS="self-hosted,unraid,gpu"' 'RUNNER_CPUS="2.5"' 'RUNNER_MEMORY="16g"'
+  load_cfg 2>/dev/null
+  [ "$RUNNER_LABELS" = "self-hosted,unraid,gpu" ] || fail "RUNNER_LABELS was not assigned verbatim"
+  [ "$RUNNER_CPUS" = "2.5" ] || fail "RUNNER_CPUS must still accept a decimal"
+  [ "$RUNNER_MEMORY" = "16g" ] || fail "RUNNER_MEMORY must still accept a unit suffix"
+) || exit 1
+
+# The autoscale anti-flap counter is read back from a file into the same kind of
+# arithmetic context, so it carries the identical guard.
+grep -qF "case \"\$over\" in ''|*[!0-9]*|0[0-9]*) over=0 ;; esac" "$ENGINE" \
+  || fail "autoscale_tick no longer shape-checks the persisted 'over' counter"
+
+echo "numeric-config: OK — numeric cfg keys are shape-checked before assignment."

--- a/tests/numeric-config.sh
+++ b/tests/numeric-config.sh
@@ -10,6 +10,7 @@ ENGINE="src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
+# Print a labeled failure message to stderr and abort the test script.
 fail() { printf 'NUMERIC CONFIG FAIL: %s\n' "$*" >&2; exit 1; }
 
 (
@@ -18,7 +19,8 @@ fail() { printf 'NUMERIC CONFIG FAIL: %s\n' "$*" >&2; exit 1; }
   # shellcheck source=/dev/null
   source "$ENGINE"
 
-  # $CFG resolves under CRF_CFGDIR, so load_cfg can be driven directly.
+  # Write each argument as its own line to $CFG (resolved under CRF_CFGDIR), so
+  # load_cfg can be driven directly against a scratch cfg file.
   write_cfg() { printf '%s\n' "$@" > "$CFG"; }
 
   # A command substitution in an array-subscript shape is what makes this a code
@@ -91,8 +93,11 @@ fail() { printf 'NUMERIC CONFIG FAIL: %s\n' "$*" >&2; exit 1; }
   # reads the persisted counter into `over + 1` arithmetic.
   AUTOSCALE=true AUTOSCALE_MIN=1 AUTOSCALE_MAX=10 AUTOSCALE_MIN_IDLE=1 \
     AUTOSCALE_STEP=1 AUTOSCALE_IDLE_GRACE=5
+  # Stub out reaping so the tick can't be short-circuited by real container state.
   reap_dead_runners() { return 0; }
+  # Stub the provider query autoscale_tick reads fleet counts from: 3 running, all idle.
   provider_call() { cur=3; busy=0; idle=3; return 0; }
+  # Stub out stale-runner reconciliation; irrelevant to the counter guard under test.
   reconcile_stale_runners() { :; }
 
   statef="$CRF_RUNDIR/autoscale.state"


### PR DESCRIPTION
## Summary

`load_cfg` validates each key in `ci-runner-farm.cfg` against the `CFG_KEYS` allowlist, but assigns the value verbatim. Most of the numeric keys then reach arithmetic contexts, numeric tests, `seq`, and `sleep`. Bash evaluates the contents of a variable used inside `$(( ))`, so a value that is not a well-formed integer is executable there rather than merely wrong.

The comment above `load_cfg` already treats this file as untrusted input, since it is written by the web form. This extends that stance to the values as well as the keys, so the guarantee holds once at parse time rather than depending on each consumer to re-check.

This was reported privately to `security@unraid.net`; opening it as a PR at the maintainer's request.

## Changes

- Add `CFG_NUMERIC_KEYS`, the subset of the allowlist whose values reach arithmetic contexts: `RUNNER_COUNT`, `MIRROR_PORT`, the six `AUTOSCALE_*` values, `IMAGE_AUTOUPDATE_INTERVAL`, `IMAGE_DRAIN_TIMEOUT`, `GITLAB_SHUTDOWN_TIMEOUT`, and `GITLAB_SHM_SIZE`. `RUNNER_CPUS` (decimal) and `RUNNER_MEMORY` / `WORK_TMPFS_SIZE` (unit-suffixed) are legitimately non-integer and are deliberately excluded.
- Shape-check those keys in `load_cfg` before assignment, reusing the base-10 integer idiom already used in `providers/gitlab.sh`. A rejected value leaves the key at its built-in default; a bare `0` remains valid, as `GITLAB_SHM_SIZE` ships with it.
- Write the diagnostic straight to stderr rather than through `log()`, which is defined after `load_cfg` is both defined and first invoked. The rejected key is named; its value is never echoed back.
- Apply the same guard to the autoscale anti-flap counter read back from `autoscale.state`, which feeds the same kind of arithmetic context.

Values are only rejected, never clamped. Server-side enforcement of the min/max ranges the settings form advertises is a separate concern and is not addressed here.

## Testing

- New `tests/numeric-config.sh`, registered in `tests/check.sh`. It drives `load_cfg` directly against a crafted cfg in a temp `CRF_CFGDIR` and asserts that a crafted value is rejected with the default retained and no side effect, that every key in `CFG_NUMERIC_KEYS` is covered rather than just the probed ones, that a leading-zero value is rejected while a bare `0` is accepted, that well-formed values still load and the autoscale arithmetic is unchanged, and that non-numeric keys are still assigned verbatim.
- Full `tests/check.sh` passes in the pinned Ubuntu environment, including `config-parity.sh` — the new list sits outside the defaults block that parity parses, so engine/`default.cfg`/UI parity is unaffected.
- `GITLAB_SHUTDOWN_TIMEOUT` and `GITLAB_SHM_SIZE` are also validated in `gitlab_validate_settings`. Every test that exercises those errors sets the values by direct assignment rather than through the cfg file, so those paths are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of numeric configuration values, rejecting malformed, empty, zero-padded, and unsafe inputs.
  * Preserved default settings when invalid values are provided.
  * Sanitized autoscaling state values before use.
  * Prevented untrusted configuration values from appearing in diagnostics.

* **Tests**
  * Added regression coverage for numeric validation, arithmetic behavior, defaults, and autoscaling state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->