### PR TITLE
fix(web): redact secrets on every path that reaches the browser

### DIFF
--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/exec.php
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/exec.php
@@ -51,12 +51,55 @@ $rawAction = $_POST['action'] ?? 'status-json';
 // trigger PHP type juggling/warnings in switch. Bound the dispatch string too.
 $action = is_string($rawAction) && strlen($rawAction) <= 64 ? $rawAction : '';
 
-function run($cmd) { exec($cmd . ' 2>&1', $out, $rc); return [implode("\n", $out), $rc]; }
+// The currently stored credential snapshot, for the literal pass of crf_redact.
+// These are the same four files the engine loads into its redaction set; a value
+// under 4 bytes is too short to substitute without mangling ordinary log text.
+function crf_secret_values($cfgdir) {
+  $secrets = [];
+  foreach (['token', 'gitlab-runner-token', 'gitlab-api-token', 'registry-token'] as $name) {
+    $value = @file_get_contents("$cfgdir/$name");
+    // The engine reads these through command substitution, which drops trailing
+    // newlines; an opaque registry password's edge spaces are still significant.
+    if (is_string($value)) $value = rtrim($value, "\n");
+    if (is_string($value) && strlen($value) >= 4) $secrets[] = $value;
+  }
+  return $secrets;
+}
+
+// Command output is not a trusted redaction boundary: stderr in particular is
+// unanticipated text from docker and the engine's dependencies. Every response
+// body leaves through run()/run_json(), so filter here, with the same locked-
+// credential-then-token-shape order and the same markers as redact_log_stream
+// in runner-farm.sh. The $secrets injection point keeps this testable without
+// giving a root endpoint an environment override for $CFGDIR.
+function crf_redact($s, $secrets = null) {
+  if (!is_string($s) || $s === '') return $s;
+  if ($secrets === null) $secrets = crf_secret_values($GLOBALS['CFGDIR'] ?? '');
+  foreach ($secrets as $secret) {
+    if (is_string($secret) && strlen($secret) >= 4) $s = str_replace($secret, '[REDACTED]', $s);
+  }
+  $out = preg_replace([
+    '/([A-Za-z0-9_.@-]{1,64}-)?glrt(r)?-[A-Za-z0-9_.-]{10,507}/',
+    '/github_pat_[A-Za-z0-9_]{10,}/',
+    '/gh[pousr]_[A-Za-z0-9_]{10,}/',
+    '/glpat-[A-Za-z0-9_-]{8,}/',
+  ], [
+    '[REDACTED_GITLAB_TOKEN]',
+    '[REDACTED_GITHUB_TOKEN]',
+    '[REDACTED_GITHUB_TOKEN]',
+    '[REDACTED_GITLAB_TOKEN]',
+  ], $s);
+  // preg_replace returns null only when PCRE itself fails. Fall back to the
+  // empty body every caller already handles, never to the unfiltered input.
+  return is_string($out) ? $out : '';
+}
+
+function run($cmd) { exec($cmd . ' 2>&1', $out, $rc); return [crf_redact(implode("\n", $out)), $rc]; }
 // For actions whose stdout is a JSON body the frontend parses: keep stderr OUT of
 // it, so a stray docker/system warning can't corrupt the JSON (JSON.parse would
 // throw and the consumer's .catch would silently freeze the panel). run() keeps
 // 2>&1 for the action responses where the merged log IS the payload.
-function run_json($cmd) { exec($cmd . ' 2>/dev/null', $out, $rc); return [implode("\n", $out), $rc]; }
+function run_json($cmd) { exec($cmd . ' 2>/dev/null', $out, $rc); return [crf_redact(implode("\n", $out)), $rc]; }
 // The last non-empty stdout line, if it is a JSON object — lets an emitter print
 // progress logs then its {ok,error?} verdict as the final line and have us pass
 // that verdict through with its specific reason intact.

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -32,6 +32,7 @@ bash tests/config-parity.sh
 bash tests/safe-paths.sh
 bash tests/provider-contract.sh
 bash tests/exec-csrf.sh
