### PR TITLE
fix(github): keep the runner registration token out of docker argv

### DIFF
--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -165,6 +165,7 @@ github_registry_credentials() {
 github_build_args() {
   local idx="$1"
   local name="${2:-${NAME_PREFIX}-${idx}}" role="${CRF_CONTAINER_ROLE:-runner}"
+  ARGS_TMPDIR=""
   ARGS=(
     -d --restart=no
     --name "$name" --hostname "$name"
@@ -209,7 +210,7 @@ github_build_args() {
     mkdir -p "$CACHE_ROOT/work/$name"
     ARGS+=( -v "$CACHE_ROOT/work/$name:/_work" )
   fi
-  local scope_target="" repo reg
+  local scope_target="" repo reg envdir envf
   if [ "$GH_SCOPE" = "org" ]; then
     ARGS+=( -e RUNNER_SCOPE="org" -e ORG_NAME="$GH_OWNER" )
     [ -n "$RUNNER_GROUP" ] && ARGS+=( -e RUNNER_GROUP="$RUNNER_GROUP" )
@@ -222,16 +223,34 @@ github_build_args() {
   if [ -n "$ACCESS_TOKEN" ] && [ "${NO_REGISTER:-0}" != "1" ]; then
     reg="$(github_registration_token "$scope_target")"
     [ -z "$reg" ] && { err "could not mint a runner registration token for ${scope_target#*:} (check the PAT's scope/permissions)"; return 1; }
-    ARGS+=( -e RUNNER_TOKEN="$reg" )
+    # The image only accepts this token as RUNNER_TOKEN in its environment, so it
+    # still lands in Config.Env — but a restricted --env-file keeps it out of
+    # docker's argv, where /proc/<pid>/cmdline exposes it to every local user for
+    # the lifetime of the run. The engine retires ARGS_TMPDIR once the run this
+    # argv was built for has been dispatched.
+    envdir="$(mktemp -d "$RUNDIR/github-runner-token.XXXXXX" 2>/dev/null)" \
+      || { err "could not create a protected registration-token file for $name"; return 1; }
+    envf="$envdir/runner.env"
+    chmod 700 "$envdir" 2>/dev/null \
+      || { rm -rf "$envdir"; err "could not protect the registration-token directory for $name"; return 1; }
+    ( umask 077; printf 'RUNNER_TOKEN=%s\n' "$reg" > "$envf" ) \
+      || { rm -rf "$envdir"; err "could not write the registration-token file for $name"; return 1; }
+    chmod 600 "$envf" 2>/dev/null \
+      || { rm -rf "$envdir"; err "could not protect the registration-token file for $name"; return 1; }
+    ARGS+=( --env-file "$envf" )
+    ARGS_TMPDIR="$envdir"
   fi
   ARGS+=( "$(effective_image)" )
 }
 
 github_start_one() {
-  local idx="$1" name="$2"
+  local idx="$1" name="$2" rc
   github_build_args "$idx" "$name" || { err "runner $name not started (registration-token error)"; return 1; }
   log "starting $name (cpus=$RUNNER_CPUS mem=$RUNNER_MEMORY scope=$GH_SCOPE)"
   docker run "${ARGS[@]}" >/dev/null
+  rc=$?
+  clear_args_tmpdir
+  return "$rc"
 }
 
 github_remove_runner() {

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -1439,6 +1439,30 @@ recycle_image_preflight() {
 # Provider adapters own the complete docker argv contract.
 build_args() { provider_call build_args "$@"; }
 
+# An adapter may stage secret material for its argv (a mode-0600 --env-file, so a
+# credential never reaches /proc/<pid>/cmdline) and publish that directory as
+# ARGS_TMPDIR. ARGS outlives the adapter call and has more than one consumer, so
+# the engine retires the directory once the run it was built for is dispatched.
+# Like every other destructive path here the target is validated first: realpath -m
+# collapses ../ . and trailing slashes lexically so the guard checks the REAL
+# location, and only a path strictly under RUNDIR — never an empty value — may be
+# removed, so a stale or misdirected ARGS_TMPDIR cannot delete anything else.
+clear_args_tmpdir() {
+  local dir="${ARGS_TMPDIR:-}" resolved root
+  ARGS_TMPDIR=""
+  [ -n "$dir" ] || return 0
+  resolved="$(realpath -m -- "$dir" 2>/dev/null)"
+  root="$(realpath -m -- "$RUNDIR" 2>/dev/null)"
+  [ -n "$resolved" ] && [ -n "$root" ] \
+    || { err "refusing to remove unresolvable temporary argv dir '$dir'"; return 1; }
+  case "$resolved" in
+    "$root"/?*) ;;
+    *) err "refusing to remove temporary argv dir '$dir' outside $RUNDIR"; return 1 ;;
+  esac
+  rm -rf "${resolved:?}" 2>/dev/null \
+    || { err "could not remove temporary argv dir '$dir'"; return 1; }
+}
+
 start_one() {
   local idx="$1" name="${NAME_PREFIX}-$1" snapshot
   if docker inspect "$name" >/dev/null 2>&1; then
@@ -2676,8 +2700,10 @@ cmd_recycle() {
       echo '{"ok":false,"error":"removed but a fresh GitHub registration token could not be minted"}'; return 1
     fi
     if ! docker run "${ARGS[@]}" >/dev/null 2>&1; then
+      clear_args_tmpdir
       echo '{"ok":false,"error":"removed but not recreated"}'; return 1
     fi
+    clear_args_tmpdir
   fi
 
   # Verify final state without converting a failed Docker inspect into zero.

--- a/tests/provider-mocks.sh
+++ b/tests/provider-mocks.sh
@@ -76,12 +76,32 @@ printf '%s\n' "$github_args" | grep -qx 'ci-runner-2' \
   || fail "GitHub default runner name did not use its function argument"
 printf '%s\n' "$github_args" | grep -qx 'REPO_URL=https://github.com/example/two' \
   || fail "GitHub repo round-robin assignment changed"
-printf '%s\n' "$github_args" | grep -qx 'RUNNER_TOKEN=short-registration-token' \
-  || fail "short-lived GitHub registration token missing from runner argv"
+if printf '%s\n' "$github_args" | grep -qF short-registration-token; then
+  fail "short-lived GitHub registration token leaked into Docker argv"
+fi
+gh_envfile="$(printf '%s\n' "$github_args" | grep -A1 -Fx -- '--env-file' | tail -1)"
+[ -n "$gh_envfile" ] || fail "GitHub registration token is not passed through an env file"
+grep -qx 'RUNNER_TOKEN=short-registration-token' "$gh_envfile" \
+  || fail "short-lived GitHub registration token missing from its protected env file"
+[ "$(mode_of "$gh_envfile")" = 600 ] || fail "GitHub registration-token env file is not mode 0600"
+[ "$ARGS_TMPDIR" = "${gh_envfile%/*}" ] || fail "GitHub adapter did not publish its token dir for engine cleanup"
 if printf '%s\n' "$github_args" | grep -qF "$ACCESS_TOKEN"; then fail "GitHub PAT leaked into runner argv"; fi
 printf '%s\n' "$github_args" | grep -qx -- '--privileged' || fail "GitHub DinD privilege flag missing"
 printf '%s\n' "$github_args" | grep -qx 'START_DOCKER_SERVICE=true' || fail "GitHub DinD environment missing"
 printf '%s\n' "$github_args" | grep -qx '/_work:rw,exec,size=2g' || fail "GitHub workspace tmpfs changed"
+
+# The engine owns that staged directory's lifetime, and its removal must refuse
+# any target that is empty or resolves outside RUNDIR.
+clear_args_tmpdir || fail "engine could not retire the GitHub registration-token dir"
+[ ! -e "$gh_envfile" ] || fail "engine left the GitHub registration-token file on disk"
+[ -z "$ARGS_TMPDIR" ] || fail "engine kept a stale ARGS_TMPDIR after cleanup"
+outside_rundir="$tmp/outside-rundir"; mkdir -p "$outside_rundir"
+ARGS_TMPDIR="$outside_rundir"
+if clear_args_tmpdir 2>/dev/null; then fail "engine removed a temporary argv dir outside RUNDIR"; fi
+[ -d "$outside_rundir" ] || fail "engine deleted a temporary argv dir outside RUNDIR"
+ARGS_TMPDIR="$CRF_RUNDIR/../outside-rundir"
+if clear_args_tmpdir 2>/dev/null; then fail "engine accepted a traversal out of RUNDIR"; fi
+[ -d "$outside_rundir" ] || fail "engine deleted a traversal target outside RUNDIR"
 
 GH_SCOPE=org
 github_build_args 1 ci-runner-1 || fail "GitHub org argv generation failed"


### PR DESCRIPTION
## Summary

`github_build_args` passed the freshly minted runner registration token as `-e RUNNER_TOKEN=...`, which places it in `docker`'s argv, where `/proc/<pid>/cmdline` exposes it to every local user for the lifetime of the run.

The rest of the codebase already avoids argv for credentials: `gh_api` feeds the PAT to `curl --config -` over stdin, `docker login` uses `--password-stdin`, and GitLab writes its token into a mode-0600 `config.toml`. The comment on `github_replacement_preflight` names argv-avoidance for this exact token as a design goal — it held for the probe path but not for the start path. This brings the start path in line.

This closes the argv exposure only. The token still lands in the container's `Config.Env`, because `RUNNER_TOKEN` in the environment is how `myoung34/github-runner` receives it — that part is unchanged and remains visible to `docker inspect`.

This was reported privately to `security@unraid.net`; opening it as a PR at the maintainer's request.

## Changes

**`include/providers/github.sh`**

- Stage the token in a mode-0600 `--env-file` inside a mode-0700 `mktemp -d` under `RUNDIR`, following the pattern `gitlab.sh` already uses for its `config.toml`, and pass `--env-file` in argv instead of the value. Every failure branch removes the directory explicitly.
- Reset `ARGS_TMPDIR` at the top of `github_build_args` so a stale value from a previous call can never be reused.
- `github_start_one` retires the directory after `docker run` on both success and failure, preserving the run's exit status.
- The validate path sets `NO_REGISTER=1`, so it mints no token, creates no file, and leaves `ARGS_TMPDIR` empty.

**`include/runner-farm.sh`**

- Add `clear_args_tmpdir()` beside `build_args()`. `ARGS` outlives the adapter call and has more than one consumer, so the engine owns this cleanup rather than the adapter — extending the existing "adapters own the complete docker argv contract" boundary with a generic `ARGS_TMPDIR` handshake, instead of calling a `github_*` function from the engine.
- The helper refuses any target that is empty or does not resolve strictly under `RUNDIR`, using the same `realpath -m` guard the other destructive paths in the engine already use.
- Call it after `docker run` on both branches of the recycle path.

One consequence worth stating: if the process is killed between building argv and dispatching the run, a mode-0700 directory holding the token can be left in `RUNDIR`. That is tmpfs and mode-restricted, so it is a narrower exposure than argv, but it is new state that did not exist before.

## Testing

- `tests/provider-mocks.sh` previously asserted the token *was* present in the runner argv. That assertion is inverted to the leak-check form already used on the GitLab side, and joined by positive assertions that `--env-file` is present, that the referenced file contains the expected `RUNNER_TOKEN=`, that it is mode `600`, and that the adapter published its directory for the engine to retire.
- Added coverage for the cleanup contract itself: the engine removes the staged directory and clears `ARGS_TMPDIR`, and refuses both a target outside `RUNDIR` and a `../` traversal that escapes it.
- `github_confgen` and its fingerprint pin are deliberately untouched — no schema salt is added, so existing installs do not see a spurious config change.
- Both call shapes, `build_args "$idx"` from the recycle path and `github_build_args "$idx" "$name"`, continue to work.
- Full `tests/check.sh` passes in the pinned Ubuntu environment, including `provider-contract.sh`, `ownership-safety.sh`, and `safe-paths.sh`.
