### PR TITLE
fix(github): expose local farm host gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,11 @@ privileged or socket-mounted runners only for trusted private projects.
   other Unraid containers. `strict` also blocks the Unraid host and LAN, apart
   from narrowly configured service endpoints.
 
+GitHub runner containers resolve `host.docker.internal` to their own Unraid
+farm host. Use this stable local address for a service that is deliberately
+colocated with a runner pool. The alias does not weaken network policy:
+`strict` mode still blocks host access.
+
 See [GitHub's self-hosted runner security guidance](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
 and [GitLab's self-managed runner security guidance](https://docs.gitlab.com/runner/security/).
 

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/README.md
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/README.md
@@ -11,6 +11,10 @@ organization scope. GitLab pools require a pool-specific `glrt-` runner token
 whose GitLab runner configuration owns the matching tags. Pool edits take
 effect on Fleet Restart, so Settings Apply does not interrupt active jobs.
 
+GitHub runner containers resolve `host.docker.internal` to their own Unraid
+farm host. A colocated service can use this stable local address without a
+machine-specific hostname. Strict network isolation still blocks host access.
+
 For GitLab, create the runner and its tags/protection/scope in GitLab, then save
 the reusable `glrt-` runner authentication token in the plugin. A separate
 `read_api` token is optional and is used only for advisory queue/recent-job

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -176,6 +176,7 @@ github_build_args() {
     --label "net.unraid.ci-runner-farm.index=${idx}"
     --label "net.unraid.ci-runner-farm.pool=${CRF_POOL_ID:-default}"
     --label "net.unraid.ci-runner-farm.confgen=$(crf_confgen)"
+    --add-host "host.docker.internal:host-gateway"
     -e RUNNER_NAME="$(host)-${name}"
     -e LABELS="$RUNNER_LABELS"
     -e DISABLE_AUTO_UPDATE="true"
@@ -201,7 +202,6 @@ github_build_args() {
     ARGS+=( -v "$CACHE_ROOT/docker/$name:/var/lib/docker" )
     ARGS+=( -v "$CACHE_ROOT/dind-daemon.json:/etc/docker/daemon.json:ro" )
     ARGS+=( -v "$CACHE_ROOT/dind-logs/$name:/var/log/dind" )
-    [ "$SHARED_IMAGE_CACHE" = "true" ] && [ "$NETWORK_ISOLATION" = "off" ] && ARGS+=( --add-host "host.docker.internal:host-gateway" )
   elif [ "$SHARE_DOCKER_SOCK" = "true" ]; then
     ARGS+=( -v /var/run/docker.sock:/var/run/docker.sock )
   fi

--- a/tests/pool-runtime.sh
+++ b/tests/pool-runtime.sh
@@ -29,6 +29,8 @@ github_build_args 1 ci-runner-qa-vm-1 || fail 'GitHub pool argv failed'
 args="$(printf '%s\n' "${ARGS[@]}")"
 printf '%s\n' "$args" | grep -qx 'net.unraid.ci-runner-farm.pool=qa-vm' || fail 'GitHub pool label missing'
 printf '%s\n' "$args" | grep -qx 'LABELS=qa-vm-client,linux,x64' || fail 'GitHub routing labels missing'
+printf '%s\n' "$args" | grep -qx 'host.docker.internal:host-gateway' \
+  || fail 'GitHub runner does not expose its local farm host gateway'
 printf '%s\n' "$args" | grep -qx 'ghcr.io/unraid/qa-vm-client:latest' || fail 'GitHub pool image missing'
 
 start_log="$tmp/starts"

--- a/tests/provider-contract.sh
+++ b/tests/provider-contract.sh
@@ -221,6 +221,8 @@ done
 grep -q '^provider_remote_image_host_pull_required()' "$ENGINE" \
   || bad "common provisioning does not dispatch remote-image pull ownership"
 grep -q '^github_build_args()' "$GITHUB_ADAPTER" || bad "GitHub build adapter contract is missing"
+grep -qF -- '--add-host "host.docker.internal:host-gateway"' "$GITHUB_ADAPTER" \
+  || bad "GitHub runners do not expose a stable local farm-host address"
 grep -q '^github_queued_refresh()' "$GITHUB_ADAPTER" || bad "GitHub queue adapter contract is missing"
 grep -q '^gitlab_write_config()' "$GITLAB_ADAPTER" || bad "GitLab TOML adapter contract is missing"
 grep -q '^gitlab_start_one()' "$GITLAB_ADAPTER" || bad "GitLab manager adapter contract is missing"


### PR DESCRIPTION
## Summary

GitHub runner containers now receive a stable `host.docker.internal` route to the Unraid host that launched them. This lets a colocated runner pool use a service on its own farm host without embedding a machine-specific address or phoning another farm.

## Why

QA-VM jobs must execute on the same farm host that owns their qa-vm-service provider and capacity pool. A repository-level devgen address made the otherwise portable runner image depend on a remote machine.

## Resolution

- add Docker's host-gateway alias to every GitHub runner container
- keep strict network isolation authoritative; strict mode still blocks host access
- document the alias as a colocated-service boundary
- test both runtime arguments and provider adapter wiring

## Reviewer guidance

Please verify that this adds only name resolution/routing metadata and does not weaken the strict firewall policy. The runner-farm remains provider-neutral and does not contain QA-VM-specific configuration. A farm should advertise the QA routing label only when it has its own local provider and capacity pool.

## Validation

- `bash tests/run-linux-checks.sh`
- `bash tests/pool-runtime.sh`
- `bash tests/provider-contract.sh`
- `git diff --check`

The full Linux test image passed. The direct macOS `tests/check.sh` run reached the known BSD `sed` portability failure in log-redaction; the same test passed in the supported Linux check environment.

## Risk

Low. The alias is added to GitHub runner containers, but existing network-isolation rules remain unchanged and continue to decide whether the host is reachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GitHub runner containers can reliably access services on the local farm host through `host.docker.internal`.
  - Strict network isolation remains enforced when enabled.

- **Documentation**
  - Added guidance explaining host access behavior and local service connectivity.

- **Tests**
  - Added coverage verifying the host mapping is included for GitHub runner containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->