### PR TITLE
fix(release): publish validated plugin assets from the release tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,8 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never interrupt a run between creating the release and attaching its files.
+  cancel-in-progress: false
 
 jobs:
   release-please:
@@ -32,9 +33,8 @@ jobs:
         with:
           token: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN || github.token }}
 
-  # On the open release PR, regenerate the self-contained .plg so its version
-  # entities and embedded payload match the version release-please just bumped,
-  # then commit it back onto the PR branch.
+  # Keep a preview of the plugin metadata on the open release PR. Publishing
+  # independently builds from the tag, so a merge cannot race this preparation.
   prepare-plugin-release-pr:
     needs: release-please
     if: ${{ github.repository == 'unraid/ci-runner-farm' && needs.release-please.outputs.pr != '' }}
@@ -81,19 +81,17 @@ jobs:
       tag: ${{ needs.release-please.outputs.tag_name }}
 
   # When the release PR merges and release-please cuts the tag + GitHub Release,
-  # attach the tagged .plg as the release asset that CA / Unraid installs from.
+  # attach the validated files that CA / Unraid installs from.
   publish-plugin-release:
     needs:
       - release-please
       - validate-plugin-release
     if: ${{ github.repository == 'unraid/ci-runner-farm' && needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
     steps:
-      - name: Checkout release tag
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
-
       - name: Upload plugin release artifact
         env:
           GH_TOKEN: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN || github.token }}
