### PR TITLE
fix(github): route colocated services to local farm

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,10 +369,11 @@ privileged or socket-mounted runners only for trusted private projects.
   other Unraid containers. `strict` also blocks the Unraid host and LAN, apart
   from narrowly configured service endpoints.
 
-GitHub runner containers resolve `host.docker.internal` to their own Unraid
-farm host. Use this stable local address for a service that is deliberately
-colocated with a runner pool. The alias does not weaken network policy:
-`strict` mode still blocks host access.
+GitHub runner containers resolve `runner-farm.host` to the management address
+of the Unraid host that launched them. Use this stable alias for a service that
+is deliberately colocated with a runner pool. `host.docker.internal` remains
+the Docker bridge gateway for local Docker services. Neither alias weakens
+network policy: `strict` mode still blocks host access.
 
 See [GitHub's self-hosted runner security guidance](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
 and [GitLab's self-managed runner security guidance](https://docs.gitlab.com/runner/security/).

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/README.md
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/README.md
@@ -11,9 +11,10 @@ organization scope. GitLab pools require a pool-specific `glrt-` runner token
 whose GitLab runner configuration owns the matching tags. Pool edits take
 effect on Fleet Restart, so Settings Apply does not interrupt active jobs.
 
-GitHub runner containers resolve `host.docker.internal` to their own Unraid
-farm host. A colocated service can use this stable local address without a
-machine-specific hostname. Strict network isolation still blocks host access.
+GitHub runner containers resolve `runner-farm.host` to the management address
+of the Unraid host that launched them. A colocated service can use this stable
+alias without a machine-specific hostname. `host.docker.internal` remains the
+Docker bridge gateway. Strict network isolation still blocks host access.
 
 For GitLab, create the runner and its tags/protection/scope in GitLab, then save
 the reusable `glrt-` runner authentication token in the plugin. A separate

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -164,7 +164,9 @@ github_registry_credentials() {
 
 github_build_args() {
   local idx="$1"
-  local name="${2:-${NAME_PREFIX}-${idx}}" role="${CRF_CONTAINER_ROLE:-runner}"
+  local name="${2:-${NAME_PREFIX}-${idx}}" role="${CRF_CONTAINER_ROLE:-runner}" host_service_ip
+  host_service_ip="$(runner_host_service_ipv4)" \
+    || { err "could not resolve this farm host's local service address"; return 1; }
   ARGS_TMPDIR=""
   ARGS=(
     -d --restart=no
@@ -177,6 +179,7 @@ github_build_args() {
     --label "net.unraid.ci-runner-farm.pool=${CRF_POOL_ID:-default}"
     --label "net.unraid.ci-runner-farm.confgen=$(crf_confgen)"
     --add-host "host.docker.internal:host-gateway"
+    --add-host "runner-farm.host:${host_service_ip}"
     -e RUNNER_NAME="$(host)-${name}"
     -e LABELS="$RUNNER_LABELS"
     -e DISABLE_AUTO_UPDATE="true"

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -234,6 +234,24 @@ log()  { echo "[ci-runner-farm] $*"; }
 err()  { echo "[ci-runner-farm] ERROR: $*" >&2; }
 host() { hostname -s; }
 
+# Resolve the IPv4 address used by this Unraid host for its default route. The
+# runner receives it under a fixed /etc/hosts alias, so colocated services can
+# be reached without putting one farm's machine address into repository config.
+# Strict isolation still blocks the resulting host/LAN route in the firewall.
+runner_host_service_ipv4() {
+  local route ip
+  if [ "${CRF_SOURCE_ONLY:-0}" = 1 ]; then
+    printf '192.0.2.10\n'
+    return 0
+  fi
+  route="$(ip -4 route get 1.1.1.1 2>/dev/null | head -n 1)" || return 1
+  ip="$(printf '%s\n' "$route" | awk '{ for (i = 1; i <= NF; i++) if ($i == "src" && (i + 1) <= NF) { print $(i + 1); exit } }')"
+  case "$ip" in
+    ''|*[!0-9.]*) return 1 ;;
+  esac
+  printf '%s\n' "$ip"
+}
+
 # Provider implementations live in adapters. CI_PROVIDER is normalized to the
 # two allowlisted names above, so dynamic dispatch cannot resolve an arbitrary
 # function. The files contain definitions only and are safe in source-only tests.

--- a/tests/pool-runtime.sh
+++ b/tests/pool-runtime.sh
@@ -11,6 +11,12 @@ mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR" "$tmp/cache"
 
 fail() { printf 'POOL RUNTIME FAIL: %s\n' "$*" >&2; exit 1; }
 
+CRF_SOURCE_ONLY=0
+ip() { printf '1.1.1.1 via 192.0.2.1 dev eth0 src 192.0.2.55 uid 0\n'; }
+[ "$(runner_host_service_ipv4)" = 192.0.2.55 ] || fail 'local farm service address resolution failed'
+unset -f ip
+CRF_SOURCE_ONLY=1
+
 build='v3|build|ci-build|linux,x64|2|0|2|0|2|8g|builtin'
 qa='v3|qa-vm|qa-vm-client|linux,x64|1|0|1|0|1.5|4g|ghcr.io/unraid/qa-vm-client:latest'
 RUNNER_MODE=pools RUNNER_POOLS="$build;$qa" GH_SCOPE=org CI_PROVIDER=github
@@ -31,6 +37,8 @@ printf '%s\n' "$args" | grep -qx 'net.unraid.ci-runner-farm.pool=qa-vm' || fail 
 printf '%s\n' "$args" | grep -qx 'LABELS=qa-vm-client,linux,x64' || fail 'GitHub routing labels missing'
 printf '%s\n' "$args" | grep -qx 'host.docker.internal:host-gateway' \
   || fail 'GitHub runner does not expose its local farm host gateway'
+printf '%s\n' "$args" | grep -qx 'runner-farm.host:192.0.2.10' \
+  || fail 'GitHub runner does not expose its local farm service address'
 printf '%s\n' "$args" | grep -qx 'ghcr.io/unraid/qa-vm-client:latest' || fail 'GitHub pool image missing'
 
 start_log="$tmp/starts"

--- a/tests/provider-contract.sh
+++ b/tests/provider-contract.sh
@@ -222,7 +222,9 @@ grep -q '^provider_remote_image_host_pull_required()' "$ENGINE" \
   || bad "common provisioning does not dispatch remote-image pull ownership"
 grep -q '^github_build_args()' "$GITHUB_ADAPTER" || bad "GitHub build adapter contract is missing"
 grep -qF -- '--add-host "host.docker.internal:host-gateway"' "$GITHUB_ADAPTER" \
-  || bad "GitHub runners do not expose a stable local farm-host address"
+  || bad "GitHub runners do not expose Docker's local farm-host gateway"
+grep -qF -- '--add-host "runner-farm.host:${host_service_ip}"' "$GITHUB_ADAPTER" \
+  || bad "GitHub runners do not expose a stable local farm service address"
 grep -q '^github_queued_refresh()' "$GITHUB_ADAPTER" || bad "GitHub queue adapter contract is missing"
 grep -q '^gitlab_write_config()' "$GITLAB_ADAPTER" || bad "GitLab TOML adapter contract is missing"
 grep -q '^gitlab_start_one()' "$GITLAB_ADAPTER" || bad "GitLab manager adapter contract is missing"

--- a/tests/provider-mocks.sh
+++ b/tests/provider-mocks.sh
@@ -34,6 +34,7 @@ RUNNER_CPUS='2'; RUNNER_MEMORY='4g'; IMAGE_SOURCE=builtin
 WORK_TMPFS_SIZE='2g'; DIND=true; SHARE_DOCKER_SOCK=false
 SHARED_IMAGE_CACHE=true; NETWORK_ISOLATION=off; EPHEMERAL=false; RUN_AS_ROOT=false
 host() { printf 'mockhost\n'; }
+runner_host_service_ipv4() { printf '192.0.2.10\n'; }
 legacy_confgen="$(printf '%s\0' "$GH_SCOPE" "$GH_OWNER" "$GH_REPOS" "$RUNNER_GROUP" "$RUNNER_LABELS" \
   "$EPHEMERAL" "$RUNNER_CPUS" "$RUNNER_MEMORY" "$WORK_TMPFS_SIZE" "$CACHE_MOUNTS" \
   "$DIND" "$SHARE_DOCKER_SOCK" "$RUN_AS_ROOT" "$IMAGE_SOURCE" "$IMAGE" \


### PR DESCRIPTION
## Summary

GitHub runners now receive `runner-farm.host`, resolved by the farm itself to that Unraid host's default-route source address. Colocated services can use one stable name on every farm without storing a machine address or contacting another farm.

## Why

Docker's `host-gateway` points at the bridge gateway, but Unraid SSH is bound to management interfaces rather than `docker0`. The first live deployment correctly resolved locally and then failed at port 22. A separate farm-owned alias must target the host's management address while retaining `host.docker.internal` for Docker bridge services.

## Resolution

- resolve the current host's default-route IPv4 address before creating a GitHub runner
- fail closed when that address cannot be resolved
- expose it as `runner-farm.host` inside the runner
- retain `host.docker.internal:host-gateway` for existing bridge-local uses
- document that strict isolation continues to block both host routes

## Placement invariant

A pool may advertise a colocated-service label such as `qa-vm-client` only when the same farm host owns that provider and capacity pool. Build-only farms must not receive that label.

## Validation

- `bash tests/run-linux-checks.sh`
- focused pool/provider contract tests
- parser test for default-route source selection
- `git diff --check`

## Risk

Low and fail-closed. This adds one `/etc/hosts` alias. Existing firewall rules still own authorization; strict mode blocks the host/LAN as before.