### PR TITLE
feat: add provider-neutral runner pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ provider's credentials and runtime.
 | Warm shared caches | Reuse npm, yarn, pnpm, Playwright, Cargo, sccache, or custom cache directories across jobs. |
 | Slot-scoped Docker-in-Docker | Give each runner slot a private privileged Docker daemon without exposing Unraid's existing Docker socket by default; privileged DinD is still capable of host compromise. |
 | Bring your own job image | Pull a remote image or edit and build a provider-specific starter image in the plugin. |
+| Named runner pools | Route jobs to purpose-built pools with independent fixed capacity, labels/tags, CPU, memory, and images. |
 | Fleet controls and telemetry | Validate, start, stop, scale, recycle, and inspect runner/job state from the Unraid webGUI. |
 | Optional autoscaling | Keep a warm idle buffer between configured minimum and maximum runner counts. |
 
@@ -45,6 +46,36 @@ it does not modify or fork GitLab Runner itself. Each slot contains:
 The reusable GitLab `glrt-` token identifies the runner configuration. Each
 manager retains its own system ID, so recycling a slot does not create a new
 shared runner configuration in GitLab.
+
+## Named pools and per-pool images
+
+Set **Runner layout** to **Named pools** when one host should offer different
+runner capabilities, for example a normal build pool and a QA-VM client pool.
+Each pool record declares a stable pool ID, routing label, additional labels,
+fixed capacity, resource limits, and either the built-in image or a registry
+image. Containers are named `ci-runner-<pool>-<index>` and carry the pool as a
+provider-neutral ownership label.
+
+GitHub pools require organization scope. Their routing and additional labels
+are passed to the GitHub runner directly. GitLab pools require a separate
+runner configuration and modern `glrt-` authentication token per pool; create
+that runner in GitLab with tags matching the pool's labels, then save the token
+with the pool ID in Settings. This keeps GitLab's server-owned tag routing
+authoritative instead of pretending local `config.toml` can change it.
+
+The V3 record format is:
+
+```text
+v3|id|routing-label|additional-labels|fixed|min|max|idle|cpus|memory|image
+```
+
+Records are separated by semicolons. `cpus` and `memory` may be `inherit`;
+`image` may be `builtin` or a full registry reference. The current classic-pool
+implementation uses `fixed` capacity and deliberately rejects global autoscale
+and global image auto-update in pool mode. `min`, `max`, and `idle` are retained
+in the versioned contract so adding per-pool autoscaling later does not require
+reformatting every pool. Saving pool changes does not interrupt jobs; use Fleet
+**Restart** when ready to apply exact membership, images, and limits.
 
 ## Install
 

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/README.md
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/README.md
@@ -5,6 +5,12 @@ resource-capped slots, warm package/image caches, Docker-in-Docker, and optional
 autoscaling. One provider owns the farm at a time; GitHub remains the default so
 existing installations keep their behavior.
 
+Named pools work with both providers. Each pool can use its own fixed capacity,
+labels or tags, CPU, memory, and runner/job image. GitHub pools require
+organization scope. GitLab pools require a pool-specific `glrt-` runner token
+whose GitLab runner configuration owns the matching tags. Pool edits take
+effect on Fleet Restart, so Settings Apply does not interrupt active jobs.
+
 For GitLab, create the runner and its tags/protection/scope in GitLab, then save
 the reusable `glrt-` runner authentication token in the plugin. A separate
 `read_api` token is optional and is used only for advisory queue/recent-job

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/RunnerFarmSettings.page
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/RunnerFarmSettings.page
@@ -29,6 +29,7 @@ $defaults = [
   'GITLAB_SHUTDOWN_TIMEOUT'=>'7200',
   'GITLAB_ALLOWED_IMAGES'=>'', 'GITLAB_ALLOWED_SERVICES'=>'', 'GITLAB_PULL_POLICY'=>'auto', 'GITLAB_SHM_SIZE'=>'0',
   'RUNNER_GROUP'=>'', 'RUNNER_COUNT'=>'4', 'RUNNER_LABELS'=>'self-hosted,unraid,build',
+  'RUNNER_MODE'=>'single', 'RUNNER_POOLS'=>'',
   'RUNNER_CPUS'=>'', 'RUNNER_MEMORY'=>'16g', 'EPHEMERAL'=>'false', 'RUN_AS_ROOT'=>'false',
   'IMAGE_SOURCE'=>'builtin', 'IMAGE'=>'', 'REGISTRY_SERVER'=>'', 'REGISTRY_USERNAME'=>'',
   'CACHE_ROOT'=>'/mnt/cache/github-runner', 'WORK_TMPFS_SIZE'=>'8g',
@@ -259,6 +260,30 @@ _(Monitored projects)_:
 :end
 
 ### Runners
+
+_(Runner layout)_:
+: <select name="RUNNER_MODE" id="crf-runner-mode">
+  <option value="single" <?=crf_sel($cfg,'RUNNER_MODE','single','single')?>>Single fleet</option>
+  <option value="pools" <?=crf_sel($cfg,'RUNNER_MODE','pools','single')?>>Named pools</option>
+  </select>
+
+:crf_runner_mode_plug:
+> Single fleet preserves the existing GitHub and GitLab behavior. Named pools let workflows select a purpose-built runner image by routing label. GitHub pools require organization scope. GitLab pools require one pool-specific runner authentication token per pool so routing tags remain distinct.
+:end
+
+_(Named pool records)_:
+: <input type="text" name="RUNNER_POOLS" id="crf-runner-pools" value="<?=crf_g($cfg,'RUNNER_POOLS','')?>" placeholder="v3|build|ci-build|linux,x64|3|0|3|0|inherit|inherit|builtin;v3|qa-vm|qa-vm-client|linux,x64|2|0|2|0|2|8g|ghcr.io/unraid/qa-vm-client:latest">
+
+:crf_runner_pools_plug:
+> Named-pool mode only. Enter semicolon-separated V3 records: <code>v3|id|routing-label|additional-labels|fixed|min|max|idle|cpus|memory|image</code>. The current classic-pool implementation uses <code>fixed</code>; min/max/idle are retained in the bounded contract for future per-pool autoscaling. Use <code>inherit</code> for global CPU or memory, <code>builtin</code> for the locally built image, or a full registry image reference. Pool mode requires GitHub organization scope and disables global autoscaling and global image auto-update.
+:end
+
+_(GitLab pool token)_:
+: <input type="text" id="crf-gitlab-pool-id" placeholder="pool id, e.g. qa-vm"> <input type="password" id="crf-gitlab-pool-token" autocomplete="new-password" placeholder="pool-specific glrt- token"> <uui-button type="button" size="xs" onclick="crfSetGitLabPoolToken()">Save</uui-button> <uui-button type="button" variant="secondary" size="xs" onclick="crfClearGitLabPoolToken()">Clear</uui-button>
+
+:crf_gitlab_pool_token_plug:
+> GitLab named-pool mode only. Create one GitLab runner configuration per pool with tags matching that pool's routing/additional labels, then save its modern <code>glrt-</code> authentication token here. Tokens are stored as mode-0600 files and never in the pool record. Stop the fleet before clearing a pool token.
+:end
 
 _(Concurrent runners)_:
 : <input type="number" name="RUNNER_COUNT" min="1" max="20" value="<?=crf_g($cfg,'RUNNER_COUNT','4')?>">
@@ -581,6 +606,16 @@ function crfDoClearGitLabRunnerToken(confirmed){
   }).catch(e=>console.error('ci-runner-farm clear-gitlab-runner-token:',e));
 }
 function crfClearGitLabRunnerToken(){crfDoClearGitLabRunnerToken(false);}
