### PR TITLE
feat(autoscale): self-heal runners poisoned by dangling buildkit leases

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,18 @@ recreated for the new provider.
 The Fleet tab may therefore briefly show both providers during the transition;
 ordinary steady state still has one active provider.
 
+Alongside reaping dead or deregistered slots, the autoscale tick also
+self-heals build-poisoned GitHub DinD slots. If a slot's nested Docker daemon
+crashes mid-build, its persistent buildkit store can be left with dangling
+lease metadata: every later build on that slot fails with
+`failed to solve: lease "...": not found` while the runner itself stays
+healthy and keeps accepting jobs. The farm detects this from the failed job
+logs on GitHub (the only place the error is visible), then — only while the
+slot is idle, and at most once per slot per hour — stops the container,
+clears just the `buildkit/` subdirectory of its Docker root (warm image and
+layer caches survive), and starts the same container again. Events appear in
+the autoscale log.
+
 ![Fleet state and controls](docs/images/fleet.png)
 
 ## CLI

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -154,6 +154,107 @@ github_public_repo_problem() {
   printf '%s' "$msg"
 }
 
+# ── Build-poison detection ───────────────────────────────────────────────────
+# A crashed nested dockerd can leave a slot's persistent buildkit store with
+# dangling lease references; every later build on that slot then fails with
+#   ERROR: failed to solve: lease "...": not found
+# while the runner stays healthy and keeps accepting jobs. Nothing host-side
+# ever sees that error: the nested daemon does not log solve failures and job
+# step output exists only in the uploaded GitHub job log. So detection reads
+# what the jobs themselves saw — recent failed workflow runs, their jobs that
+# ran on THIS host's slots, and each such job's log — looking for the lease
+# signature. Rate-bounded and cached so an idle fleet costs one runs listing
+# per repo per POISON_SCAN_INTERVAL, and log downloads happen at most once per
+# failed job ever (the seen cache).
+GITHUB_POISON_SIGNATURE='failed to solve: lease "[^"]*": not found'
+
+# IDs of recent failed workflow runs for one repo, newest first. The pretty
+# GitHub JSON puts every field on its own line; a run object's own "id" is the
+# only anchored "id" key that is later followed by "head_branch", which nested
+# objects (repository, check suite) never carry.
+github_recent_failed_runs() {
+  local repo="$1" cutoff="$2" url body
+  url="/repos/${repo}/actions/runs?status=failure&per_page=5"
+  [ -n "$cutoff" ] && url="${url}&created=%3E${cutoff}"
+  body="$(gh_api GET "$url")" || return 1
+  printf '%s\n' "$body" | awk '
+    /^[[:space:]]*"id":/ { if (match($0, /[0-9]+/)) last = substr($0, RSTART, RLENGTH) }
+    /^[[:space:]]*"head_branch":/ { if (last != "") { print last; last = "" } }'
+}
+
+# "jobid|slot" for each failed job of one run (latest attempt) that executed on
+# one of this host's managed slots. Per job object the fields arrive as: "id",
+# then the job-level "conclusion" (before the steps array, whose steps carry
+# their own "conclusion" but never an anchored "id"), then "runner_name".
+github_failed_local_jobs() {
+  local repo="$1" run_id="$2" body
+  body="$(gh_api GET "/repos/${repo}/actions/runs/${run_id}/jobs?per_page=50")" || return 1
+  printf '%s\n' "$body" | awk -v host="$(host)-" -v prefix="${NAME_PREFIX}-" '
+    /^[[:space:]]*"id":/ { if (match($0, /[0-9]+/)) { jid = substr($0, RSTART, RLENGTH); conc = "" } }
+    /^[[:space:]]*"conclusion":/ {
+      if (conc == "") { s = $0; sub(/^[^:]*:[[:space:]]*"?/, "", s); sub(/"?,?[[:space:]]*$/, "", s); conc = s }
+    }
+    /^[[:space:]]*"runner_name":/ {
+      s = $0; sub(/^[^:]*:[[:space:]]*"/, "", s); sub(/".*/, "", s)
+      if (jid != "" && conc == "failure" && index(s, host) == 1) {
+        slot = substr(s, length(host) + 1)
+        if (slot ~ ("^" prefix "[0-9]+$")) print jid "|" slot
+      }
+      jid = ""; conc = ""
+    }'
+}
+
+# Does one failed job's log carry the dangling-lease signature? The logs
+# endpoint redirects to short-lived blob storage; the PAT enters curl through
+# config stdin (never argv), like gh_api. Size/time caps keep a runaway log
+# from stalling the tick — a poisoned build dies in its first minute, so the
+# logs that matter are small. grep without -q reads to EOF, so pipefail cannot
+# turn an early-match SIGPIPE into a false negative.
+github_job_log_poisoned() {
+  local repo="$1" job_id="$2"
+  [ -n "$ACCESS_TOKEN" ] || return 1
+  printf 'header = "Authorization: Bearer %s"\n' "$ACCESS_TOKEN" \
+    | curl -fsSL -m 30 --max-filesize 8000000 --config - \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/${repo}/actions/jobs/${job_id}/logs" 2>/dev/null \
+    | grep -E "$GITHUB_POISON_SIGNATURE" >/dev/null 2>&1
+}
+
+github_build_poison_scan() {
+  [ "$DIND" = "true" ] || return 0     # no nested daemon, no buildkit store to poison
+  [ -n "$ACCESS_TOKEN" ] || return 0
+  local stampf="$RUNDIR/poison-scan.stamp" seenf="$RUNDIR/poison-scan.seen"
+  local now last=0 cutoff repo run_id line jid slot snapshot id provider role index gen
+  now="$(date +%s)"
+  [ -f "$stampf" ] && read -r last < "$stampf"
+  case "$last" in ''|*[!0-9]*) last=0 ;; esac
+  [ $((now - last)) -lt "$POISON_SCAN_INTERVAL" ] && return 0
+  echo "$now" > "$stampf"
+  # GNU date on Unraid; an environment without epoch -d support just drops the
+  # created filter and lets the seen cache bound the rework instead.
+  cutoff="$(date -u -d "@$((now - POISON_SCAN_LOOKBACK))" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+  [ -f "$seenf" ] || : > "$seenf"
+  for repo in $GH_REPOS; do
+    [ -n "$repo" ] || continue
+    for run_id in $(github_recent_failed_runs "$repo" "$cutoff"); do
+      for line in $(github_failed_local_jobs "$repo" "$run_id"); do
+        jid="${line%%|*}"; slot="${line##*|}"
+        grep -qx "$jid" "$seenf" 2>/dev/null && continue
+        echo "$jid" >> "$seenf"
+        github_job_log_poisoned "$repo" "$jid" || continue
+        # Flag the slot with its current immutable container ID so the healer
+        # can discard the flag if the slot is replaced before repair runs.
+        snapshot="$(managed_runner_snapshot "$slot" 2>/dev/null)" || continue
+        IFS='|' read -r id provider role index gen <<< "$snapshot"
+        log "selfheal: job $jid on $slot failed with a dangling buildkit lease -> flagging for repair"
+        echo "$id" > "$RUNDIR/poison-pending.$slot"
+      done
+    done
+  done
+  tail -500 "$seenf" > "$seenf.tmp" 2>/dev/null && mv "$seenf.tmp" "$seenf"
+  return 0
+}
+
 github_registry_credentials() {
   if [ -z "$pass" ]; then
     case "$REGISTRY_SERVER" in

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/gitlab.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/gitlab.sh
@@ -53,6 +53,11 @@ gitlab_shutdown_timeout() {
 }
 gitlab_docker_stopping_timeout() { gitlab_shutdown_timeout; }
 gitlab_docker_stopping() { provider_stop_container "$1"; }
+# Build-poison self-heal is GitHub-only for now: the dangling-lease failure has
+# only been observed under the GitHub DinD slots, and GitLab job logs live in
+# GitLab, outside the scan this hook feeds. heal_poisoned_runners also ignores
+# any flag that resolves to a GitLab slot.
+gitlab_build_poison_scan() { return 0; }
 
 gitlab_confgen() {
   # Hash the exact token values loaded after fleet.lock was acquired. Reading the

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -105,6 +105,12 @@ AUTOSCALE_MIN_IDLE="2"                # keep at least this many idle (warm) runn
 AUTOSCALE_STEP="2"                    # add/remove this many per adjustment
 AUTOSCALE_INTERVAL="30"              # seconds between checks
 AUTOSCALE_IDLE_GRACE="5"             # consecutive over-idle checks before scaling down (anti-flap)
+# ---- build-poison self-heal (see heal_poisoned_runners) ----------------------
+# Internal cadence/bounds, deliberately not web-settable. The CRF_* environment
+# overrides exist for the test harness, not for operators.
+POISON_SCAN_INTERVAL="${CRF_POISON_SCAN_INTERVAL:-300}"           # min seconds between failed-job log scans
+POISON_SCAN_LOOKBACK="${CRF_POISON_SCAN_LOOKBACK:-1800}"          # only consider workflow runs created this recently
+POISON_HEAL_MIN_INTERVAL="${CRF_POISON_HEAL_MIN_INTERVAL:-3600}"  # at most one buildkit reset per slot per hour
 # ---- image auto-update: keep the runner image current, roll the fleet --------
 IMAGE_AUTOUPDATE="false"             # true => a daemon periodically pulls the runner image and,
                                      # when the digest moves, recreates runners on the new image.
@@ -303,6 +309,7 @@ provider_imageupdate_pull() { provider_call imageupdate_pull; }
 provider_remote_image_host_pull_required() { provider_call remote_image_host_pull_required; }
 provider_prepare_remote_image() { provider_call prepare_remote_image "$@"; }
 provider_remote_image_update_allowed() { provider_call remote_image_update_allowed; }
+provider_build_poison_scan() { provider_call build_poison_scan; }
 
 container_docker_stopping_timeout() {
   local provider
@@ -505,6 +512,80 @@ reap_dead_runners() {
   return "$failed"
 }
 
+# A runner whose nested dockerd crashed mid-build can be left with dangling
+# buildkit lease metadata in its persistent DinD root: every later build on that
+# slot fails with `failed to solve: lease "...": not found` while the container
+# stays running, healthy, and registered — so it keeps taking (and failing)
+# jobs, invisible to reap_dead_runners, which only sees dead containers and
+# lost registrations. The provider scan classifies a slot as build-poisoned by
+# that exact signature (GitHub reads recent failed-job logs, the only place the
+# error is visible — the nested daemon does not log solve failures) and drops a
+# poison-pending flag; this pass repairs flagged IDLE slots by stopping the
+# container, clearing ONLY the buildkit/ subdir of its DinD root (the warm
+# image/layer caches survive), and starting the same container again (runner
+# registration persists across stop/start). Conservative by design: busy slots
+# are never touched, each slot gets at most one reset attempt per
+# POISON_HEAL_MIN_INTERVAL, and a flag whose container was replaced since
+# detection is discarded (replacements always start with a fresh DinD root).
+# Like the reaper this runs from the autoscale tick under the fleet lock; with
+# autoscaling off, an operator recycle remains the repair path.
+heal_poisoned_runners() {
+  provider_build_poison_scan \
+    || err "selfheal: build-poison scan failed; acting on existing flags only"
+  local f c snapshot id provider role index gen flagged_id root now last healf failed=0
+  for f in "$RUNDIR"/poison-pending.*; do
+    [ -e "$f" ] || break
+    c="${f##*/poison-pending.}"
+    printf '%s' "$c" | grep -qE "^${NAME_PREFIX}-[0-9]+$" || { rm -f "$f"; continue; }
+    flagged_id="$(head -1 "$f" 2>/dev/null)"
+    if ! snapshot="$(managed_runner_snapshot "$c" 2>/dev/null)"; then
+      log "selfheal: dropping poison flag for $c (slot no longer present)"
+      rm -f "$f"; continue
+    fi
+    IFS='|' read -r id provider role index gen <<< "$snapshot"
+    [ "$provider" = github ] || { rm -f "$f"; continue; }
+    if [ "$flagged_id" != "$id" ]; then
+      log "selfheal: dropping poison flag for $c (container replaced since detection)"
+      rm -f "$f"; continue
+    fi
+    healf="$RUNDIR/poison-healed.$c"; last=0
+    [ -f "$healf" ] && read -r last < "$healf"
+    case "$last" in ''|*[!0-9]*) last=0 ;; esac
+    now="$(date +%s)"
+    if [ $((now - last)) -lt "$POISON_HEAL_MIN_INTERVAL" ]; then
+      log "selfheal: $c flagged again after a recent buildkit reset; waiting out the per-slot bound"
+      continue
+    fi
+    if runner_busy "$c"; then
+      log "selfheal: $c is build-poisoned but busy; deferring its buildkit reset"
+      continue
+    fi
+    root="$(crf_safe_cache_root)" \
+      || { err "selfheal: refusing buildkit reset under unsafe CACHE_ROOT '$CACHE_ROOT'"; return 1; }
+    # Stamp the ATTEMPT before acting: whatever fails below, this slot cannot
+    # be stop/start-cycled more than once per bound interval.
+    echo "$now" > "$healf"
+    log "selfheal: $c is build-poisoned (dangling buildkit lease) -> stop, clear buildkit metadata, restart"
+    provider_stop_owned_runner "$c" "$id" "$provider" \
+      || { err "selfheal: could not stop $c for its buildkit reset"; failed=1; continue; }
+    if rm -rf "$root/docker/$c/buildkit" 2>/dev/null; then
+      rm -f "$f"
+    else
+      err "selfheal: could not clear $root/docker/$c/buildkit; restarting $c unrepaired"
+      failed=1
+    fi
+    if docker start "$id" >/dev/null 2>&1; then
+      log "selfheal: $c restarted with fresh buildkit metadata (image/layer cache preserved)"
+    else
+      # A slot left stopped is not lost capacity for long: the reaper removes
+      # it and the floor refills it with a freshly registered runner.
+      err "selfheal: could not restart $c after its buildkit reset; the reaper will replace it"
+      failed=1
+    fi
+  done
+  return "$failed"
+}
+
 # one autoscaling evaluation: keep AUTOSCALE_MIN_IDLE warm runners, within [MIN,MAX]
 autoscale_tick() {
   [ "$AUTOSCALE" = "true" ] || return 0
@@ -550,6 +631,11 @@ autoscale_tick() {
   else
     echo 0 > "$statef"
   fi
+  # Self-heal build-poisoned slots after the scale math: healing stop/starts an
+  # idle container inside the tick, which would otherwise perturb the idle/busy
+  # counts above. Non-fatal so a failed repair never blocks reconciliation.
+  heal_poisoned_runners \
+    || err "autoscale: one or more build-poisoned runners could not be repaired this tick"
   # Continuous safety net behind the Apply-triggered drain: migrate one runner still on a
   # previous baked config onto the current one (idle only). Also the path that eventually
   # picks up a direct cfg edit, or a runner whose job outlasted the Apply drain timeout.

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -35,6 +35,7 @@ bash tests/provider-contract.sh
 bash tests/exec-csrf.sh
 bash tests/log-redaction.sh
 bash tests/provider-mocks.sh
+bash tests/lease-selfheal.sh
 bash tests/ownership-safety.sh
 bash tests/resource-ownership.sh
 bash tests/gitlab-policy.sh

--- a/tests/lease-selfheal.sh
+++ b/tests/lease-selfheal.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Build-poison self-heal: the GitHub scan must flag exactly the slots whose
+# failed jobs carry the dangling-lease signature, download each job log at most
+# once, and the healer must repair only an idle, still-current flagged slot —
+# stop, clear ONLY buildkit/ from its DinD root, restart — bounded to one
+# attempt per slot per interval, never touching a busy slot.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export CRF_CFGDIR="$tmp/config"
+export CRF_RUNDIR="$tmp/run"
+export CRF_SOURCE_ONLY=1
+export CRF_POISON_SCAN_INTERVAL=0
+export CRF_POISON_SCAN_LOOKBACK=1800
+export CRF_POISON_HEAL_MIN_INTERVAL=3600
+mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+# shellcheck source=/dev/null
+source src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+
+fail() { printf 'LEASE SELFHEAL FAIL: %s\n' "$*" >&2; exit 1; }
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+ACCESS_TOKEN='github_pat_selfheal_secret'
+GH_REPOS='example/one'
+DIND=true
+CACHE_ROOT="$tmp/cache"
+RID2="$(printf '2%.0s' $(seq 64))"
+RID3="$(printf '3%.0s' $(seq 64))"
+host() { printf 'mockhost\n'; }
+# The cache-root guard has its own dedicated coverage in safe-paths.sh; here it
+# must resolve to the sandbox so the heal's rm -rf can be observed for real.
+crf_safe_cache_root() { printf '%s' "$CACHE_ROOT"; }
+
+# Runner slot 2 (poisoned) and slot 3 (healthy) exist and are idle by default.
+CRF_TEST_BUSY=0
+DOCKER_LOG="$tmp/docker.log"; : > "$DOCKER_LOG"
+docker() {
+  printf 'docker %s\n' "$*" >> "$DOCKER_LOG"
+  local last="${*: -1}"
+  case "$1" in
+    inspect)
+      local fmt="$3"
+      case "$last" in
+        ci-runner-2|"$RID2") slot=2; rid="$RID2" ;;
+        ci-runner-3|"$RID3") slot=3; rid="$RID3" ;;
+        *) return 1 ;;
+      esac
+      case "$fmt" in
+        *'.Id}}'*) printf '%s|true|github|runner|%s|gen123|/ci-runner-%s\n' "$rid" "$slot" "$slot" ;;
+        *provider*) printf 'github\n' ;;
+        *'.State.Status'*) printf 'running\n' ;;
+        *) printf '\n' ;;
+      esac ;;
+    exec)
+      [ "$CRF_TEST_BUSY" = 1 ] && printf 'busy\n' || printf 'idle\n' ;;
+    logs) printf 'Listening for Jobs\n' ;;
+    stop|start) return 0 ;;
+    *) return 0 ;;
+  esac
+}
+
+# One failed run (900001) whose jobs: 700001 failed on mockhost-ci-runner-2
+# (log carries the signature), 700002 failed on a GitHub-hosted runner, and
+# 700003 SUCCEEDED on mockhost-ci-runner-3 with a step whose nested conclusion
+# is "failure" — the parser must keep the job-level conclusion, not a step's.
+GH_API_LOG="$tmp/gh-api.log"; : > "$GH_API_LOG"
+gh_api() {
+  printf '%s %s\n' "$1" "$2" >> "$GH_API_LOG"
+  case "$2" in
+    /repos/example/one/actions/runs\?status=failure*)
+      cat <<'EOF'
+{
+  "total_count": 1,
+  "workflow_runs": [
+    {
+      "id": 900001,
+      "name": "CI",
+      "check_suite_id": 111222333,
+      "head_branch": "feat/x",
+      "repository": {
+        "id": 4242,
+        "name": "one"
+      }
+    }
+  ]
+}
+EOF
+      ;;
+    /repos/example/one/actions/runs/900001/jobs*)
+      cat <<'EOF'
+{
+  "total_count": 3,
+  "jobs": [
+    {
+      "id": 700001,
+      "run_id": 900001,
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {
+          "name": "build",
+          "conclusion": "failure"
+        }
+      ],
+      "runner_id": 11,
+      "runner_name": "mockhost-ci-runner-2"
+    },
+    {
+      "id": 700002,
+      "run_id": 900001,
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [],
+      "runner_id": 12,
+      "runner_name": "GitHub Actions 42"
+    },
+    {
+      "id": 700003,
+      "run_id": 900001,
+      "status": "completed",
+      "conclusion": "success",
+      "steps": [
+        {
+          "name": "flaky step that was retried",
+          "conclusion": "failure"
+        }
+      ],
+      "runner_id": 13,
+      "runner_name": "mockhost-ci-runner-3"
+    }
+  ]
+}
+EOF
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# Job-log transport: only job 700001's log carries the real incident signature.
+CURL_LOG="$tmp/curl.log"; : > "$CURL_LOG"
+curl() {
+  printf '%s\n' "$*" >> "$CURL_LOG"
+  cat >/dev/null   # consume the stdin curl config carrying the PAT
+  case "$*" in
+    */jobs/700001/logs*)
+      printf '2026-08-16T20:57:43.6390511Z #13 ERROR: lease "idf11ya2iiot5bqwvr7qojagq": not found\n'
+      printf '2026-08-16T20:57:43.6402537Z ERROR: failed to build: failed to solve: lease "idf11ya2iiot5bqwvr7qojagq": not found\n' ;;
+    *) printf 'ordinary failing job log without the signature\n' ;;
+  esac
+}
+
+# ── Detection ────────────────────────────────────────────────────────────────
+github_build_poison_scan || fail "scan returned non-zero on the fixture"
+[ -f "$CRF_RUNDIR/poison-pending.ci-runner-2" ] || fail "signature job did not flag ci-runner-2"
+[ "$(cat "$CRF_RUNDIR/poison-pending.ci-runner-2")" = "$RID2" ] \
+  || fail "poison flag does not carry the slot's immutable container ID"
+[ ! -e "$CRF_RUNDIR/poison-pending.ci-runner-3" ] \
+  || fail "a succeeded job (with a failed step) flagged ci-runner-3"
+grep -qx 700001 "$CRF_RUNDIR/poison-scan.seen" || fail "seen cache is missing the scanned job"
+if grep -q 700003 "$CURL_LOG"; then fail "log of a succeeded job was downloaded"; fi
+if grep -qF "$ACCESS_TOKEN" "$CURL_LOG"; then fail "PAT leaked into the log-download curl argv"; fi
+logs_before="$(grep -c 'jobs/70000' "$CURL_LOG" || true)"
+POISON_SCAN_INTERVAL=0 github_build_poison_scan || fail "rescan returned non-zero"
+logs_after="$(grep -c 'jobs/70000' "$CURL_LOG" || true)"
+[ "$logs_before" = "$logs_after" ] || fail "a rescan re-downloaded an already-seen job log"
+
+# ── Heal defers while the slot is busy ───────────────────────────────────────
+POISON_SCAN_INTERVAL=99999   # keep the embedded scan quiet during heal phases
+mkdir -p "$CACHE_ROOT/docker/ci-runner-2/buildkit" "$CACHE_ROOT/docker/ci-runner-2/image" \
+         "$CACHE_ROOT/docker/ci-runner-2/overlay2"
+touch "$CACHE_ROOT/docker/ci-runner-2/buildkit/metadata_v2.db"
+CRF_TEST_BUSY=1
+heal_poisoned_runners || fail "heal returned non-zero while deferring a busy slot"
+[ -f "$CRF_RUNDIR/poison-pending.ci-runner-2" ] || fail "busy slot lost its poison flag"
+if grep -q "docker stop" "$DOCKER_LOG"; then fail "healer stopped a busy slot"; fi
+[ -d "$CACHE_ROOT/docker/ci-runner-2/buildkit" ] || fail "busy slot's buildkit store was cleared"
+
+# ── Heal repairs the idle slot: stop, clear only buildkit/, start ────────────
+CRF_TEST_BUSY=0
+heal_poisoned_runners || fail "heal returned non-zero repairing an idle slot"
+grep -q "docker stop.*$RID2" "$DOCKER_LOG" || fail "healer did not stop the poisoned container by immutable ID"
+grep -q "docker start $RID2" "$DOCKER_LOG" || fail "healer did not restart the poisoned container"
+[ ! -d "$CACHE_ROOT/docker/ci-runner-2/buildkit" ] || fail "buildkit store survived the heal"
+[ -d "$CACHE_ROOT/docker/ci-runner-2/image" ] || fail "heal deleted the warm image cache"
+[ -d "$CACHE_ROOT/docker/ci-runner-2/overlay2" ] || fail "heal deleted the layer store"
+[ ! -e "$CRF_RUNDIR/poison-pending.ci-runner-2" ] || fail "healed slot kept its poison flag"
+[ -f "$CRF_RUNDIR/poison-healed.ci-runner-2" ] || fail "heal did not stamp its attempt"
+
+# ── The per-slot bound blocks an immediate second reset ──────────────────────
+echo "$RID2" > "$CRF_RUNDIR/poison-pending.ci-runner-2"
+stops_before="$(grep -c 'docker stop' "$DOCKER_LOG" || true)"
+heal_poisoned_runners || fail "heal returned non-zero while enforcing the per-slot bound"
+stops_after="$(grep -c 'docker stop' "$DOCKER_LOG" || true)"
+[ "$stops_before" = "$stops_after" ] || fail "per-slot bound did not prevent a second stop within the interval"
+[ -f "$CRF_RUNDIR/poison-pending.ci-runner-2" ] || fail "bounded slot lost its poison flag"
+rm -f "$CRF_RUNDIR/poison-pending.ci-runner-2"
+
+# ── A flag for a replaced container is discarded untouched ───────────────────
+echo "$(printf '9%.0s' $(seq 64))" > "$CRF_RUNDIR/poison-pending.ci-runner-3"
+stops_before="$(grep -c 'docker stop' "$DOCKER_LOG" || true)"
+heal_poisoned_runners || fail "heal returned non-zero discarding a stale flag"
+stops_after="$(grep -c 'docker stop' "$DOCKER_LOG" || true)"
+[ "$stops_before" = "$stops_after" ] || fail "healer stopped a container whose flag no longer matches it"
+[ ! -e "$CRF_RUNDIR/poison-pending.ci-runner-3" ] || fail "stale flag for a replaced container survived"
+
+echo "lease-selfheal checks passed"


