### PR TITLE
feat: add MegaLinter to CI with a DISABLE_LINTERS baseline

### DIFF
--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -1,0 +1,45 @@
+---
+name: MegaLinter
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  megalinter:
+    name: MegaLinter
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: MegaLinter
+        id: ml
+        uses: oxsecurity/megalinter/flavors/php@15e5b45552097e318c93de385779ce3b1084052c # v10.0.0
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload MegaLinter reports
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: megalinter-reports
+          include-hidden-files: "true"
+          path: |
+            megalinter-reports
+            mega-linter.log

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: MegaLinter
         id: ml
-        uses: oxsecurity/megalinter/flavors/php@15e5b45552097e318c93de385779ce3b1084052c # v10.0.0
+        uses: oxsecurity/megalinter@15e5b45552097e318c93de385779ce3b1084052c # v10.0.0
         env:
           VALIDATE_ALL_CODEBASE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,0 +1,48 @@
+---
+# MegaLinter — https://megalinter.io/
+# PHP flavor (github.com/oxsecurity/megalinter/tree/main/flavors/php): this
+# repo has no JS/TS, Go, Python, Rust, etc., so the full flavor's image would
+# only add unused linters and pull time.
+#
+# Everything the PHP flavor runs is enabled except what's explicitly disabled
+# below. Each entry is removed by the tracking issue that enables and fixes
+# that linter — see DISABLE_LINTERS for the current baseline and why it's
+# structured this way rather than as an ENABLE_LINTERS allowlist.
+APPLY_FIXES: none
+SHOW_ELAPSED_TIME: true
+PARALLEL: true
+FILEIO_REPORTER: false
+
+# All linters run except this list. Baseline measured 2026-08-15 against
+# oxsecurity/megalinter-php:v10.0.0, VALIDATE_ALL_CODEBASE=true, on a clean
+# LF checkout (see docs/sessions/upstream-issues/00-megalinter-baseline-report.md
+# for the CRLF pitfall this avoids). Each follow-up issue opens by removing its
+# linter from this list, then fixing whatever it flags — smaller diffs than
+# growing an allowlist, and any linter MegaLinter adds later is on by default.
+DISABLE_LINTERS:
+  - ACTION_ZIZMOR
+  - BASH_SHELLCHECK
+  - BASH_SHFMT
+  - COPYPASTE_JSCPD
+  - DOCKERFILE_HADOLINT
+  - JSON_PRETTIER
+  - MARKDOWN_MARKDOWNLINT
+  - MARKDOWN_MARKDOWN_TABLE_FORMATTER
+  - PHP_PHPCS
+  - PHP_PHPCSFIXER
+  - PHP_PSALM
+  - REPOSITORY_BETTERLEAKS
+  - REPOSITORY_CHECKOV
+  - REPOSITORY_TRIVY
+  - SPELL_CSPELL
+  - YAML_PRETTIER
+
+# LICENSE is a verbatim upstream legal document (Apache-2.0) — exclude it from
+# every linter rather than tuning each one around it. CHANGELOG.md is
+# release-please-managed output, not hand-authored content.
+FILTER_REGEX_EXCLUDE: (^LICENSE$|^CHANGELOG\.md$|\.git/|megalinter-reports/)
+
+# .jsonc is used inconsistently across editors (e.g. VS Code config commonly
+# uses .json with comments rather than .jsonc), so allow comments/trailing
+# commas for all JSON rather than relying on file extension.
+JSON_JSONLINT_ARGUMENTS: "--comments --trailing-newline --trailing-commas"

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,21 +1,23 @@
 ---
 # MegaLinter — https://megalinter.io/
-# PHP flavor (github.com/oxsecurity/megalinter/tree/main/flavors/php): this
-# repo has no JS/TS, Go, Python, Rust, etc., so the full flavor's image would
-# only add unused linters and pull time.
+# Full image, not a language flavor: flavors trim their linter set to match a
+# detected language, and that also drops general-purpose scanners (DevSkim,
+# Dustilock, Kingfisher, ...) that aren't language-specific. This repo is
+# small enough that the full image's extra pull time isn't worth trading
+# those away.
 #
