### PR TITLE
Ignore linter report and cache artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,9 @@
 ci-runner-farm.tgz
 docs/sessions
 *.err
+
+megalinter-reports
+mega-linter.log
+.php-cs-fixer.cache
+.phplint.cache
+*-megalinter_file_names_cspell.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,15 @@
 .git
+
+### Build ###
 /tmp/
 ci-runner-farm.tgz
-docs/sessions
 *.err
 
+### Session Logs ###
+docs/sessions
+
+### Linters ###
+.megalinter_github_conf
 megalinter-reports
 mega-linter.log
 .php-cs-fixer.cache

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@
 
 # Local session logs (save-to-md / quick-push notes) — dev artifacts, never committed.
 docs/sessions/
+
+# Linter reports and caches (MegaLinter and the tools it wraps).
+/megalinter-reports/
+/mega-linter.log
+/.php-cs-fixer.cache
+/.phplint.cache/
+/*-megalinter_file_names_cspell.txt

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,97 @@ docs/sessions/
 /.php-cs-fixer.cache
 /.phplint.cache/
 /*-megalinter_file_names_cspell.txt
+
+# Created by https://www.toptal.com/developers/gitignore/api/windows,linux,macos,git
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows,linux,macos,git
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/windows,linux,macos,git

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,17 @@
+### Build ###
 *.err
 /tmp/
 # Build output: the .plg is committed (its version stamp is frozen at the tag),
 # but the .tgz package is rebuilt reproducibly by CI at publish — never committed.
 /ci-runner-farm.tgz
 
+### Session Logs ###
 # Local session logs (save-to-md / quick-push notes) — dev artifacts, never committed.
 docs/sessions/
 
+### Linters ###
 # Linter reports and caches (MegaLinter and the tools it wraps).
+.megalinter_github_conf/
 /megalinter-reports/
 /mega-linter.log
 /.php-cs-fixer.cache


### PR DESCRIPTION
## Summary
- Ignore MegaLinter's report/cache artifacts (`megalinter-reports/`, `mega-linter.log`, `.php-cs-fixer.cache`, `.phplint.cache/`, the UUID-suffixed cspell filename, and `.megalinter_github_conf/`) in both `.gitignore` and `.dockerignore`, so a local lint run doesn't dirty the working tree or leak into the Docker build context.
- Group `.gitignore` into `### Heading ###` sections consistent with the toptal.com-generated block below it, and mirror the same headings into `.dockerignore` for readability.

## Test plan
- [x] `./tests/run-linux-checks.sh` — the only failure (`release-guard: unguarded job 'release-please'`) reproduces identically on a clean `main`, so it's pre-existing and unrelated to this change.

Fixes #66