+bash tests/log-redaction.sh
 bash tests/provider-mocks.sh
 bash tests/ownership-safety.sh
 bash tests/resource-ownership.sh

--- a/tests/log-redaction.sh
+++ b/tests/log-redaction.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# The engine and the UI endpoint must scrub diagnostics identically: the shell
+# filters the log verbs, the endpoint filters every response body (including the
+# stderr run() merges in). One shared fixture — the loaded credential snapshot
+# plus every recognized provider token shape — goes through both implementations
+# and the two outputs must be byte-for-byte identical.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail() { printf 'log-redaction: FAIL: %s\n' "$*" >&2; exit 1; }
+command -v php >/dev/null 2>&1 || fail "php is required"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# The token shapes provider-mocks.sh pins for redact_log_stream, plus a registry
+# password of shell/sed punctuation that both sides must treat literally.
+redact_access='loaded-access-secret-1234'
+redact_runner='loaded-glrt-runner-secret-1234'
+redact_api='loaded-api-secret-5678'
+redact_registry='reg[]/.*&\punct$token-9012'
+routable='glrt-AAECAwQFBgcICQoLDA0OD286MQpwOjIKdTozCnQ6Mw8.01.170z6aiyq'
+payload="${routable#glrt-}"
+
+fixture="$tmp/fixture.log"
+printf '%s\n' \
+  "loaded $redact_access $redact_runner $redact_api $redact_registry" \
+  'shape glrt-abcdefghijklmnop glrtr-abcdefghijklmnop acme-glrt-abcdefghijklmnop' \
+  "shape $routable glrtr-$payload acme-glrt-$payload" \
+  'shape glpat-abcdefghijklmnop github_pat_abcdefghijklmnop ghp_abcdefghijklmnop' \
+  'shape gho_abcdefghijklmnop ghs_abcdefghijklmnop ghu_abcdefghijklmnop ghr_abcdefghijklmnop' \
+  'plain time="2026-01-01T00:00:00Z" level=warning msg="docker: no such image"' \
+  > "$fixture"
+
+(
+  export CRF_CFGDIR="$tmp/config" CRF_RUNDIR="$tmp/run" CRF_SOURCE_ONLY=1
+  mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+  # shellcheck source=/dev/null
+  source src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+  ACCESS_TOKEN="$redact_access"
+  GITLAB_RUNNER_TOKEN="$redact_runner"
+  GITLAB_API_TOKEN="$redact_api"
+  REGISTRY_TOKEN="$redact_registry"
+  redact_log_stream < "$fixture"
+) > "$tmp/shell.out" || fail "engine redaction failed"
+
+# Same standalone-CSRF harness the endpoint's other tests use. The action is
+# unknown, so dispatch falls to default and no credential path is touched.
+marker='CRF_REDACTED_FIXTURE'
+CRF_FIXTURE="$fixture" CRF_MARKER="$marker" \
+CRF_ACCESS="$redact_access" CRF_RUNNER="$redact_runner" \
+CRF_API="$redact_api" CRF_REGISTRY="$redact_registry" \
+  php -d auto_prepend_file= > "$tmp/php.raw" <<'PHP' || fail "endpoint redaction failed"
+<?php
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$var = ['csrf_token'=>'known-test-token'];
+$_POST = ['csrf_token'=>'known-test-token', 'action'=>'crf-redaction-parity'];
+include 'src/usr/local/emhttp/plugins/ci-runner-farm/include/exec.php';
+$secrets = [getenv('CRF_ACCESS'), getenv('CRF_RUNNER'), getenv('CRF_API'), getenv('CRF_REGISTRY')];
+echo "\n" . getenv('CRF_MARKER') . "\n";
+echo crf_redact(file_get_contents(getenv('CRF_FIXTURE')), $secrets);
+PHP
+sed "1,/^$marker\$/d" "$tmp/php.raw" > "$tmp/php.out"
+
+if ! cmp -s "$tmp/shell.out" "$tmp/php.out"; then
+  diff -u "$tmp/shell.out" "$tmp/php.out" >&2 || true
+  fail "endpoint redaction diverged from the engine"
+fi
+
+# Parity alone would also accept two identically broken filters, so assert the
+# shared output on its merits: nothing recognizable survives, and each marker
+# the UI/CLI shows an operator is actually produced.
+for leaked in "$redact_access" "$redact_runner" "$redact_api" "$redact_registry" \
+  glrt-abcdefghijklmnop glrtr-abcdefghijklmnop acme-glrt-abcdefghijklmnop \
+  "$routable" "glrtr-$payload" "acme-glrt-$payload" \
+  glpat-abcdefghijklmnop github_pat_abcdefghijklmnop \
+  ghp_abcdefghijklmnop gho_abcdefghijklmnop ghs_abcdefghijklmnop \
+  ghu_abcdefghijklmnop ghr_abcdefghijklmnop
+do
+  if grep -Fq -- "$leaked" "$tmp/php.out"; then fail "shared redaction leaked $leaked"; fi
+done
+for marker_text in '[REDACTED]' '[REDACTED_GITLAB_TOKEN]' '[REDACTED_GITHUB_TOKEN]'; do
+  grep -Fq -- "$marker_text" "$tmp/php.out" || fail "shared redaction never emits $marker_text"
+done
+grep -Fq 'no such image' "$tmp/php.out" || fail "shared redaction discards ordinary log text"
+
+# status-json/image-info/farm-log/build-log echo an engine JSON body verbatim
+# through run_json(), so redaction must leave that body parseable.
+CRF_TOKEN="$routable" php -d auto_prepend_file= -r '
+  $_SERVER["REQUEST_METHOD"] = "POST";
+  $var = ["csrf_token"=>"known-test-token"];
+  $_POST = ["csrf_token"=>"known-test-token", "action"=>"crf-redaction-parity"];
+  ob_start(); include "src/usr/local/emhttp/plugins/ci-runner-farm/include/exec.php"; ob_end_clean();
+  $body = json_encode(["ok"=>true,"log"=>"registering with ".getenv("CRF_TOKEN")." and ghp_abcdefghijklmnop"]);
+  $decoded = json_decode(crf_redact($body, []), true);
+  exit(is_array($decoded) && strpos($decoded["log"], "[REDACTED_GITLAB_TOKEN]") !== false ? 0 : 1);
+' || fail "redacting a passthrough JSON body left it unparseable"
+
+# Without an explicit set, the literal pass uses the stored credentials: the same
+# four filenames and 4-byte floor the engine loads, read like the engine's
+# command substitution (trailing newline dropped, edge spaces preserved).
+mkdir -p "$tmp/secrets"
+printf '%s\n' 'aaaa-github-token' > "$tmp/secrets/token"
+printf '%s' 'bbbb-runner-token' > "$tmp/secrets/gitlab-runner-token"
+printf '%s' 'cc' > "$tmp/secrets/gitlab-api-token"
+printf '%s' ' dd-registry-token ' > "$tmp/secrets/registry-token"
+CRF_SECRET_DIR="$tmp/secrets" php -d auto_prepend_file= -r '
+  $_SERVER["REQUEST_METHOD"] = "POST";
+  $var = ["csrf_token"=>"known-test-token"];
+  $_POST = ["csrf_token"=>"known-test-token", "action"=>"crf-redaction-parity"];
+  ob_start(); include "src/usr/local/emhttp/plugins/ci-runner-farm/include/exec.php"; ob_end_clean();
+  $expected = ["aaaa-github-token", "bbbb-runner-token", " dd-registry-token "];
+  exit(crf_secret_values(getenv("CRF_SECRET_DIR")) === $expected ? 0 : 1);
+' || fail "endpoint does not load the stored credential set the engine redacts"
+
+echo "log-redaction: PASS"