-# Everything the PHP flavor runs is enabled except what's explicitly disabled
-# below. Each entry is removed by the tracking issue that enables and fixes
-# that linter — see DISABLE_LINTERS for the current baseline and why it's
-# structured this way rather than as an ENABLE_LINTERS allowlist.
+# Everything is enabled except what's explicitly disabled below. Each entry
+# is removed by the tracking issue that enables and fixes that linter — see
+# DISABLE_LINTERS for the current baseline and why it's structured this way
+# rather than as an ENABLE_LINTERS allowlist.
 APPLY_FIXES: none
 SHOW_ELAPSED_TIME: true
 PARALLEL: true
 FILEIO_REPORTER: false
 
 # All linters run except this list. Baseline measured 2026-08-15 against
-# oxsecurity/megalinter-php:v10.0.0, VALIDATE_ALL_CODEBASE=true, on a clean
-# LF checkout (see docs/sessions/upstream-issues/00-megalinter-baseline-report.md
+# oxsecurity/megalinter:v10.0.0 (full image), VALIDATE_ALL_CODEBASE=true, on a
+# clean LF checkout (see docs/sessions/upstream-issues/00-megalinter-baseline-report.md
 # for the CRLF pitfall this avoids). Each follow-up issue opens by removing its
 # linter from this list, then fixing whatever it flags — smaller diffs than
 # growing an allowlist, and any linter MegaLinter adds later is on by default.
@@ -33,6 +35,7 @@ DISABLE_LINTERS:
   - PHP_PSALM
   - REPOSITORY_BETTERLEAKS
   - REPOSITORY_CHECKOV
+  - REPOSITORY_DEVSKIM
   - REPOSITORY_TRIVY
   - SPELL_CSPELL
   - YAML_PRETTIER

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -27,6 +27,12 @@ DISABLE_LINTERS:
   - BASH_SHFMT
   - COPYPASTE_JSCPD
   - DOCKERFILE_HADOLINT
+  # Not part of the PHP-flavor linter set the original baseline measured
+  # against; switching to the full image turned it on and it fell through
+  # that sweep. Repo-wide indentation debt (README.md, shell scripts, .plg,
+  # .page files, ...) — needs its own tracking issue rather than a
+  # sprawling reformat bundled into unrelated PRs.
+  - EDITORCONFIG_EDITORCONFIG_CHECKER
   - JSON_PRETTIER
   - MARKDOWN_MARKDOWNLINT
   - MARKDOWN_MARKDOWN_TABLE_FORMATTER

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -14,6 +14,13 @@ APPLY_FIXES: none
 SHOW_ELAPSED_TIME: true
 PARALLEL: true
 FILEIO_REPORTER: false
+# Most PRs here come from contributor forks, where GitHub always forces a
+# read-only GITHUB_TOKEN on pull_request-triggered workflows no matter what
+# the workflow's permissions block grants. This reporter would only ever
+# succeed on same-repo branches (e.g. release-please's), so it's off rather
+# than 403-ing on every contributor PR; the job summary and uploaded report
+# artifact already cover every PR type without needing write permissions.
+GITHUB_COMMENT_REPORTER: false
 
 # All linters run except this list. Baseline measured 2026-08-15 against
 # oxsecurity/megalinter:v10.0.0 (full image), VALIDATE_ALL_CODEBASE=true, on a


### PR DESCRIPTION
## Summary
- Add a MegaLinter workflow (full image, not a language flavor) that runs on PRs, pushes to `main`, and manual dispatch
- Add `.mega-linter.yml` with a baseline `DISABLE_LINTERS` list capturing the linters not yet clean, so follow-up issues can enable them one at a time by removing entries rather than growing an allowlist
- Extend `.gitignore`/`.dockerignore` to exclude MegaLinter report/cache artifacts
- Fix the workflow to use the full MegaLinter image instead of the PHP flavor, since flavors trim general-purpose scanners (DevSkim, Kingfisher, etc.) that aren't language-specific

Closes #67

## Test plan
- [x] `./tests/run-linux-checks.sh` passes locally
- [x] MegaLinter workflow runs in CI on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated code-quality checks for pull requests, updates to the main branch, and manual runs.
  * Added full-codebase validation with parallel execution and timing reports.
  * Added downloadable linting reports and logs for troubleshooting.
  * Configured exclusions and formatting allowances to reduce irrelevant validation noise.
  * Added safeguards to ensure consistent checks and minimize redundant runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->