+function crfSetGitLabPoolToken(){
+  const p=document.getElementById('crf-gitlab-pool-id').value.trim(), el=document.getElementById('crf-gitlab-pool-token'), t=el.value;
+  if(!p||!t){crfToast('Enter a pool id and token');return;}
+  crfPost({action:'set-gitlab-pool-token',pool:p,token:t}).then(o=>{if(!crfCredentialOk(o,'Pool token rejected'))return;el.value='';crfCredentialDone(o,'GitLab pool token saved for '+p);}).catch(e=>{crfToast('Pool token save failed');console.error('ci-runner-farm set-gitlab-pool-token:',e);});
+}
+function crfClearGitLabPoolToken(){
+  const p=document.getElementById('crf-gitlab-pool-id').value.trim();
+  if(!p){crfToast('Enter a pool id');return;}
+  crfPost({action:'clear-gitlab-pool-token',pool:p}).then(o=>{if(!crfCredentialOk(o,'Pool token removal failed'))return;crfCredentialDone(o,'GitLab pool token removed for '+p);}).catch(e=>{crfToast('Pool token removal failed');console.error('ci-runner-farm clear-gitlab-pool-token:',e);});
+}
 function crfGitLabApiState(ok){
   document.getElementById('crf-gitlab-api-status').textContent=ok?'GitLab API token configured':'GitLab API token not set (optional)';
   document.getElementById('crf-gitlab-api-ball').className='crf-ball '+(ok?'crf-ball-idle':'');

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/default.cfg
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/default.cfg
@@ -29,6 +29,11 @@ GITLAB_PULL_POLICY="auto"
 GITLAB_SHM_SIZE="0"
 RUNNER_COUNT="4"
 RUNNER_LABELS="self-hosted,unraid,build"
+; Named pools require GitHub organization scope. Each V3 record is:
+; v3|id|routing-label|additional-labels|fixed|min|max|idle|cpus|memory|image
+; Use image=builtin for the locally built image, or an immutable/full registry ref.
+RUNNER_MODE="single"
+RUNNER_POOLS=""
 RUNNER_CPUS=""
 RUNNER_MEMORY="16g"
 CACHE_ROOT="/mnt/cache/github-runner"

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/exec.php
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/exec.php
@@ -56,8 +56,11 @@ $action = is_string($rawAction) && strlen($rawAction) <= 64 ? $rawAction : '';
 // under 4 bytes is too short to substitute without mangling ordinary log text.
 function crf_secret_values($cfgdir) {
   $secrets = [];
-  foreach (['token', 'gitlab-runner-token', 'gitlab-api-token', 'registry-token'] as $name) {
-    $value = @file_get_contents("$cfgdir/$name");
+  $paths = array_map(fn($name) => "$cfgdir/$name", ['token', 'gitlab-runner-token', 'gitlab-api-token', 'registry-token']);
+  $poolTokens = glob("$cfgdir/gitlab-runner-token.*", GLOB_NOSORT);
+  if (is_array($poolTokens)) $paths = array_merge($paths, $poolTokens);
+  foreach ($paths as $path) {
+    $value = @file_get_contents($path);
     // The engine reads these through command substitution, which drops trailing
     // newlines; an opaque registry password's edge spaces are still significant.
     if (is_string($value)) $value = rtrim($value, "\n");
@@ -317,6 +320,36 @@ switch ($action) {
     credential_response('set-gitlab-runner-token', $ok, 'write failed', $reconcile);
     break;
 
+  case 'set-gitlab-pool-token':
+    $pool = $_POST['pool'] ?? '';
+    if (!is_string($pool) || !preg_match('/^[a-z](?:[a-z0-9-]{0,22}[a-z0-9])?$/D', $pool)
+        || in_array($pool, ['default', 'invalid'], true)) {
+      echo json_encode(['ok'=>false,'error'=>'invalid pool id']); break;
+    }
+    $raw = $_POST['token'] ?? '';
+    $tok = '';
+    $validation = gitlab_runner_token_validation($raw, $tok);
+    if (is_array($validation)) {
+      echo json_encode(['ok'=>false, 'error_code'=>$validation['code'], 'error'=>$validation['error']]); break;
+    }
+    $ok = write_secret("$CFGDIR/gitlab-runner-token.$pool", $tok);
+    echo json_encode(['ok'=>$ok,'action'=>'set-gitlab-pool-token','pool'=>$pool,'error'=>$ok ? null : 'write failed']);
+    break;
+
+  case 'clear-gitlab-pool-token':
+    $pool = $_POST['pool'] ?? '';
+    if (!is_string($pool) || !preg_match('/^[a-z](?:[a-z0-9-]{0,22}[a-z0-9])?$/D', $pool)
+        || in_array($pool, ['default', 'invalid'], true)) {
+      echo json_encode(['ok'=>false,'error'=>'invalid pool id']); break;
+    }
+    [$active, $activeRc] = run_json('docker ps -a --filter ' . escapeshellarg('label=net.unraid.ci-runner-farm.pool=' . $pool) . " --format '{{.Names}}'");
+    if ($activeRc !== 0) { echo json_encode(['ok'=>false,'error'=>'could not verify pool usage']); break; }
+    if (trim($active) !== '') { echo json_encode(['ok'=>false,'error'=>'stop the fleet before clearing a pool token']); break; }
+    $path = "$CFGDIR/gitlab-runner-token.$pool";
+    $ok = !file_exists($path) || @unlink($path);
+    echo json_encode(['ok'=>$ok,'action'=>'clear-gitlab-pool-token','pool'=>$pool,'error'=>$ok ? null : 'remove failed']);
+    break;
+
   case 'clear-gitlab-runner-token':
     $active = active_provider($CFGDIR) === 'gitlab';
     $confirmStop = $_POST['confirm_stop'] ?? '';
@@ -465,7 +498,7 @@ switch ($action) {
 
   case 'recycle':
     $n = $_POST['name'] ?? '';
-    if (!is_string($n) || !preg_match('/^ci-runner-[0-9]+$/', $n)) { echo json_encode(['ok'=>false,'error'=>'bad name']); break; }
+    if (!is_string($n) || !preg_match('/^ci-runner-(?:[0-9]+|[a-z][a-z0-9-]{0,23}-[0-9]+)$/', $n)) { echo json_encode(['ok'=>false,'error'=>'bad name']); break; }
     [$out, $rc] = run_json(escapeshellarg($SCRIPT) . ' recycle ' . escapeshellarg($n));
     // cmd_recycle emits progress logs then its {ok,error?} verdict as the final
     // stdout line; pass it through so the specific reason (removed-not-recreated,
@@ -477,7 +510,7 @@ switch ($action) {
   case 'force-forget-gitlab':
     $n = $_POST['name'] ?? '';
     $confirm = $_POST['confirm'] ?? '';
-    if (!is_string($n) || !preg_match('/^ci-runner-[0-9]+$/', $n)) {
+    if (!is_string($n) || !preg_match('/^ci-runner-(?:[0-9]+|[a-z][a-z0-9-]{0,23}-[0-9]+)$/', $n)) {
       echo json_encode(['ok'=>false,'error'=>'bad name']); break;
     }
     // This is the escape hatch for a permanently unreachable GitLab instance
@@ -499,7 +532,7 @@ switch ($action) {
 
   case 'runner-log':
     $n = $_POST['name'] ?? '';
-    if (!is_string($n) || !preg_match('/^ci-runner-[0-9]+$/', $n)) { echo json_encode(['ok'=>false,'error'=>'bad name']); break; }
+    if (!is_string($n) || !preg_match('/^ci-runner-(?:[0-9]+|[a-z][a-z0-9-]{0,23}-[0-9]+)$/', $n)) { echo json_encode(['ok'=>false,'error'=>'bad name']); break; }
     [$out, $rc] = run(escapeshellarg($SCRIPT) . ' logs-tail ' . escapeshellarg($n) . ' 150');
     echo json_encode(['ok' => $rc === 0, 'log' => $out, 'error' => $rc === 0 ? null : 'runner is not an owned managed slot']);
     break;

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -174,6 +174,7 @@ github_build_args() {
     --label "net.unraid.ci-runner-farm.provider=github"
     --label "net.unraid.ci-runner-farm.role=${role}"
     --label "net.unraid.ci-runner-farm.index=${idx}"
+    --label "net.unraid.ci-runner-farm.pool=${CRF_POOL_ID:-default}"
     --label "net.unraid.ci-runner-farm.confgen=$(crf_confgen)"
     -e RUNNER_NAME="$(host)-${name}"
     -e LABELS="$RUNNER_LABELS"
@@ -246,7 +247,7 @@ github_build_args() {
 github_start_one() {
   local idx="$1" name="$2" rc
   github_build_args "$idx" "$name" || { err "runner $name not started (registration-token error)"; return 1; }
-  log "starting $name (cpus=$RUNNER_CPUS mem=$RUNNER_MEMORY scope=$GH_SCOPE)"
+  log "starting $name (pool=${CRF_POOL_ID:-default} cpus=$RUNNER_CPUS mem=$RUNNER_MEMORY scope=$GH_SCOPE image=$(effective_image))"
   docker run "${ARGS[@]}" >/dev/null
   rc=$?
   clear_args_tmpdir

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/gitlab.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/gitlab.sh
@@ -3,8 +3,12 @@
 # Uses persistent official Runner managers plus Docker-executor job containers.
 
 gitlab_token_ready() {
-  printf '%s' "$GITLAB_RUNNER_TOKEN" \
-    | grep -qE '^glrt-[A-Za-z0-9_.-]{10,507}$'
+  local token="$GITLAB_RUNNER_TOKEN" payload
+  case "$token" in glrt-*) ;; *) return 1 ;; esac
+  [ "${#token}" -le 512 ] || return 1
+  payload="${token#glrt-}"
+  [ "${#payload}" -ge 10 ] || return 1
+  case "$payload" in *[!A-Za-z0-9_.-]*) return 1 ;; esac
 }
 gitlab_token_name() { echo "GitLab runner authentication token"; }
 gitlab_builtin_image() { echo "$GITLAB_BUILTIN_IMAGE"; }
@@ -813,6 +817,7 @@ gitlab_build_manager_args() {
     --label "net.unraid.ci-runner-farm.provider=gitlab"
     --label "net.unraid.ci-runner-farm.role=manager"
     --label "net.unraid.ci-runner-farm.index=${idx}"
+    --label "net.unraid.ci-runner-farm.pool=${CRF_POOL_ID:-default}"
     --label "net.unraid.ci-runner-farm.confgen=$(crf_confgen)"
     --label "net.unraid.ci-runner-farm.socket=${sock}"
     # Local process liveness only. A GitLab/network/CA outage must not make a

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -52,6 +52,8 @@ GITLAB_SHM_SIZE="0"                   # job/service /dev/shm size in bytes; 0 = 
 GITLAB_DIND_IMAGE="docker:27-dind"    # private executor daemon; deliberately not user-configurable yet
 RUNNER_COUNT=4
 RUNNER_LABELS="self-hosted,unraid,build"
+RUNNER_MODE="single"                  # single | pools (provider-neutral classic pools)
+RUNNER_POOLS=""                       # semicolon-separated validated V3 pool records
 RUNNER_CPUS=""                        # per-runner CPU cap; empty = uncapped (CFS time-shares fairly)
 RUNNER_MEMORY="16g"                   # per-runner memory cap (kept: memory isn't time-shared like CPU)
 CACHE_ROOT="/mnt/cache/github-runner" # must be a dedicated SUBDIR under a pool/disk, never a bare mount root (see crf_safe_cache_root)
@@ -115,10 +117,14 @@ IMAGE_DRAIN_TIMEOUT="3600"           # max seconds to wait for a busy runner to 
 DASHBOARD_WIDGET_ENABLE="true"       # show the Main->Dashboard status tile (read only by RunnerFarmDashboard.page's Cond)
 # ----------------------------------------------------------------------------
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-pools.sh
+. "$SCRIPT_DIR/runner-pools.sh"
+
 # Allowlist of keys the settings page may set. load_cfg only ever assigns these.
 CFG_KEYS="CI_PROVIDER GH_SCOPE GH_OWNER GH_REPOS RUNNER_GROUP GITLAB_URL GITLAB_RUNNER_IMAGE GITLAB_PROJECTS GITLAB_SHUTDOWN_TIMEOUT \
 GITLAB_ALLOWED_IMAGES GITLAB_ALLOWED_SERVICES GITLAB_PULL_POLICY GITLAB_SHM_SIZE \
-RUNNER_COUNT RUNNER_LABELS \
+RUNNER_COUNT RUNNER_LABELS RUNNER_MODE RUNNER_POOLS \
 RUNNER_CPUS RUNNER_MEMORY CACHE_ROOT WORK_TMPFS_SIZE IMAGE_SOURCE IMAGE EPHEMERAL \
 RUN_AS_ROOT REGISTRY_SERVER REGISTRY_USERNAME CACHE_MOUNTS SHARE_DOCKER_SOCK DIND \
 SHARED_IMAGE_CACHE NETWORK_ISOLATION RUNNER_NETWORK MIRROR_PORT AUTOSCALE AUTOSCALE_MIN \
@@ -165,6 +171,14 @@ load_cfg() {
 
 load_cfg
 [ "$CI_PROVIDER" = "gitlab" ] || CI_PROVIDER="github"
+
+validate_runner_mode() {
+  pool_config_validate "$RUNNER_MODE" "$RUNNER_POOLS" "$GH_SCOPE" "$CI_PROVIDER" || return 1
+  if pool_mode_enabled; then
+    [ "$AUTOSCALE" != true ] || { pool_error "Runner pools currently use each pool's fixed capacity; disable global autoscaling."; return 1; }
+    [ "$IMAGE_AUTOUPDATE" != true ] || { pool_error "Runner pools require explicit image updates per pool; disable global image auto-update."; return 1; }
+  fi
+}
 read_secret_file() {
   [ -f "$1" ] && cat "$1" 2>/dev/null || true
 }
@@ -203,6 +217,7 @@ reload_locked_snapshot() {
   load_cfg
   [ "$CI_PROVIDER" = "gitlab" ] || CI_PROVIDER="github"
   reload_secret_files || { err "could not take a consistent credential/CA snapshot"; return 1; }
+  if command -v pool_base_refresh >/dev/null 2>&1; then pool_base_refresh; fi
 }
 # PID files live on tmpfs (RUNDIR), not flash: they're pure per-boot runtime state,
 # so this both spares the USB stick and means a stale PID can't survive a reboot to
@@ -286,7 +301,7 @@ owned_container_snapshot() {
 
 managed_runner_snapshot() {
   local name="$1" index
-  echo "$name" | grep -qE "^${NAME_PREFIX}-[0-9]+$" \
+  echo "$name" | grep -qE '^ci-runner-([0-9]+|[a-z][a-z0-9-]{0,23}-[0-9]+)$' \
     || { err "unsafe runner slot name: $name"; return 1; }
   index="${name##*-}"
   owned_container_snapshot "$name" "$index" runner
@@ -323,8 +338,87 @@ managed_names() {
   listed="$(docker ps -a --filter "label=${MANAGED_LABEL}" --format '{{.Names}}')" \
     || { err "could not enumerate managed runner containers"; return 1; }
   printf '%s\n' "$listed" \
-    | awk -v prefix="${NAME_PREFIX}-" 'index($0,prefix)==1 && substr($0,length(prefix)+1) ~ /^[0-9]+$/ {print}' \
+    | awk '($0 ~ /^ci-runner-[0-9]+$/ || $0 ~ /^ci-runner-[a-z][a-z0-9-]{0,23}-[0-9]+$/) {print}' \
     | sort -V
+}
+
+runner_pool() {
+  local value
+  if ! pool_mode_enabled; then printf 'default\n'; return 0; fi
+  value="$(docker inspect -f '{{ index .Config.Labels "net.unraid.ci-runner-farm.pool" }}' "$1" 2>/dev/null)" || return 1
+  [ "$value" = '<no value>' ] && value=""
+  printf '%s\n' "${value:-default}"
+}
+
+BASE_NAME_PREFIX="$NAME_PREFIX"
+BASE_RUNNER_LABELS="$RUNNER_LABELS"
+BASE_RUNNER_CPUS="$RUNNER_CPUS"
+BASE_RUNNER_MEMORY="$RUNNER_MEMORY"
+BASE_IMAGE_SOURCE="$IMAGE_SOURCE"
+BASE_IMAGE="$IMAGE"
+BASE_GITLAB_RUNNER_TOKEN="$GITLAB_RUNNER_TOKEN"
+
+pool_base_refresh() {
+  BASE_NAME_PREFIX="ci-runner"
+  BASE_RUNNER_LABELS="$RUNNER_LABELS"
+  BASE_RUNNER_CPUS="$RUNNER_CPUS"
+  BASE_RUNNER_MEMORY="$RUNNER_MEMORY"
+  BASE_IMAGE_SOURCE="$IMAGE_SOURCE"
+  BASE_IMAGE="$IMAGE"
+  BASE_GITLAB_RUNNER_TOKEN="$GITLAB_RUNNER_TOKEN"
+}
+
+pool_activate() {
+  local pool="${1:-default}" image cpus memory
+  CRF_POOL_ID="$pool"
+  NAME_PREFIX="$BASE_NAME_PREFIX"
+  RUNNER_LABELS="$BASE_RUNNER_LABELS"
+  RUNNER_CPUS="$BASE_RUNNER_CPUS"
+  RUNNER_MEMORY="$BASE_RUNNER_MEMORY"
+  IMAGE_SOURCE="$BASE_IMAGE_SOURCE"
+  IMAGE="$BASE_IMAGE"
+  GITLAB_RUNNER_TOKEN="$BASE_GITLAB_RUNNER_TOKEN"
+  [ "$pool" = default ] && return 0
+  pool_mode_enabled || return 1
+  RUNNER_LABELS="$(pool_effective_labels "$pool")" || return 1
+  cpus="$(pool_cpus "$pool")" || return 1
+  memory="$(pool_memory "$pool")" || return 1
+  image="$(pool_image "$pool")" || return 1
+  [ "$cpus" = inherit ] || RUNNER_CPUS="$cpus"
+  [ "$memory" = inherit ] || RUNNER_MEMORY="$memory"
+  if [ "$image" = builtin ]; then
+    IMAGE_SOURCE=builtin
+    IMAGE=""
+  else
+    IMAGE_SOURCE=remote
+    IMAGE="$image"
+  fi
+  NAME_PREFIX="${BASE_NAME_PREFIX}-${pool}"
+  if [ "$CI_PROVIDER" = gitlab ]; then
+    local token_file="${CFGDIR}/gitlab-runner-token.${pool}"
+    [ -f "$token_file" ] || { err "GitLab pool $pool has no pool-specific runner token"; return 1; }
+    GITLAB_RUNNER_TOKEN="$(read_secret_file "$token_file")"
+    gitlab_token_ready \
+      || { err "GitLab pool $pool has an invalid runner token"; return 1; }
+  fi
+}
+
+expected_runner_confgen() {
+  local pool
+  pool="$(runner_pool "$1")" || return 1
+  ( pool_activate "$pool" && crf_confgen )
+}
+
+pool_tokens_ready() {
+  local rec pool
+  if ! pool_mode_enabled || [ "$CI_PROVIDER" != gitlab ]; then
+    provider_token_ready
+    return
+  fi
+  while IFS= read -r rec; do
+    pool="$(printf '%s' "$rec" | cut -d'|' -f2)"
+    ( pool_activate "$pool" && gitlab_token_ready ) || return 1
+  done < <(pool_records)
 }
 
 owned_managed_names() {
@@ -374,13 +468,12 @@ runner_confgen() { docker inspect -f '{{ index .Config.Labels "net.unraid.ci-run
 # visible to the drain instead of letting reconciliation advance through the fleet.
 count_stale_runners() {
   local cur c names snapshot id provider role index gen n=0
-  cur="$(crf_confgen)" || { err "could not calculate the current runner configuration"; return 1; }
-  [ -n "$cur" ] || { err "current runner configuration fingerprint is empty"; return 1; }
   names="$(managed_names)" || return 1
   for c in $names; do
     [ -n "$c" ] || continue
     snapshot="$(managed_runner_snapshot "$c")" || return 1
     IFS='|' read -r id provider role index gen <<< "$snapshot"
+    cur="$(expected_runner_confgen "$c")" || { n=$((n+1)); continue; }
     [ "$gen" = "$cur" ] || n=$((n+1))
   done
   echo "$n"
@@ -1495,15 +1588,39 @@ start_one() {
   provider_call start_one "$idx" "$name"
 }
 
+start_configured_capacity() {
+  local startn="$RUNNER_COUNT" i rec pool failed=0
+  if pool_mode_enabled; then
+    while IFS= read -r rec; do
+      pool="$(printf '%s' "$rec" | cut -d'|' -f2)"
+      pool_activate "$pool" || { failed=1; continue; }
+      startn="$(pool_fixed "$pool")" || { failed=1; continue; }
+      if [ "$IMAGE_SOURCE" = remote ] && provider_remote_image_host_pull_required; then
+        registry_login || { failed=1; continue; }
+        provider_prepare_remote_image "$(effective_image)" >/dev/null \
+          || { err "could not prepare image $(effective_image) for pool $pool"; failed=1; continue; }
+      fi
+      for i in $(seq 1 "$startn"); do start_one "$i" || failed=1; done
+    done < <(pool_records)
+  else
+    [ "$AUTOSCALE" = true ] && startn="$AUTOSCALE_MIN"
+    pool_activate default
+    for i in $(seq 1 "$startn"); do start_one "$i" || failed=1; done
+  fi
+  return "$failed"
+}
+
 # Recreate a stopped managed runner when its provider/config requires it. GitHub
 # needs a fresh short-lived registration token; a stale/provider-switched GitLab
 # manager must unregister its old persisted identity before replacement.
 recreate_stopped_runner() {
-  local c="$1" supplied_snapshot="${2:-}" snapshot id provider role idx gen
+  local c="$1" supplied_snapshot="${2:-}" snapshot id provider role idx gen pool
   snapshot="$supplied_snapshot"
   [ -n "$snapshot" ] || snapshot="$(managed_runner_snapshot "$c")" || return 1
   IFS='|' read -r id provider role idx gen <<< "$snapshot"
+  pool="$(runner_pool "$c")" || return 1
   remove_runner "$c" false "$id" "$provider" || return 1
+  pool_activate "$pool" || { err "runner $c belongs to unknown pool $pool"; return 1; }
   start_one "$idx"
 }
 
@@ -1621,12 +1738,12 @@ reconcile_stale_runners() {
   # token that was cleared/rotated while it waited.
   reload_locked_snapshot || return 1
   local cur c gen names snapshot id provider role index
-  cur="$(crf_confgen)" || return 1
   names="$(managed_names)" || return 1
   for c in $names; do
     [ -n "$c" ] || continue
     snapshot="$(managed_runner_snapshot "$c")" || return 1
     IFS='|' read -r id provider role index gen <<< "$snapshot"
+    cur="$(expected_runner_confgen "$c")" || return 1
     [ "$gen" = "$cur" ] && continue                  # already on the current config
     # Migrate idle runners; also migrate error-state ones (a wedged runner will never
     # reach idle on its own, so leaving it would strand it on the old config forever).
@@ -1719,6 +1836,11 @@ cmd_reconcile_drain() {
 # slow). Safe no-op when nothing is stale (the drain exits on the first count). Output
 # shows in the Apply progress frame — human text, not JSON.
 cmd_reconcile_config() {
+  validate_runner_mode || { err "cannot reconcile: $POOL_CONFIG_ERROR"; return 1; }
+  if pool_mode_enabled; then
+    echo "Named-pool configuration saved. Restart the fleet to apply exact pool membership, images, labels/tags, and resource limits; running jobs are not interrupted by this Apply action."
+    return 0
+  fi
   local managed
   managed="$(managed_names)" \
     || { err "cannot reconcile: could not enumerate the managed fleet"; return 1; }
@@ -1752,9 +1874,10 @@ reconcile_stop() {
 }
 
 cmd_start() {
+  validate_runner_mode || { err "$POOL_CONFIG_ERROR"; return 1; }
   local start_failed=0
-  provider_token_ready || { err "no valid $(provider_token_name) configured (set it in the web UI). Use 'validate' to test provisioning without one."; return 1; }
-  [ "$CI_PROVIDER" = "gitlab" ] && gitlab_validate_settings || { [ "$CI_PROVIDER" != "gitlab" ] || return 1; }
+  pool_tokens_ready || { err "one or more required $(provider_token_name) credentials are missing or invalid"; return 1; }
+  if [ "$CI_PROVIDER" = gitlab ] && ! pool_mode_enabled; then gitlab_validate_settings || return 1; fi
   rm -f "$SECURITY_CACHE"                       # force a fresh public-repo check on an explicit Start
   local secp; secp="$(public_repo_problem)"
   [ -n "$secp" ] && err "SECURITY: $secp"       # warn, do not block (operator's call)
@@ -1801,10 +1924,7 @@ cmd_start() {
   # across a Docker/array restart instead of collapsing straight to MIN.
   reap_dead_runners || start_failed=1
   # with autoscaling on, start the floor (MIN) and let the daemon grow to demand
-  local startn="$RUNNER_COUNT"
-  [ "$AUTOSCALE" = "true" ] && startn="$AUTOSCALE_MIN"
-  local i
-  for i in $(seq 1 "$startn"); do start_one "$i" || start_failed=1; done
+  start_configured_capacity || start_failed=1
   local final_count
   final_count="$(current_count)" || start_failed=1
   log "fleet up: ${final_count:-unknown} runner(s)"
@@ -2275,6 +2395,7 @@ cmd_credential_clear_registry_token() {
 
 cmd_scale() {
   local target="$1" failed=0
+  pool_mode_enabled && { err "manual scale is not available in named-pool mode; edit each pool's fixed capacity and restart the fleet"; return 1; }
   # Server-side validate + clamp. The form's max="20" is presentation-only, so a
   # crafted POST (n=99999) would otherwise drive an unbounded provisioning loop —
   # a container + a minted GitHub registration token per iteration (host / API
@@ -2351,7 +2472,9 @@ cmd_status() {
     local st; st="$(docker inspect -f '{{.State.Status}}' "$c" 2>/dev/null)"
     local cpus mem; cpus="$(docker inspect -f '{{.HostConfig.NanoCpus}}' "$c" 2>/dev/null)"
     mem="$(docker inspect -f '{{.HostConfig.Memory}}' "$c" 2>/dev/null)"
-    printf "%-22s %-10s %-8s %-10s %s\n" "$c" "$st" "$(runner_state "$c")" "$((cpus/1000000000))c/$((mem/1024/1024/1024))g" "$(effective_image)"
+    local image
+    image="$(docker inspect -f '{{.Config.Image}}' "$c" 2>/dev/null)"
+    printf "%-22s %-10s %-8s %-10s %s\n" "$c" "$st" "$(runner_state "$c")" "$((cpus/1000000000))c/$((mem/1024/1024/1024))g" "$image"
   done
 }
 
@@ -2606,14 +2729,18 @@ cmd_queued_json() {
 cmd_recycle() {
   # Replace one slot without purging its Docker/cache roots. The old provider
   # owns removal ordering; the selected provider owns replacement startup.
-  local name="$1" idx old_provider old_gen cur_gen image
+  local name="$1" idx old_provider old_gen cur_gen image pool
   local snapshot target_id target_role current_id current_name
   local was_stale=false
-  echo "$name" | grep -qE "^${NAME_PREFIX}-[0-9]+$" \
+  echo "$name" | grep -qE '^ci-runner-([0-9]+|[a-z][a-z0-9-]{0,23}-[0-9]+)$' \
     || { echo '{"ok":false,"error":"bad name"}'; return 1; }
   snapshot="$(managed_runner_snapshot "$name")" \
     || { echo '{"ok":false,"error":"runner is not an owned managed slot"}'; return 1; }
   IFS='|' read -r target_id old_provider target_role idx old_gen <<< "$snapshot"
+  pool="$(runner_pool "$name")" \
+    || { echo '{"ok":false,"error":"runner pool identity is unavailable"}'; return 1; }
+  pool_activate "$pool" \
+    || { echo '{"ok":false,"error":"runner belongs to an unavailable pool"}'; return 1; }
   cur_gen="$(crf_confgen)"
   if [ "$old_provider" != "$CI_PROVIDER" ] || [ "$old_gen" != "$cur_gen" ]; then was_stale=true; fi
 
@@ -2863,22 +2990,26 @@ cmd_status_json() {
   side_names="$(docker ps -a --filter 'label=net.unraid.ci-runner-farm.sidecar=true' --format '{{.Names}}' 2>/dev/null)"
   inspect_names="$names $side_names"
   # shellcheck disable=SC2086  # $names is intentionally word-split into one arg per runner
-  [ -n "$names" ] && inspraw="$(docker inspect -f '{{.Name}}|{{.State.Status}}|{{.HostConfig.NanoCpus}}|{{.HostConfig.Memory}}|{{index .Config.Labels "net.unraid.ci-runner-farm.confgen"}}|{{index .Config.Labels "net.unraid.ci-runner-farm.provider"}}' $inspect_names 2>/dev/null)"
+  [ -n "$names" ] && inspraw="$(docker inspect -f '{{.Name}}|{{.State.Status}}|{{.HostConfig.NanoCpus}}|{{.HostConfig.Memory}}|{{index .Config.Labels "net.unraid.ci-runner-farm.confgen"}}|{{index .Config.Labels "net.unraid.ci-runner-farm.provider"}}|{{index .Config.Labels "net.unraid.ci-runner-farm.pool"}}' $inspect_names 2>/dev/null)"
   local out="["; local first=1
   for c in $names; do
     [ -z "$c" ] && continue
-    local irow st cpus mem cgen row_provider stale=false
+    local irow st cpus mem cgen row_provider row_pool expected_gen stale=false
     # {{.Name}} carries a leading '/', so field 1 is "/name"; split the pipe-delimited
     # inspect row with one read builtin instead of three cut subshells per runner.
     irow="$(printf '%s\n' "$inspraw" | grep -m1 -E "^/?${c}\|")"
-    IFS='|' read -r _ st cpus mem cgen row_provider <<< "$irow"
+    IFS='|' read -r _ st cpus mem cgen row_provider row_pool <<< "$irow"
     [ "$row_provider" = gitlab ] || row_provider=github
+    [ "$row_pool" = '<no value>' ] && row_pool=""
+    row_pool="${row_pool:-default}"
     "${row_provider}_status_resources" "$c" "$inspraw"
     # Any managed runner whose baked-config fingerprint differs from the current
     # cfg predates a change. Include stopped fail-closed managers: hiding them
     # would make the UI claim migration is complete while unregister/retry work
     # is still outstanding.
-    [ "$cgen" != "$cur_gen" ] && { stale=true; stalec=$((stalec+1)); }
+    expected_gen="$(expected_runner_confgen "$c" 2>/dev/null || true)"
+    [ -n "$expected_gen" ] || expected_gen="$cur_gen"
+    [ "$cgen" != "$expected_gen" ] && { stale=true; stalec=$((stalec+1)); }
     # phase + cpu/mem usage + job context: all from the background cache line
     # New cache rows contain provider-neutral metadata followed by the legacy
     # GitHub fields; pre-provider cache rows are accepted for a seamless upgrade.
@@ -2920,7 +3051,7 @@ cmd_status_json() {
     case "$jrun" in *[!0-9]*) jrun="" ;; esac
     case "$job_id" in *[!0-9]*) job_id="" ;; esac
     [ $first -eq 0 ] && out+=","
-    out+="{\"name\":\"$(echo "$c"|json_escape)\",\"provider\":\"$row_provider\",\"state\":\"${st:-unknown}\",\"phase\":\"$phase\",\"job\":\"${job}\",\"job_started\":\"${jstarted}\",\"project\":\"${project}\",\"job_id\":\"${job_id}\",\"job_url\":\"${job_url}\",\"ref\":\"${ref}\",\"ref_url\":\"${ref_url}\",\"repo\":\"${jrepo}\",\"pr\":\"${jpr}\",\"branch\":\"${jbranch}\",\"run_id\":\"${jrun}\",\"cpus\":$(( ${cpus:-0}/1000000000 )),\"mem_gb\":$(( ${mem:-0}/1024/1024/1024 )),\"cpu_pct\":${cpu_pct:-0},\"mem_used_mib\":${mem_used_mib:-0},\"stale\":${stale}}"
+    out+="{\"name\":\"$(echo "$c"|json_escape)\",\"provider\":\"$row_provider\",\"pool\":\"$(printf '%s' "$row_pool"|json_escape)\",\"state\":\"${st:-unknown}\",\"phase\":\"$phase\",\"job\":\"${job}\",\"job_started\":\"${jstarted}\",\"project\":\"${project}\",\"job_id\":\"${job_id}\",\"job_url\":\"${job_url}\",\"ref\":\"${ref}\",\"ref_url\":\"${ref_url}\",\"repo\":\"${jrepo}\",\"pr\":\"${jpr}\",\"branch\":\"${jbranch}\",\"run_id\":\"${jrun}\",\"cpus\":$(( ${cpus:-0}/1000000000 )),\"mem_gb\":$(( ${mem:-0}/1024/1024/1024 )),\"cpu_pct\":${cpu_pct:-0},\"mem_used_mib\":${mem_used_mib:-0},\"stale\":${stale}}"
     first=0
   done
   out+="]"
@@ -2931,7 +3062,20 @@ cmd_status_json() {
   # public_repo_problem inline here: on a cold/expired cache that would run the
   # per-repo GitHub curls on the poll's own response path and stall it.
   local sec; sec="$(cat "$RUNDIR/sec.cache" 2>/dev/null | json_escape)"
-  echo "{\"provider\":\"$CI_PROVIDER\",\"count\":$(echo "$names" | grep -c . ),\"configured\":${RUNNER_COUNT},\"token\":$(provider_token_ready && echo true || echo false),\"autoscale\":\"${as} [${AUTOSCALE_MIN}-${AUTOSCALE_MAX}, buffer ${AUTOSCALE_MIN_IDLE}]\",\"image_autoupdate\":\"$(echo "$iu" | json_escape)\",\"warning\":\"${warn}\",\"security\":\"${sec}\",\"stale\":${stalec},\"runners\":${out}}"
+  local configured="$RUNNER_COUNT" pools='[]' rec pool pfirst=1 pcount labels pimage pjson='['
+  if pool_mode_enabled && pool_config_validate "$RUNNER_MODE" "$RUNNER_POOLS" "$GH_SCOPE" "$CI_PROVIDER"; then
+    configured=0
+    while IFS= read -r rec; do
+      pool="$(printf '%s' "$rec" | cut -d'|' -f2)"; pcount="$(pool_fixed "$pool")"
+      labels="$(pool_effective_labels "$pool")"; pimage="$(pool_image "$pool")"
+      configured=$((configured+pcount))
+      [ "$pfirst" -eq 0 ] && pjson+=','
+      pjson+="{\"id\":\"$(printf '%s' "$pool"|json_escape)\",\"labels\":\"$(printf '%s' "$labels"|json_escape)\",\"configured\":${pcount},\"image\":\"$(printf '%s' "$pimage"|json_escape)\"}"
+      pfirst=0
+    done < <(pool_records)
+    pools="${pjson}]"
+  fi
+  echo "{\"provider\":\"$CI_PROVIDER\",\"mode\":\"$RUNNER_MODE\",\"count\":$(echo "$names" | grep -c . ),\"configured\":${configured},\"token\":$(pool_tokens_ready 2>/dev/null && echo true || echo false),\"autoscale\":\"${as} [${AUTOSCALE_MIN}-${AUTOSCALE_MAX}, buffer ${AUTOSCALE_MIN_IDLE}]\",\"image_autoupdate\":\"$(echo "$iu" | json_escape)\",\"warning\":\"${warn}\",\"security\":\"${sec}\",\"stale\":${stalec},\"pools\":${pools},\"runners\":${out}}"
 }
 
 # Aggregate-only status for the Main -> Dashboard nchan widget: {count,up,busy,idle}.
@@ -2976,7 +3120,21 @@ cmd_logs() {
   return "$rc"
 }
 
-cmd_validate() { provider_call validate; }
+cmd_validate() {
+  validate_runner_mode || { err "$POOL_CONFIG_ERROR"; return 1; }
+  local rec pool failed=0
+  if pool_mode_enabled; then
+    while IFS= read -r rec; do
+      pool="$(printf '%s' "$rec" | cut -d'|' -f2)"
+      pool_activate "$pool" || { failed=1; continue; }
+      log "validating provider contract for pool $pool with image $(effective_image)"
+      provider_call validate || failed=1
+    done < <(pool_records)
+    return "$failed"
+  fi
+  pool_activate default
+  provider_call validate
+}
 
 # Clear the plugin's caches under CACHE_ROOT. Two independent safeguards: (1) the
 # root must pass crf_safe_cache_root — a dedicated subdir under a pool/disk, never a

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-pools.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-pools.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+# Pure runner-pool configuration helpers.
+#
+# Safe to source from tests. These helpers validate literal values loaded by
+# the allowlisted configuration reader. They do not access Docker or GitHub.
+
+POOL_HARD_MAX=64
+POOL_MAX_COUNT=8
+POOL_CONFIG_MAX_BYTES=16384
+POOL_LABEL_MAX_BYTES=63
+POOL_CONFIG_ERROR=""
+POOL_RECORDS=""
+
+pool_error() {
+  POOL_CONFIG_ERROR="$1"
+  return 1
+}
+
+pool_id_valid() {
+  printf '%s' "$1" | grep -qE '^[a-z]([a-z0-9-]{0,22}[a-z0-9])?$'
+}
+
+pool_uint_valid() {
+  case "$1" in
+    0|[1-9]|[1-9][0-9]) [ "$1" -le "$POOL_HARD_MAX" ] ;;
+    *) return 1 ;;
+  esac
+}
+
+pool_positive_uint_valid() {
+  pool_uint_valid "$1" && [ "$1" -gt 0 ]
+}
+
+pool_label_valid() {
+  [ -n "$1" ] && [ "${#1}" -le "$POOL_LABEL_MAX_BYTES" ] \
+    && printf '%s' "$1" | grep -qE '^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$'
+}
+
+pool_labels_normalize() {
+  local raw="$1" label out="" seen="," oldifs
+  case "$raw" in
+    '') printf '\n'; return 0 ;;
+    ','*|*','|*',,'*) return 1 ;;
+  esac
+  oldifs="$IFS"; IFS=','
+  # shellcheck disable=SC2086 # strict comma grammar is validated above
+  set -- $raw
+  IFS="$oldifs"
+  for label in "$@"; do
+    pool_label_valid "$label" || return 1
+    case "$seen" in *",$label,"*) return 1 ;; esac
+    seen="${seen}${label},"
+    out="${out}${out:+,}${label}"
+  done
+  printf '%s\n' "$out"
+}
+
+pool_cpu_valid() {
+  [ "$1" = inherit ] && return 0
+  printf '%s' "$1" | grep -qE '^(0\.[0-9]{1,3}|[1-9][0-9]*(\.[0-9]{1,3})?)$'
+}
+
+pool_memory_valid() {
+  [ "$1" = inherit ] && return 0
+  printf '%s' "$1" | grep -qiE '^[1-9][0-9]*(b|k|kb|ki|kib|m|mb|mi|mib|g|gb|gi|gib|t|tb|ti|tib)?$'
+}
+
+pool_image_valid() {
+  local image="$1"
+  [ "$image" = builtin ] && return 0
+  [ -n "$image" ] && [ "${#image}" -le 255 ] || return 1
+  case "$image" in
+    -*|*[$'\r\n\t ']*|*\|*|*\;*) return 1 ;;
+  esac
+  printf '%s' "$image" | grep -qE '^[A-Za-z0-9][A-Za-z0-9._/:@-]*$'
+}
+
+# V3 record:
+# v3|id|routing-label|additional-labels|fixed|min|max|idle|cpus|memory|image
+pool_record_normalize() {
+  local rec="$1" version id routing additional fixed min max idle cpus memory image extra labels oldifs
+  oldifs="$IFS"; IFS='|' read -r version id routing additional fixed min max idle cpus memory image extra <<EOF
+$rec
+EOF
+  IFS="$oldifs"
+  [ "$version" = v3 ] && [ -z "${extra:-}" ] && [ -n "$image" ] || {
+    pool_error "Pool '$rec' must have exactly eleven V3 fields."
+    return 1
+  }
+  pool_id_valid "$id" || { pool_error "Pool id '$id' is invalid."; return 1; }
+  case "$id" in default|invalid) pool_error "Pool id '$id' is reserved."; return 1 ;; esac
+  routing="$(printf '%s' "$routing" | tr '[:upper:]' '[:lower:]')"
+  pool_label_valid "$routing" || { pool_error "Pool '$id' routing label is invalid."; return 1; }
+  labels="$(pool_labels_normalize "$additional")" || {
+    pool_error "Pool '$id' additional labels are invalid or duplicated."
+    return 1
+  }
+  case ",$labels," in *",$routing,"*) pool_error "Pool '$id' repeats its routing label."; return 1 ;; esac
+  pool_positive_uint_valid "$fixed" || { pool_error "Pool '$id' fixed capacity is invalid."; return 1; }
+  pool_uint_valid "$min" || { pool_error "Pool '$id' minimum is invalid."; return 1; }
+  pool_positive_uint_valid "$max" || { pool_error "Pool '$id' maximum is invalid."; return 1; }
+  pool_uint_valid "$idle" || { pool_error "Pool '$id' idle target is invalid."; return 1; }
+  [ "$min" -le "$max" ] || { pool_error "Pool '$id' minimum exceeds its maximum."; return 1; }
+  [ "$idle" -le "$max" ] || { pool_error "Pool '$id' idle target exceeds its maximum."; return 1; }
+  cpus="$(printf '%s' "$cpus" | tr '[:upper:]' '[:lower:]')"
+  memory="$(printf '%s' "$memory" | tr '[:upper:]' '[:lower:]')"
+  pool_cpu_valid "$cpus" || { pool_error "Pool '$id' CPU claim is invalid."; return 1; }
+  pool_memory_valid "$memory" || { pool_error "Pool '$id' memory claim is invalid."; return 1; }
+  pool_image_valid "$image" || { pool_error "Pool '$id' image reference is invalid."; return 1; }
+  printf 'v3|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
+    "$id" "$routing" "$labels" "$fixed" "$min" "$max" "$idle" "$cpus" "$memory" "$image"
+}
+
+# Validate one complete immutable snapshot.
+# Usage: pool_config_validate <single|pools> <serialized records> <repo|org> [github|gitlab]
+pool_config_validate() {
+  local mode="${1:-}" raw="${2:-}" scope="${3:-}" provider="${4:-github}" rec normalized id routing image
+  local count=0 sum_fixed=0 sum_max=0 ids=" " routings=" " oldifs
+  POOL_CONFIG_ERROR=""
+  POOL_RECORDS=""
+
+  case "$mode" in
+    single) return 0 ;;
+    pools) ;;
+    *) pool_error "Runner mode must be single or pools."; return 1 ;;
+  esac
+  if [ "$provider" = github ] && [ "$scope" != org ]; then
+    pool_error "GitHub runner pools require Organization scope."
+    return 1
+  fi
+  [ -n "$raw" ] || { pool_error "Runner pools mode requires at least one pool."; return 1; }
+  [ "${#raw}" -le "$POOL_CONFIG_MAX_BYTES" ] || { pool_error "Runner pool configuration is too large."; return 1; }
+  case "$raw" in
+    *[$'\r\n\t']*|*\'*|*\"*|*\\*) pool_error "Runner pools contain unsupported characters."; return 1 ;;
+    ';'*|*';'|*';;'*) pool_error "Runner pool entries cannot be empty."; return 1 ;;
+  esac
+
+  oldifs="$IFS"; IFS=';'
+  # shellcheck disable=SC2086 # strict semicolon grammar is validated above
+  set -- $raw
+  IFS="$oldifs"
+  [ "$#" -le "$POOL_MAX_COUNT" ] || { pool_error "At most $POOL_MAX_COUNT runner pools are supported."; return 1; }
+  for rec in "$@"; do
+    normalized="$(pool_record_normalize "$rec")" || return 1
+    id="$(printf '%s' "$normalized" | cut -d'|' -f2)"
+    routing="$(printf '%s' "$normalized" | cut -d'|' -f3)"
+    image="$(printf '%s' "$normalized" | cut -d'|' -f11)"
+    case "$ids" in *" $id "*) pool_error "Pool id '$id' is duplicated."; return 1 ;; esac
+    case "$routings" in *" $routing "*) pool_error "Routing label '$routing' is duplicated."; return 1 ;; esac
+    ids="${ids}${id} "; routings="${routings}${routing} "
+    sum_fixed=$((sum_fixed + $(printf '%s' "$normalized" | cut -d'|' -f5)))
+    sum_max=$((sum_max + $(printf '%s' "$normalized" | cut -d'|' -f7)))
+    count=$((count + 1))
+    POOL_RECORDS="${POOL_RECORDS}${POOL_RECORDS:+;}${normalized}"
+    [ -n "$image" ] || return 1
+  done
+  [ "$count" -gt 0 ] || { pool_error "Runner pools mode requires at least one pool."; return 1; }
+  [ "$sum_fixed" -le "$POOL_HARD_MAX" ] || { pool_error "Fixed capacity exceeds $POOL_HARD_MAX."; return 1; }
+  [ "$sum_max" -le "$POOL_HARD_MAX" ] || { pool_error "Maximum capacity exceeds $POOL_HARD_MAX."; return 1; }
+}
+
+pool_mode_enabled() { [ "${RUNNER_MODE:-single}" = pools ]; }
+
+pool_records() {
+  pool_config_validate "${RUNNER_MODE:-single}" "${RUNNER_POOLS:-}" "${GH_SCOPE:-repo}" "${CI_PROVIDER:-github}" || return 1
+  if pool_mode_enabled; then
+    printf '%s\n' "$POOL_RECORDS" | tr ';' '\n'
+  else
+    printf 'single|default|legacy||%s|%s|%s|%s|inherit|inherit|%s\n' \
+      "${RUNNER_COUNT:-4}" "${AUTOSCALE_MIN:-2}" "${AUTOSCALE_MAX:-16}" \
+      "${AUTOSCALE_MIN_IDLE:-2}" "${IMAGE:-builtin}"
+  fi
+}
+
+pool_record() {
+  local want="$1" rec
+  while IFS= read -r rec; do
+    [ "$(printf '%s' "$rec" | cut -d'|' -f2)" = "$want" ] && { printf '%s\n' "$rec"; return 0; }
+  done < <(pool_records)
+  return 1
+}
+
+pool_field() { pool_record "$1" | cut -d'|' -f"$2"; }
+pool_routing_label() { pool_field "$1" 3; }
+pool_additional_labels() { pool_field "$1" 4; }
+pool_fixed() { pool_field "$1" 5; }
+pool_min() { pool_field "$1" 6; }
+pool_max() { pool_field "$1" 7; }
+pool_idle() { pool_field "$1" 8; }
+pool_cpus() { pool_field "$1" 9; }
+pool_memory() { pool_field "$1" 10; }
+pool_image() { pool_field "$1" 11; }
+
+pool_effective_labels() {
+  local routing additional
+  if [ "$1" = default ] && ! pool_mode_enabled; then printf '%s\n' "${RUNNER_LABELS:-}"; return; fi
+  routing="$(pool_routing_label "$1")" || return 1
+  additional="$(pool_additional_labels "$1")" || return 1
+  printf '%s%s\n' "$routing" "${additional:+,$additional}"
+}
+
+pool_configured_target() {
+  if [ "${AUTOSCALE:-false}" = true ]; then pool_min "$1"; else pool_fixed "$1"; fi
+}
+
+pool_state_generation() {
+  local rec
+  rec="$(pool_record "$1")" || return 1
+  printf '%s' "${RUNNER_MODE:-single}|${AUTOSCALE:-false}|$rec" | sha256sum | cut -c1-12
+}

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -29,6 +29,8 @@ done < <(find "$RUNTIME" -type f \( -name '*.php' -o -name '*.page' \) -print | 
 
 echo "== Contracts and package =="
 bash tests/config-parity.sh
+bash tests/runner-pools.sh
+bash tests/pool-runtime.sh
 bash tests/numeric-config.sh
 bash tests/safe-paths.sh
 bash tests/provider-contract.sh

--- a/tests/config-parity.sh
+++ b/tests/config-parity.sh
@@ -94,8 +94,8 @@ php_cap="$(grep -oE 'min\([0-9]+' "$EXEC" | head -1 | grep -oE '[0-9]+')"
 [ -n "$eng_cap" ] && [ "$eng_cap" = "$php_cap" ] || bad "scale hard-cap differs: engine HARD_MAX='$eng_cap' vs exec.php min='$php_cap'"
 
 prefix="$(grep -oE 'NAME_PREFIX="[^"]+"' "$ENGINE" | head -1 | sed -E 's/NAME_PREFIX="([^"]+)"/\1/')"
-if [ -n "$prefix" ] && ! grep -qF "^${prefix}-[0-9]" "$EXEC"; then
-  bad "exec.php runner-name regex does not match NAME_PREFIX='$prefix' (expected ^${prefix}-[0-9]+\$)"
+if [ -n "$prefix" ] && ! grep -qF "^${prefix}-(?:[0-9]" "$EXEC"; then
+  bad "exec.php runner-name regex does not match single and named-pool slots for NAME_PREFIX='$prefix'"
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/tests/pool-runtime.sh
+++ b/tests/pool-runtime.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export CRF_CFGDIR="$tmp/config" CRF_RUNDIR="$tmp/run" CRF_SOURCE_ONLY=1
+mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR" "$tmp/cache"
+# shellcheck source=/dev/null
+. src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+
+fail() { printf 'POOL RUNTIME FAIL: %s\n' "$*" >&2; exit 1; }
+
+build='v3|build|ci-build|linux,x64|2|0|2|0|2|8g|builtin'
+qa='v3|qa-vm|qa-vm-client|linux,x64|1|0|1|0|1.5|4g|ghcr.io/unraid/qa-vm-client:latest'
+RUNNER_MODE=pools RUNNER_POOLS="$build;$qa" GH_SCOPE=org CI_PROVIDER=github
+RUNNER_CPUS='' RUNNER_MEMORY=16g IMAGE_SOURCE=builtin IMAGE=''
+CACHE_ROOT="$tmp/cache" CACHE_MOUNTS='' WORK_TMPFS_SIZE=1g
+ACCESS_TOKEN='' NO_REGISTER=1 DIND=false SHARE_DOCKER_SOCK=false NETWORK_ISOLATION=off
+pool_base_refresh
+
+validate_runner_mode || fail "$POOL_CONFIG_ERROR"
+pool_activate qa-vm || fail 'GitHub pool activation failed'
+[ "$NAME_PREFIX" = ci-runner-qa-vm ] || fail 'pool name prefix is wrong'
+[ "$RUNNER_LABELS" = qa-vm-client,linux,x64 ] || fail 'pool labels are wrong'
+[ "$RUNNER_CPUS" = 1.5 ] && [ "$RUNNER_MEMORY" = 4g ] || fail 'pool resources are wrong'
+[ "$(effective_image)" = ghcr.io/unraid/qa-vm-client:latest ] || fail 'pool image is wrong'
+github_build_args 1 ci-runner-qa-vm-1 || fail 'GitHub pool argv failed'
+args="$(printf '%s\n' "${ARGS[@]}")"
+printf '%s\n' "$args" | grep -qx 'net.unraid.ci-runner-farm.pool=qa-vm' || fail 'GitHub pool label missing'
+printf '%s\n' "$args" | grep -qx 'LABELS=qa-vm-client,linux,x64' || fail 'GitHub routing labels missing'
+printf '%s\n' "$args" | grep -qx 'ghcr.io/unraid/qa-vm-client:latest' || fail 'GitHub pool image missing'
+
+start_log="$tmp/starts"
+provider_remote_image_host_pull_required() { return 1; }
+start_one() { printf '%s|%s|%s|%s\n' "$CRF_POOL_ID" "$1" "$RUNNER_LABELS" "$(effective_image)" >> "$start_log"; }
+start_configured_capacity || fail 'configured pool capacity failed'
+[ "$(grep -c '^build|' "$start_log")" -eq 2 ] || fail 'build fixed capacity was not started'
+[ "$(grep -c '^qa-vm|' "$start_log")" -eq 1 ] || fail 'QA-VM fixed capacity was not started'
+grep -qF 'qa-vm|1|qa-vm-client,linux,x64|ghcr.io/unraid/qa-vm-client:latest' "$start_log" \
+  || fail 'QA-VM pool start did not retain its image and labels'
+
+CI_PROVIDER=gitlab GH_SCOPE=repo
+RUNNER_LABELS='self-hosted,unraid,build' RUNNER_CPUS='' RUNNER_MEMORY=16g IMAGE_SOURCE=builtin IMAGE=''
+printf '%s\n' 'glrt-pooltoken0000000000' > "$CRF_CFGDIR/gitlab-runner-token.qa-vm"
+pool_base_refresh
+validate_runner_mode || fail "GitLab pool validation failed: $POOL_CONFIG_ERROR"
+pool_activate qa-vm || fail 'GitLab pool activation failed'
+[ "$GITLAB_RUNNER_TOKEN" = glrt-pooltoken0000000000 ] || fail 'GitLab pool token was not selected'
+[ "$(effective_image)" = ghcr.io/unraid/qa-vm-client:latest ] || fail 'GitLab pool image is wrong'
+
+rm -f "$CRF_CFGDIR/gitlab-runner-token.qa-vm"
+if pool_activate qa-vm 2>/dev/null; then fail 'GitLab pool accepted a missing pool token'; fi
+
+printf 'pool-runtime: provider-neutral pool activation and image routing passed\n'

--- a/tests/provider-contract.sh
+++ b/tests/provider-contract.sh
@@ -84,7 +84,10 @@ grep -qF "preg_match('/\A[A-Za-z0-9_.-]+\z/D', \$payload)" "$EXEC" \
   || bad "runner-token endpoint rejects GitLab routable-token dots"
 grep -qF '$length < 10 || $length > 507' "$EXEC" \
   || bad "runner-token endpoint does not enforce the shared 10..507 post-prefix bound"
-[ "$(grep -Fc 'glrt-[A-Za-z0-9_.-]{10,507}' "$GITLAB_ADAPTER")" -ge 3 ] \
+grep -qF '[ "${#token}" -le 512 ]' "$GITLAB_ADAPTER" \
+  && grep -qF '[ "${#payload}" -ge 10 ]' "$GITLAB_ADAPTER" \
+  && grep -qF 'case "$payload" in *[!A-Za-z0-9_.-]*) return 1' "$GITLAB_ADAPTER" \
+  && [ "$(grep -Fc 'glrt-[A-Za-z0-9_.-]{10,507}' "$GITLAB_ADAPTER")" -ge 2 ] \
   || bad "GitLab readiness/probe/unregister validators do not share the dotted 10..507 token contract"
 grep -qF '\(glrt-[A-Za-z0-9_.-]*\)' "$GITLAB_ADAPTER" \
   || bad "GitLab saved-probe parser truncates routable runner tokens at the first dot"

--- a/tests/runner-pools.sh
+++ b/tests/runner-pools.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+HELPER="src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-pools.sh"
+# shellcheck disable=SC1090
+. "$HELPER"
+
+pass=0
+fail=0
+ok() { pass=$((pass+1)); }
+bad() { printf 'FAIL: %s\n' "$*" >&2; fail=$((fail+1)); }
+accept() {
+  if pool_config_validate "$1" "$2" "$3" "${4:-github}"; then ok; else bad "expected valid: $POOL_CONFIG_ERROR"; fi
+}
+reject() {
+  if pool_config_validate "$1" "$2" "$3" "${4:-github}"; then bad "expected rejection: $2"; else ok; fi
+}
+
+build='v3|build|ci-build|linux,x64|3|2|5|1|2|8g|ghcr.io/unraid/ci-runner-image@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+qa='v3|qa-vm|qa-vm-client|linux,x64|2|1|3|1|1.5|4g|ghcr.io/unraid/qa-vm-client@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+valid="$build;$qa"
+
+accept single '' repo
+accept pools "$valid" org
+[ "$POOL_RECORDS" = "$valid" ] && ok || bad 'valid records were not normalized'
+accept pools "$valid" repo gitlab
+accept pools 'v3|minimal|ci-minimal||1|0|1|0|inherit|inherit|builtin' org
+
+RUNNER_MODE=pools RUNNER_POOLS="$valid" GH_SCOPE=org AUTOSCALE=true
+[ "$(pool_routing_label qa-vm)" = qa-vm-client ] && ok || bad 'routing label mismatch'
+[ "$(pool_effective_labels qa-vm)" = 'qa-vm-client,linux,x64' ] && ok || bad 'effective labels mismatch'
+[ "$(pool_image qa-vm)" = 'ghcr.io/unraid/qa-vm-client@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ] && ok || bad 'pool image mismatch'
+[ "$(pool_configured_target build)" = 2 ] && ok || bad 'autoscale target mismatch'
+AUTOSCALE=false
+[ "$(pool_configured_target build)" = 3 ] && ok || bad 'fixed target mismatch'
+
+RUNNER_MODE=single RUNNER_COUNT=4 RUNNER_LABELS='self-hosted,unraid,build'
+AUTOSCALE_MIN=2 AUTOSCALE_MAX=16 AUTOSCALE_MIN_IDLE=2 GH_SCOPE=repo IMAGE='ghcr.io/unraid/default:latest'
+[ "$(pool_image default)" = 'ghcr.io/unraid/default:latest' ] && ok || bad 'single image compatibility mismatch'
+[ "$(pool_effective_labels default)" = "$RUNNER_LABELS" ] && ok || bad 'single labels compatibility mismatch'
+
+reject broken "$valid" org
+reject pools '' org
+reject pools "$valid" repo
+reject pools "${build};${build}" org
+reject pools "${build};v3|qa-vm|ci-build|linux|1|1|1|1|1|1g|builtin" org
+reject pools 'v3|qa-vm|qa-vm-client|linux|1|1|1|1|1|1g|' org
+reject pools 'v3|qa-vm|qa-vm-client|linux|1|1|1|1|1|1g|-bad' org
+reject pools 'v3|qa-vm|qa-vm-client|linux|1|1|1|1|1|1g|image;bad' org
+reject pools 'v3|qa-vm|qa-vm-client|linux,linux|1|1|1|1|1|1g|builtin' org
+reject pools 'v3|qa-vm|qa-vm-client|qa-vm-client|1|1|1|1|1|1g|builtin' org
+reject pools 'v3|qa-vm|qa-vm-client|linux|1|2|1|1|1|1g|builtin' org
+reject pools 'v3|qa-vm|qa-vm-client|linux|1|0|1|2|1|1g|builtin' org
+reject pools 'v3|qa-vm|qa-vm-client|linux|1|0|1|0|0|1g|builtin' org
+reject pools 'v3|qa-vm|qa-vm-client|linux|1|0|1|0|1|zero|builtin' org
+reject pools $'v3|qa-vm|qa-vm-client|linux|1|0|1|0|1|1g|builtin\n' org
+
+printf 'runner-pools: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary
One CI Runner Farm installation can now run provider-neutral named pools with separate images, labels, capacity, and resource limits.

## Why This Exists
The current single-fleet model forces every runner on one Unraid host to use the same image and labels. This prevents a farm from adding specialized runner images, including a QA VM client image, without replacing or duplicating its general build fleet.

## Resolution
Add a strict V3 pool configuration with provider-neutral records. Both GitHub and GitLab adapters consume the same pool selection while they keep their existing provider-specific registration behavior. The first release uses fixed capacity in pool mode and keeps autoscaling and automatic image updates disabled until those state machines become pool-scoped.

## Reviewer Considerations
- Confirm that fixed-capacity pool mode is the correct first boundary. This avoids one global autoscaler changing another pool.
- Review the V3 record validation and ownership labels closely. Pool IDs reach container names and Docker selectors.
- GitHub pools require organization scope. GitLab pools use one existing `glrt-` token file per pool and keep server-side tag ownership.
- Existing single-fleet installations remain unchanged until an operator selects pool mode.

## Behavior Changes
- Operators can define several named pools with separate images, labels, fixed capacity, CPU, and memory.
- GitHub and GitLab runner containers include an exact pool ownership label.
- Fleet status groups managed runners by pool.
- Pool mode rejects global autoscaling and image auto-update settings.

## Implementation Summary
- Add strict pool parsing, normalization, and validation helpers.
- Route provider adapter image, labels, resources, names, and ownership through the active pool.
- Add Settings fields and pool-aware status output.
- Add provider-neutral pool, runtime, UI, and migration regression tests.

## Verification
- `bash tests/run-linux-checks.sh` — passed in Linux, including repository checks and GitLab configuration parsing.
- `git diff --check origin/main...HEAD` — passed.

## Risk
Medium; this adds a new opt-in runtime mode. Existing single-fleet behavior remains the default, and the new mode fails closed on malformed configuration or unsupported global state machines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for named GitHub and GitLab runner pools.
  * Configure pool-specific capacity, routing labels, resource limits, images, and idle settings.
  * Added pool-specific GitLab runner token management with validation and secure storage.
  * Runner status, logs, recycling, and lifecycle operations now support pool-qualified names.
  * Added pool metadata and aggregate capacity to status reporting.

* **Documentation**
  * Added setup and configuration guidance for runner pools, including activation and provider requirements.

* **Bug Fixes**
  * Improved GitLab runner-token validation and credential redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->