--- a/tests/provider-contract.sh
+++ b/tests/provider-contract.sh
@@ -90,6 +90,17 @@ grep -qF '\(glrt-[A-Za-z0-9_.-]*\)' "$GITLAB_ADAPTER" \
   || bad "GitLab saved-probe parser truncates routable runner tokens at the first dot"
 grep -qF 'glrt(r)?-[A-Za-z0-9_.-]{10,507}' "$ENGINE" \
   || bad "GitLab diagnostic redaction does not consume full routable runner tokens"
+grep -qF 'glrt(r)?-[A-Za-z0-9_.-]{10,507}' "$EXEC" \
+  || bad "endpoint redaction does not share the engine's routable runner-token shape"
+# The engine only filters its own log verbs. stderr is where an unanticipated
+# secret would surface, and run() merges stderr into the response body, so both
+# command wrappers must return through the redactor — that one choke point is
+# what stops a future action from reopening the gap. tests/log-redaction.sh pins
+# the endpoint and the engine to byte-identical output.
+grep -Eq '^function run\(\$cmd\) \{.*return \[crf_redact\(' "$EXEC" \
+  || bad "endpoint returns merged command output without log redaction"
+grep -Eq '^function run_json\(\$cmd\) \{.*return \[crf_redact\(' "$EXEC" \
+  || bad "endpoint returns command JSON output without log redaction"
 # Self-managed GitLab can customize its PAT prefix. The optional API token must
 # use a narrow token-safe alphabet, but `glpat-` is only the common default.
 grep -qF 'A-Za-z0-9_.@:+\/=~-' "$EXEC" || bad "API-token endpoint does not enforce a narrow token-safe alphabet"


