### PR TITLE
feat: add .editorconfig and VS Code editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Markdown uses trailing double-space for hard line breaks.
+[*.md]
+trim_trailing_whitespace = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false,
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "files.trimFinalNewlines": true,
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  }
+}


### PR DESCRIPTION
Closes #65.

Adds `.editorconfig` codifying the repo's existing 2-space/LF/trim-trailing-whitespace convention, plus `.vscode/settings.json` and `.vscode/extensions.json` so the convention applies without the EditorConfig extension.

`LICENSE` is intentionally left uncovered rather than carved out with a per-file override, since it's verbatim Apache-2.0 text. It will be excluded from linting entirely once MegaLinter is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added consistent workspace formatting settings, including two-space indentation, UTF-8 encoding, LF line endings, and automatic final newlines.
  * Added automatic trailing-whitespace cleanup while preserving Markdown hard line breaks.
  * Added a recommended VS Code extension to support the formatting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->