### PR DESCRIPTION
## Why

Each runner's nested DinD `/var/lib/docker` is a persistent host bind mount that survives recycles by design (warm caches). When the inner dockerd crashes mid-build, its buildkit store can be left with dangling lease references: **every subsequent build on that slot fails** with

```
ERROR: failed to build: failed to solve: lease "idf11ya2iiot5bqwvr7qojagq": not found
```

while the runner stays online, registered, and Docker-healthy — so it keeps taking (and failing) jobs. `reap_dead_runners` only sees dead containers and lost registrations, so this poisoning was invisible to the farm. On 2026-08-16, Titan-ci-runner-2 poisoned every `build-pr-prod` job it picked up (unraid/core failed twice this way) until a manual *stop → clear buildkit → start*.

## Detection: why job logs

Empirically (docker 29.6.2 on the live fleet), no host-side channel carries the error:

- the `dind-logs` bind mounts are **empty** — the runner image's supervised daemon logs elsewhere;
- the nested dockerd **does not log buildkit solve failures** (verified: a failing build returns the error to the client while `docker.log` records nothing);
- the runner's `_diag` keeps no step output — job logs exist only on GitHub.

So `github_build_poison_scan` reads what the jobs themselves saw: recent failed workflow runs per configured repo → their jobs that ran on **this host's** slots → each such job's log (downloaded once ever, seen-cache), flagging the slot when the log matches the lease signature. Rate-bounded to one runs-listing per repo per 5 minutes; the PAT goes through curl config stdin like `gh_api`.