### PR DESCRIPTION
## Summary

`redact_log_stream` is applied on the four log-viewing verbs only. Every other verb's output is returned to the browser verbatim, and `run()` merges stderr into that body — stderr being exactly where unanticipated output from `docker` or the engine's dependencies surfaces, and the side with no filter.

Nothing is known to leak today. The point of this change is to make the boundary enforceable rather than conventional: the filter moves to the single place where command output crosses into an HTTP response, so adding a verb cannot reopen the gap by omission.

This was reported privately to `security@unraid.net`; opening it as a PR at the maintainer's request.

## Changes

**`include/exec.php`**

- Add `crf_secret_values()`, which loads the same four credential files the engine loads into its redaction set, and skips values under 4 bytes as the engine does.
- Add `crf_redact()`, applying the stored credentials literally first and then the same four token-shape patterns, with the same `[REDACTED]`, `[REDACTED_GITLAB_TOKEN]`, and `[REDACTED_GITHUB_TOKEN]` markers as `redact_log_stream`. The `$secrets` parameter defaults to `null` so the function is testable without giving a root endpoint an environment override for `$CFGDIR`.
- Route both `run()` and `run_json()` returns through it. Every response body in the file derives from one of those two, so this covers all of them, including the reconcile-error string and the credential-clear fallbacks that place raw command output into an `error` field.

The replacement markers contain no JSON metacharacters, so the passthrough verbs (`status-json`, `image-info`, `farm-log`, `build-log`) remain parseable.

Two responses deliberately stay outside this boundary: `get-dockerfile` and `get-default-dockerfile` return the operator's own Dockerfile for editing, which the UI round-trips back through `save-dockerfile`. Filtering them would write a redaction marker into the operator's Dockerfile on the next save. Neither is command output.

## Testing

- New `tests/log-redaction.sh`, registered in `tests/check.sh`. It runs a single shared fixture — the routable and short GitLab runner-token forms including an instance-prefixed variant, `glpat-`, `github_pat_`, all five `gh[pousr]_` variants, an opaque registry password containing shell and `sed` punctuation, and ordinary log text — through both the shell and the PHP implementation, and asserts the results are byte-for-byte identical. That parity check is what keeps the two languages from drifting.
- The same test asserts that no fixture token survives, that all three markers are emitted, that ordinary text is preserved, that a redacted engine-shaped JSON body still decodes, and that the credential loader reads the expected four files with the engine's trailing-newline handling and length floor.
- Added structural assertions to `tests/provider-contract.sh` that both `run()` and `run_json()` return through `crf_redact`, and that the endpoint shares the engine's routable runner-token shape — so a future change that bypasses the choke point fails the build rather than silently widening the surface.
- Full `tests/check.sh` passes in the pinned Ubuntu environment, including `exec-csrf.sh`, which continues to prove the endpoint's CSRF handling is unchanged.