@@ -101,15 +99,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Rebuild the package reproducibly from the tagged src; its MD5 matches
-          # the packageMD5 the committed .plg already advertises. Upload it under
-          # the version-pinned asset name the .plg's packageName entity expects.
-          chmod +x build-plg.sh
-          ./build-plg.sh --tgz-only
-          asset="$(sed -n 's/^<!ENTITY packageName[[:space:]]*"\([^"]*\)">$/\1/p' ci-runner-farm.plg)"
-          [[ -n "$asset" ]] || { echo "::error::packageName entity missing in .plg" >&2; exit 1; }
-          plg_md5="$(sed -n 's/^<!ENTITY packageMD5[[:space:]]*"\([0-9a-f]*\)">$/\1/p' ci-runner-farm.plg)"
-          tgz_md5="$(md5sum ci-runner-farm.tgz | cut -d' ' -f1)"
-          [[ "$plg_md5" == "$tgz_md5" ]] || { echo "::error::rebuilt package md5 ($tgz_md5) != committed .plg packageMD5 ($plg_md5)" >&2; exit 1; }
-          cp ci-runner-farm.tgz "$asset"
-          gh release upload "$RELEASE_TAG" ci-runner-farm.plg "$asset" --clobber
+          # Publish exactly the bytes accepted by validation, not another build
+          # or the stale descriptor that may still exist in the tagged tree.
+          gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "release-$RELEASE_TAG" --dir release-artifacts
+          gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            release-artifacts/*.tgz --clobber
+          # Make the descriptor available only after its package is uploaded.
+          gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            release-artifacts/ci-runner-farm.plg --clobber

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -108,3 +108,15 @@ jobs:
           # Make the descriptor available only after its package is uploaded.
           gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
             release-artifacts/ci-runner-farm.plg --clobber
+
+          # Verify anonymous downloads, as used by Unraid and CA. An upload
+          # response alone does not prove the release files are retrievable.
+          downloaded="$(mktemp -d)"
+          trap 'rm -rf "$downloaded"' EXIT
+          for asset in release-artifacts/*; do
+            filename="${asset##*/}"
+            curl --fail --silent --show-error --location --retry 5 --retry-all-errors \
+              --output "$downloaded/$filename" \
+              "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG/$filename"
+            cmp "$asset" "$downloaded/$filename"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,21 @@ jobs:
           fi
           internal_version="${tag#v}"
 
+          # The release PR can merge before its asynchronous metadata commit.
+          # Build from the checked-out tag and its authoritative manifest, not
+          # the potentially stale VERSION or .plg committed on the PR.
+          manifest_version="$(python3 -c 'import json; print(json.load(open(".release-please-manifest.json"))["."])')"
+          if [[ "$manifest_version" != "$internal_version" ]]; then
+            echo "Manifest version $manifest_version does not match tag $tag" >&2
+            exit 1
+          fi
+          printf '%s\n' "$internal_version" > VERSION
+          # Freeze the stamp to the tag's commit, so retries produce the same
+          # descriptor and package name regardless of the workflow/run number.
+          DATE="$(git show -s --format=%ct HEAD | python3 -c 'import datetime, sys; print(datetime.datetime.fromtimestamp(int(sys.stdin.read()), datetime.timezone.utc).strftime("%Y.%m.%d.%H%M"))')" \
+            BUILD_NUMBER=0 INTERNAL_VERSION="$internal_version" REPO="$GITHUB_REPOSITORY" \
+            bash ./build-plg.sh
+
           plg_entity() { sed -n "s/^<!ENTITY $1[[:space:]]*\"\([^\"]*\)\">$/\1/p" "$plg"; }
 
           plugin_version="$(plg_entity pluginVersion)"
@@ -80,23 +95,35 @@ jobs:
           python3 -c "import xml.etree.ElementTree as ET; ET.parse('$plg')"
 
           # Rebuild the package reproducibly from the tagged src. Its MD5 must
-          # match the packageMD5 the committed .plg advertises (proving publish
-          # will upload matching bytes), and its contents must match the source
-          # tree at this commit (proving the .plg fetches the tagged plugin code).
+          # match the packageMD5 the generated .plg advertises. Its contents
+          # must also match the source tree at this commit.
           tgz="ci-runner-farm.tgz"
-          chmod +x build-plg.sh
-          ./build-plg.sh --tgz-only
+          bash ./build-plg.sh --tgz-only
           plg_md5="$(sed -n 's/^<!ENTITY packageMD5[[:space:]]*"\([0-9a-f]*\)">$/\1/p' "$plg")"
           tgz_md5="$(md5sum "$tgz" | cut -d' ' -f1)"
           if [[ -z "$plg_md5" || "$plg_md5" != "$tgz_md5" ]]; then
             echo "packageMD5 in $plg ($plg_md5) does not match $tgz ($tgz_md5) at $tag" >&2
             exit 1
           fi
-          rm -rf /tmp/plgtree && mkdir -p /tmp/plgtree
-          tar -xzf "$tgz" -C /tmp/plgtree
-          if ! diff -r /tmp/plgtree src/usr/local/emhttp/plugins/ci-runner-farm; then
+          plgtree="$(mktemp -d)"
+          trap 'rm -rf "$plgtree"' EXIT
+          tar -xzf "$tgz" -C "$plgtree"
+          if ! diff -r "$plgtree" src/usr/local/emhttp/plugins/ci-runner-farm; then
             echo "PLG package ($tgz) does not match src/ at $tag" >&2
             exit 1
           fi
 
           echo "Validated $plg + $tgz for $tag (version $plg_version, package md5 $tgz_md5)"
+
+          asset="$(plg_entity packageName)"
+          mkdir -p release-artifacts
+          cp "$plg" release-artifacts/
+          cp "$tgz" "release-artifacts/$asset"
+
+      - name: Preserve validated release artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: release-${{ inputs.tag || github.ref_name }}
+          path: release-artifacts/
+          if-no-files-found: error
+          overwrite: true

--- a/tests/release-guard.sh
+++ b/tests/release-guard.sh
@@ -102,5 +102,51 @@ with tempfile.TemporaryDirectory() as temporary:
     assert "Manifest version 1.10.0 does not match tag v2.0.0" in validate("v2.0.0", False)
     assert "Release tags must use SemVer" in validate("not-a-release", False)
 
+    # Run the actual publisher with only GitHub and HTTP replaced. The workflow
+    # still owns upload order, failure handling, and downloaded-byte comparison.
+    publication = (root / ".github/workflows/release-please.yml").read_text()
+    publication = publication.split("      - name: Upload plugin release artifact\n", 1)[1]
+    publication = publication.split("        run: |\n", 1)[1]
+    publish_script = "\n".join(line[10:] if line.startswith("          ") else line
+                               for line in publication.splitlines())
+    binaries = build / "bin"
+    binaries.mkdir()
+    gh = binaries / "gh"
+    gh.write_text('''#!/usr/bin/env bash
+set -eu
+printf '%s\\n' "$*" >> "$CALLS"
+if [[ "$*" == *"release upload"* && "$*" == *".tgz"* && "${FAIL_PACKAGE:-0}" == 1 ]]; then
+  exit 1
+fi
+''')
+    curl = binaries / "curl"
+    curl.write_text('''#!/usr/bin/env python3
+import os, pathlib, shutil, sys
+destination = pathlib.Path(sys.argv[sys.argv.index("--output") + 1])
+source = pathlib.Path("release-artifacts") / destination.name
+shutil.copyfile(source, destination)
+if os.environ.get("CORRUPT_DOWNLOAD") == "1":
+    destination.write_bytes(b"wrong release bytes")
+''')
+    gh.chmod(0o755)
+    curl.chmod(0o755)
+    calls = build / "calls"
+    publish_env = dict(env, PATH=f"{binaries}:{env['PATH']}", CALLS=str(calls),
+                       GITHUB_RUN_ID="123", GITHUB_SERVER_URL="https://github.com")
+
+    def publish(**overrides):
+        calls.write_text("")
+        return subprocess.run(["bash", "-c", publish_script], cwd=build,
+                              env=dict(publish_env, **overrides),
+                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    assert publish().returncode == 0
+    uploads = [line for line in calls.read_text().splitlines() if line.startswith("release upload")]
+    assert len(uploads) == 2 and ".tgz" in uploads[0] and ".plg" in uploads[1], uploads
+    assert publish(FAIL_PACKAGE="1").returncode != 0
+    assert ".plg" not in calls.read_text(), "descriptor uploaded despite package upload failure"
+    assert publish(CORRUPT_DOWNLOAD="1").returncode != 0, "incorrect public download was accepted"
+
 print("release-guard: OK — stale metadata rebuilt, artifacts validated, retries stable, invalid tags rejected")
+print("release-guard: OK — package published first, failed uploads stop, public downloads compared")
 PY

--- a/tests/release-guard.sh
+++ b/tests/release-guard.sh
@@ -42,3 +42,65 @@ if [ -e .gitlab-ci.yml ]; then
 fi
 
 echo "release-guard: OK — fork branches/tags cannot run upstream release jobs"
+
+# Exercise the real release validation/build step with the incident's stale
+# VERSION/.plg state. No GitHub calls or plugin installation run in this test.
+python3 - <<'PY'
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+root = Path.cwd()
+workflow = (root / ".github/workflows/release.yml").read_text()
+step = workflow.split("      - name: Validate plugin metadata\n", 1)[1]
+run = step.split("        run: |\n", 1)[1].split("\n      - name:", 1)[0]
+script = "\n".join(line[10:] if line.startswith("          ") else line
+                   for line in run.splitlines())
+
+with tempfile.TemporaryDirectory() as temporary:
+    build = Path(temporary)
+    for name in ("build-plg.sh", "VERSION", "ci-runner-farm.plg", "CHANGELOG.md"):
+        shutil.copy2(root / name, build / name)
+    shutil.copytree(root / "src", build / "src")
+    (build / "VERSION").write_text("1.9.1\n")
+    (build / ".release-please-manifest.json").write_text(json.dumps({".": "1.10.0"}))
+    # The workflow obtains its reproducible build date from the checked-out
+    # commit. Use a real repository, not a mocked git response.
+    for args in (["git", "init", "-q"], ["git", "add", "."],
+                 ["git", "-c", "user.name=Release Test", "-c",
+                  "user.email=release-test@example.invalid", "commit", "-qm", "fixture"]):
+        subprocess.run(args, cwd=build, check=True, stdout=subprocess.DEVNULL)
+    env = dict(os.environ, RELEASE_TAG="v1.10.0", GITHUB_REPOSITORY="unraid/ci-runner-farm")
+
+    def validate(tag="v1.10.0", success=True):
+        result = subprocess.run(["bash", "-c", script], cwd=build,
+                                env=dict(env, RELEASE_TAG=tag), text=True,
+                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        if (result.returncode == 0) != success:
+            raise SystemExit(result.stdout)
+        return result.stdout
+
+    validate()
+    artifacts = build / "release-artifacts"
+    files = sorted(artifacts.iterdir())
+    assert len(files) == 2, files
+    assert (build / "VERSION").read_text().strip() == "1.10.0"
+    descriptor = (artifacts / "ci-runner-farm.plg").read_text()
+    assert '<!ENTITY pluginVersion "1.10.0">' in descriptor
+    assert '/releases/download/v1.10.0/' in descriptor
+    before = {path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in files}
+    # A retry must not change either artifact, even under a different run id.
+    env["GITHUB_RUN_NUMBER"] = "999999"
+    validate()
+    after = {path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+             for path in artifacts.iterdir()}
+    assert before == after, "release retry changed validated artifacts"
+    assert "Manifest version 1.10.0 does not match tag v2.0.0" in validate("v2.0.0", False)
+    assert "Release tags must use SemVer" in validate("not-a-release", False)
+
+print("release-guard: OK — stale metadata rebuilt, artifacts validated, retries stable, invalid tags rejected")
+PY


### PR DESCRIPTION
## Summary

Prevent missing plugin downloads by building release assets from the tagged source and publishing the exact validated files.

## Why This Exists

Release v1.10.0 was created with no assets. Its manifest named 1.10.0, but the merged VERSION and PLG still named 1.9.1. Release validation failed before either upload, so the latest plugin URL stopped working. Release PR preparation runs were also subject to cancellation.

## Resolution

The release validator now builds the descriptor and package from the checked-out tag and its manifest. Publishing no longer depends on the asynchronous metadata commit on a release PR. The existing preparation job remains a preview for reviewers.

## Reviewer Considerations

- The tag manifest is authoritative. A mismatched tag fails before artifact generation.
- The build date comes from the tag commit, with build number zero. A retry produces the same package name and bytes.
- The publisher downloads the validated CI artifact and uploads the package before the descriptor. Active release workflows are no longer canceled by later pushes. Anonymous downloads must match the validated files before publication succeeds.
- No runner runtime behavior or Community Applications listing changes are included.

## Behavior Changes

A release with stale committed VERSION or PLG metadata can publish the correct tagged plugin. Fork release guards remain intact. Repeated validation replaces its CI artifact without changing its contents.

## Implementation Summary

- Build and validate release artifacts in the existing reusable release workflow.
- Pass those artifacts to the publishing job instead of rebuilding from stale metadata.
- Extend release guard coverage for the incident, retries, invalid tags, upload ordering, upload failure, and corrupted downloads.

## Verification

- Full `bash tests/check.sh` passed in Linux.
- `actionlint .github/workflows/release-please.yml .github/workflows/release.yml` passed.
- `shellcheck tests/release-guard.sh` and `git diff --check` passed.
- The new regression fails against the old workflow with the reported 1.10.0/1.9.1 mismatch and passes against this change.
- GitHub Actions [validation run](https://github.com/unraid/ci-runner-farm/actions/runs/33103646945) rebuilt v1.10.0 from the unchanged release tag successfully.
- Restored both v1.10.0 release assets from that validated CI artifact. Anonymous downloads through the latest PLG URL and its pinned package URL match the CI bytes, and XML/MD5 validation passes.
- Additional publisher regression tests and actionlint pass locally. All final-head CI checks passed: Repository checks, Build and validate plugin, and MegaLinter. The verified PR head is `be3ee2dd9330bb41ca4c59573180a85d6742b8b2`.

## Risk

This changes release packaging only. Artifact transfer or GitHub upload failures still stop publication visibly and require a retry. The package is uploaded first so a new descriptor does not advertise a missing package. The existing release tag and runtime source remain unchanged during recovery.
