### PR TITLE
fix: surface docker run stderr when a recycle replacement fails

### DIFF
--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -2879,7 +2879,16 @@ cmd_recycle() {
     if ! build_args "$idx"; then
       echo '{"ok":false,"error":"removed but a fresh GitHub registration token could not be minted"}'; return 1
     fi
-    if ! docker run "${ARGS[@]}" >/dev/null 2>&1; then
+    # Capture the real docker error (don't swallow it): an image-pull failure,
+    # a port collision, or a rejected resource limit was otherwise lost behind
+    # the generic message below, with the old runner already removed. Keep it in
+    # a variable rather than a temp file so a full RUNDIR cannot stop the
+    # replacement from being attempted at all. Docker diagnostics are untrusted,
+    # so the detail is redacted on the way to the log.
+    local rout
+    if ! rout="$(docker run "${ARGS[@]}" 2>&1 >/dev/null)"; then
+      err "recycle: docker run failed:"
+      printf '%s\n' "$rout" | redact_log_stream >&2
       clear_args_tmpdir
       echo '{"ok":false,"error":"removed but not recreated"}'; return 1
     fi

--- a/tests/ownership-safety.sh
+++ b/tests/ownership-safety.sh
@@ -143,8 +143,10 @@ run_recycle_tests() (
   if grep -qF 'ghp_0123456789abcdefghijABCDEFGHIJ' "$tmp/recycle-runfail.err"; then
     fail "recycle logged an unredacted token from docker diagnostics"
   fi
-  grep -qxF '{"ok":false,"error":"removed but not recreated"}' "$tmp/recycle-runfail.out" \
-    || fail "recycle changed its JSON contract on a failed replacement"
+  # exec.php consumes the verdict as the FINAL line of stdout, after the progress
+  # logs, so assert that position rather than mere presence anywhere in the stream.
+  [ "$(tail -n 1 "$tmp/recycle-runfail.out")" = '{"ok":false,"error":"removed but not recreated"}' ] \
+    || fail "recycle changed its final-line JSON verdict on a failed replacement"
 )
 
 run_github_validate_test() (

--- a/tests/ownership-safety.sh
+++ b/tests/ownership-safety.sh
@@ -22,6 +22,7 @@ run_recycle_tests() (
   : > "$mutation_log"
   SNAP_MODE=unlabeled
   REMOVED=0
+  RUN_FAILS=0
 
   docker() {
     local cmd="${1:-}" fmt="" target="" managed provider role index
@@ -70,6 +71,11 @@ run_recycle_tests() (
         ;;
       run)
         printf 'docker run %s\n' "$*" >> "$mutation_log"
+        if [ "$RUN_FAILS" -eq 1 ]; then
+          printf 'docker: Error response from daemon: manifest unknown.\n' >&2
+          printf 'auth: ghp_0123456789abcdefghijABCDEFGHIJ\n' >&2
+          return 125
+        fi
         ;;
       *) return 0 ;;
     esac
@@ -122,6 +128,23 @@ run_recycle_tests() (
   if grep -Eq '^docker (stop|rm).*ci-runner-1$' "$mutation_log"; then
     fail "recycle sent the mutable slot name to a destructive Docker command"
   fi
+
+  # The replacement is started only after the old runner is gone, so a failed
+  # 'docker run' must surface Docker's own reason instead of the generic message
+  # alone. Docker diagnostics are untrusted, so the detail is still redacted, and
+  # the JSON contract on stdout stays byte-identical for callers that parse it.
+  : > "$mutation_log"; REMOVED=0; RUN_FAILS=1
+  if cmd_recycle ci-runner-1 >"$tmp/recycle-runfail.out" 2>"$tmp/recycle-runfail.err"; then
+    RUN_FAILS=0; fail "recycle reported success after docker run failed"
+  fi
+  RUN_FAILS=0
+  grep -qF 'manifest unknown' "$tmp/recycle-runfail.err" \
+    || fail "recycle discarded the docker run error"
+  if grep -qF 'ghp_0123456789abcdefghijABCDEFGHIJ' "$tmp/recycle-runfail.err"; then
+    fail "recycle logged an unredacted token from docker diagnostics"
+  fi
+  grep -qxF '{"ok":false,"error":"removed but not recreated"}' "$tmp/recycle-runfail.out" \
+    || fail "recycle changed its JSON contract on a failed replacement"
 )
 
 run_github_validate_test() (


### PR DESCRIPTION
Fixes #79.

`cmd_recycle` sent the replacement `docker run` to `/dev/null 2>&1`, so an image-pull failure, a port collision, a bad bind mount and a rejected resource limit all collapsed into `removed but not recreated` — with the old runner already gone at that point, and the obvious recovery path (start the slot again and read the log) being the thing that just failed.

## The change

```bash
-    if ! docker run "${ARGS[@]}" >/dev/null 2>&1; then
+    local rout
+    if ! rout="$(docker run "${ARGS[@]}" 2>&1 >/dev/null)"; then
+      err "recycle: docker run failed:"
+      printf '%s\n' "$rout" | redact_log_stream >&2
```

Two deliberate differences from the patch sketched in the issue, both found while reviewing it:

**Stderr is captured into a variable, not a temp file.** The issue suggested `mktemp "$RUNDIR/crf-recycle.XXXXXX"` to match `providers/github.sh:363`. On this path that shape is worse than the bug. `RUNDIR` is `/var/local/emhttp/ci-runner-farm`, which is on the rootfs tmpfs; with that full, `mktemp` fails, `errf` is empty, and since the engine runs `set -uo pipefail` without `-e`, execution continues into `2>"$errf"` — which bash rejects as an ambiguous redirect and therefore never runs the command at all. The replacement would be reported as failed having never been attempted, past the destructive boundary. The variable-capture shape has no such failure mode and follows `runner-farm.sh:1268-1279`, whose comment states this intent verbatim and which lives in this same file.

**The detail is redacted.** `runner-farm.sh:2515` is explicit that "Runner and Docker diagnostics are not a trusted redaction boundary" and must be filtered before reaching the UI or CLI. A failed `docker run` is exactly Docker diagnostics, so it goes through `redact_log_stream` rather than straight to the log.

The stdout contract is untouched. `exec.php:503` documents it as "cmd_recycle emits progress logs then its `{ok,error?}` verdict as the final line"; the patch adds nothing to stdout, so that final line is unchanged and nothing parsing it has to change.

## Tests

`tests/ownership-safety.sh` already drives the real `cmd_recycle` against a mocked Docker CLI under `CRF_SOURCE_ONLY=1`, so the failed-replacement case joins it there. It asserts three things: Docker's reason reaches the log, a token-shaped string in that same output does **not**, and the stdout verdict stays byte-identical.

Both assertions were checked for vacuousness — reverting the engine change fails the first, and removing only the `redact_log_stream` pipe fails the second.

`tests/check.sh` passes in the bundled `tests/linux-checks.Dockerfile` environment.

## Verified on hardware

Reproduced on Unraid running the released 1.9.1 plugin, GitHub provider, with the four changed lines spliced into the installed engine (the block is byte-identical to this branch's).

An unpullable image tag — the obvious trigger — does not reach this code: `recycle_image_preflight` runs before `remove_runner` and returns `cannot pull replacement image`, so the fleet never goes down. Setting `RUNNER_CPUS` above the host's CPU count does reach it, since that value is deliberately excluded from the engine's numeric validation (`runner-farm.sh:139-140`) and passes straight to Docker.

Recycling an idle runner with that config, on the patched engine:

```
--- stdout ---
{"ok":false,"error":"removed but not recreated"}

--- stderr ---
[ci-runner-farm] ERROR: recycle: docker run failed:
docker: Error response from daemon: range of CPUs is from 0.01 to 8.00, as there are only 8 CPUs available
```

Before the patch the second block was discarded entirely. The stdout verdict is identical in both cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker recycle failures now display the relevant error details instead of silently discarding them.
  * Sensitive tokens remain redacted in surfaced diagnostics.
  * Temporary files are cleaned up even when container recreation fails.
  * The existing failure response format remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->