## Recovery: conservative by design

`heal_poisoned_runners` runs from the autoscale tick after the scale math (fleet lock already held), mirroring `reap_dead_runners` / `reconcile_stale_runners` structure:

- only an **idle** flagged slot is touched (busy slots defer; the flag persists);
- a flag is discarded if the container was **replaced** since detection (replacements start with a fresh DinD root);
- at most **one reset attempt per slot per hour**, stamped before acting so no failure path can stop/start-cycle a slot faster;
- repair = stop container → `rm -rf <root>/docker/<slot>/buildkit` **only** (warm image/layer caches survive; `crf_safe_cache_root` guard as in `github_remove_runner`) → `docker start` the same container (registration persists across stop/start);
- every step logs to the autoscale log; if the restart fails, the reaper replaces the slot next tick.

GitLab is stubbed out (`gitlab_build_poison_scan`): the failure mode has only been observed on GitHub DinD slots and GitLab job logs live outside this scan.

## Validation

- New mocked test `tests/lease-selfheal.sh` (wired into `tests/check.sh`): flags exactly the signature job, keeps job-level vs step-level conclusions apart, downloads each log once, defers busy slots, clears only `buildkit/`, enforces the hourly bound, and drops stale flags.
- Full `tests/run-linux-checks.sh` suite passes.
- Live run on titan against the real API (24h lookback): 7 failed local jobs attributed, **zero false positives**; the real incident job log (95225805734) trips the signature, a real flaky-test failure log does not.
- Buildkit corruption anatomy confirmed in a sandbox DinD container (prod's `storage-driver: overlay2` layout) before choosing the detection channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and self-healing for corrupted BuildKit state on idle GitHub DinD runners.
  * Repairs restart affected runners and clear only damaged BuildKit metadata, preserving image and layer caches.
  * Records repair activity in autoscaling logs and limits repairs to once per runner per hour.
  * GitLab runners remain unaffected by this scanning behavior.

* **Bug Fixes**
  * Prevents failed builds caused by missing or dangling BuildKit leases from recurring on eligible runners.

* **Tests**
  * Added end-to-end coverage for detection, safe repair behavior, scheduling limits, and credential protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->