### PR TITLE
fix(selfheal): detect missing BuildKit snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,9 +397,9 @@ ordinary steady state still has one active provider.
 Alongside reaping dead or deregistered slots, the autoscale tick also
 self-heals build-poisoned GitHub DinD slots. If a slot's nested Docker daemon
 crashes mid-build, its persistent buildkit store can be left with dangling
-lease metadata: every later build on that slot fails with
-`failed to solve: lease "...": not found` while the runner itself stays
-healthy and keeps accepting jobs. The farm detects this from the failed job
+lease metadata or missing snapshot parents: every later build on that slot
+fails while the runner itself stays healthy and keeps accepting jobs. The farm
+detects the supported BuildKit corruption signatures from the failed job
 logs on GitHub (the only place the error is visible), then — only while the
 slot is idle, and at most once per slot per hour — stops the container,
 clears just the `buildkit/` subdirectory of its Docker root (warm image and

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -156,17 +156,20 @@ github_public_repo_problem() {
 
 # ── Build-poison detection ───────────────────────────────────────────────────
 # A crashed nested dockerd can leave a slot's persistent buildkit store with
-# dangling lease references; every later build on that slot then fails with
+# dangling lease references or missing snapshot parents; every later build on
+# that slot then fails with either
 #   ERROR: failed to solve: lease "...": not found
+# or
+#   failed to stat parent: stat /var/lib/buildkit/runc-overlayfs/snapshots/snapshots/<n>/fs: no such file or directory
 # while the runner stays healthy and keeps accepting jobs. Nothing host-side
 # ever sees that error: the nested daemon does not log solve failures and job
 # step output exists only in the uploaded GitHub job log. So detection reads
 # what the jobs themselves saw — recent failed workflow runs, their jobs that
 # ran on THIS host's slots, and each such job's log — looking for the lease
-# signature. Rate-bounded and cached so an idle fleet costs one runs listing
+# signatures. Rate-bounded and cached so an idle fleet costs one runs listing
 # per repo per POISON_SCAN_INTERVAL, and log downloads happen at most once per
 # failed job ever (the seen cache).
-GITHUB_POISON_SIGNATURE='failed to solve: lease "[^"]*": not found'
+GITHUB_POISON_SIGNATURE='failed to solve: lease "[^"]*": not found|failed to stat parent: stat /var/lib/buildkit/runc-overlayfs/snapshots/snapshots/[0-9]+/fs: no such file or directory'
 
 # IDs of recent failed workflow runs for one repo, newest first. The pretty
 # GitHub JSON puts every field on its own line; a run object's own "id" is the
@@ -204,7 +207,7 @@ github_failed_local_jobs() {
     }'
 }
 
-# Does one failed job's log carry the dangling-lease signature? The logs
+# Does one failed job's log carry a supported build-poison signature? The logs
 # endpoint redirects to short-lived blob storage; the PAT enters curl through
 # config stdin (never argv), like gh_api. Size/time caps keep a runaway log
 # from stalling the tick — a poisoned build dies in its first minute, so the
@@ -246,7 +249,7 @@ github_build_poison_scan() {
         # can discard the flag if the slot is replaced before repair runs.
         snapshot="$(managed_runner_snapshot "$slot" 2>/dev/null)" || continue
         IFS='|' read -r id provider role index gen <<< "$snapshot"
-        log "selfheal: job $jid on $slot failed with a dangling buildkit lease -> flagging for repair"
+        log "selfheal: job $jid on $slot failed with corrupt buildkit metadata -> flagging for repair"
         echo "$id" > "$RUNDIR/poison-pending.$slot"
       done
     done

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -624,12 +624,12 @@ reap_dead_runners() {
 }
 
 # A runner whose nested dockerd crashed mid-build can be left with dangling
-# buildkit lease metadata in its persistent DinD root: every later build on that
-# slot fails with `failed to solve: lease "...": not found` while the container
-# stays running, healthy, and registered — so it keeps taking (and failing)
+# buildkit lease metadata or missing snapshot parents in its persistent DinD
+# root: every later build on that slot fails while the container stays running,
+# healthy, and registered — so it keeps taking (and failing)
 # jobs, invisible to reap_dead_runners, which only sees dead containers and
 # lost registrations. The provider scan classifies a slot as build-poisoned by
-# that exact signature (GitHub reads recent failed-job logs, the only place the
+# supported signatures (GitHub reads recent failed-job logs, the only place the
 # error is visible — the nested daemon does not log solve failures) and drops a
 # poison-pending flag; this pass repairs flagged IDLE slots by stopping the
 # container, clearing ONLY the buildkit/ subdir of its DinD root (the warm
@@ -676,7 +676,7 @@ heal_poisoned_runners() {
     # Stamp the ATTEMPT before acting: whatever fails below, this slot cannot
     # be stop/start-cycled more than once per bound interval.
     echo "$now" > "$healf"
-    log "selfheal: $c is build-poisoned (dangling buildkit lease) -> stop, clear buildkit metadata, restart"
+    log "selfheal: $c is build-poisoned (corrupt buildkit metadata) -> stop, clear buildkit metadata, restart"
     provider_stop_owned_runner "$c" "$id" "$provider" \
       || { err "selfheal: could not stop $c for its buildkit reset"; failed=1; continue; }
     if rm -rf "$root/docker/$c/buildkit" 2>/dev/null; then

--- a/tests/lease-selfheal.sh
+++ b/tests/lease-selfheal.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Build-poison self-heal: the GitHub scan must flag exactly the slots whose
-# failed jobs carry the dangling-lease signature, download each job log at most
+# failed jobs carry a supported corruption signature, download each job log at most
 # once, and the healer must repair only an idle, still-current flagged slot —
 # stop, clear ONLY buildkit/ from its DinD root, restart — bounded to one
 # attempt per slot per interval, never touching a busy slot.
@@ -62,9 +62,11 @@ docker() {
 }
 
 # One failed run (900001) whose jobs: 700001 failed on mockhost-ci-runner-2
-# (log carries the signature), 700002 failed on a GitHub-hosted runner, and
+# with the dangling-lease signature, 700002 failed on a GitHub-hosted runner,
 # 700003 SUCCEEDED on mockhost-ci-runner-3 with a step whose nested conclusion
-# is "failure" — the parser must keep the job-level conclusion, not a step's.
+# is "failure", and 700004 failed on mockhost-ci-runner-3 with a missing
+# BuildKit snapshot parent. The parser must keep the job-level conclusion, not
+# a step's.
 GH_API_LOG="$tmp/gh-api.log"; : > "$GH_API_LOG"
 gh_api() {
   printf '%s %s\n' "$1" "$2" >> "$GH_API_LOG"
@@ -91,7 +93,7 @@ EOF
     /repos/example/one/actions/runs/900001/jobs*)
       cat <<'EOF'
 {
-  "total_count": 3,
+  "total_count": 4,
   "jobs": [
     {
       "id": 700001,
@@ -129,6 +131,15 @@ EOF
       ],
       "runner_id": 13,
       "runner_name": "mockhost-ci-runner-3"
+    },
+    {
+      "id": 700004,
+      "run_id": 900001,
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [],
+      "runner_id": 13,
+      "runner_name": "mockhost-ci-runner-3"
     }
   ]
 }
@@ -138,7 +149,7 @@ EOF
   esac
 }
 
-# Job-log transport: only job 700001's log carries the real incident signature.
+# Job-log transport: jobs 700001 and 700004 carry supported poison signatures.
 CURL_LOG="$tmp/curl.log"; : > "$CURL_LOG"
 curl() {
   printf '%s\n' "$*" >> "$CURL_LOG"
@@ -147,6 +158,8 @@ curl() {
     */jobs/700001/logs*)
       printf '2026-08-16T20:57:43.6390511Z #13 ERROR: lease "idf11ya2iiot5bqwvr7qojagq": not found\n'
       printf '2026-08-16T20:57:43.6402537Z ERROR: failed to build: failed to solve: lease "idf11ya2iiot5bqwvr7qojagq": not found\n' ;;
+    */jobs/700004/logs*)
+      printf 'ERROR: failed to prepare sha256:25cd as abc: failed to stat parent: stat /var/lib/buildkit/runc-overlayfs/snapshots/snapshots/562/fs: no such file or directory\n' ;;
     *) printf 'ordinary failing job log without the signature\n' ;;
   esac
 }
@@ -156,15 +169,19 @@ github_build_poison_scan || fail "scan returned non-zero on the fixture"
 [ -f "$CRF_RUNDIR/poison-pending.ci-runner-2" ] || fail "signature job did not flag ci-runner-2"
 [ "$(cat "$CRF_RUNDIR/poison-pending.ci-runner-2")" = "$RID2" ] \
   || fail "poison flag does not carry the slot's immutable container ID"
-[ ! -e "$CRF_RUNDIR/poison-pending.ci-runner-3" ] \
-  || fail "a succeeded job (with a failed step) flagged ci-runner-3"
+[ -f "$CRF_RUNDIR/poison-pending.ci-runner-3" ] \
+  || fail "missing-snapshot job did not flag ci-runner-3"
+[ "$(cat "$CRF_RUNDIR/poison-pending.ci-runner-3")" = "$RID3" ] \
+  || fail "snapshot-corruption flag does not carry ci-runner-3's immutable container ID"
 grep -qx 700001 "$CRF_RUNDIR/poison-scan.seen" || fail "seen cache is missing the scanned job"
+grep -qx 700004 "$CRF_RUNDIR/poison-scan.seen" || fail "seen cache is missing the snapshot-corruption job"
 if grep -q 700003 "$CURL_LOG"; then fail "log of a succeeded job was downloaded"; fi
 if grep -qF "$ACCESS_TOKEN" "$CURL_LOG"; then fail "PAT leaked into the log-download curl argv"; fi
 logs_before="$(grep -c 'jobs/70000' "$CURL_LOG" || true)"
 POISON_SCAN_INTERVAL=0 github_build_poison_scan || fail "rescan returned non-zero"
 logs_after="$(grep -c 'jobs/70000' "$CURL_LOG" || true)"
 [ "$logs_before" = "$logs_after" ] || fail "a rescan re-downloaded an already-seen job log"
+rm -f "$CRF_RUNDIR/poison-pending.ci-runner-3"
 
 # ── Heal defers while the slot is busy ───────────────────────────────────────
 POISON_SCAN_INTERVAL=99999   # keep the embedded scan quiet during heal phases


### PR DESCRIPTION
## What changed

- recognize BuildKit missing-snapshot-parent failures as poisoned runner state
- reuse the existing idle-only, rate-limited BuildKit metadata reset
- preserve image and layer caches
- cover both lease and snapshot corruption signatures in the self-heal fixture

## Verification

- `bash tests/lease-selfheal.sh`
- `bash tests/run-linux-checks.sh`
- `git diff --check`

## Risk

Low. Detection is limited to an exact BuildKit path/error signature. Existing safeguards still require a failed local job, an idle current slot, and the one-reset-per-hour bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of corrupted build environments by recognizing missing BuildKit snapshot parents in addition to invalid lease metadata.
  * Automatically flags affected runners for self-healing across both supported corruption scenarios.
  * Updated repair logs to clearly identify corrupted build metadata.

* **Tests**
  * Added coverage for runner failures caused by missing snapshot parents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->