### PR TITLE
fix(autoscale): use fresh queue depth for growth

### DIFF
--- a/.limetech/ai-review-markers/codex-issue-80-queue-aware-autoscale-693120e2fc1d.json
+++ b/.limetech/ai-review-markers/codex-issue-80-queue-aware-autoscale-693120e2fc1d.json
@@ -1,0 +1,25 @@
+{
+  "disposition": "NOT_REQUIRED",
+  "expected_structural_delta": "No new production modules, roots, durable state owners, protocols, or public operations. Extend the existing autoscale owner and add one focused test file.",
+  "minimum_design": "Read the existing queued.cache in autoscale_tick through one parser that accepts current and legacy formats, rejects stale, mismatched, or invalid data, and uses the result only in growth target math.",
+  "outcome": "When autoscaling reads a provider-matching queue cache no older than 60 seconds, a backlog increases the next growth target without exceeding AUTOSCALE_MAX. Invalid cache data keeps the existing growth step and shrink behavior.",
+  "reuse_decisions": [
+    {
+      "decision": "reuse",
+      "name": "queued.cache format and refresh writers",
+      "rationale": "The provider adapters already write the cache and cmd_queued_json defines its current and legacy formats. The autoscaler should consume that existing contract."
+    },
+    {
+      "decision": "extend",
+      "name": "autoscale_tick",
+      "rationale": "The existing growth branch owns the target calculation, so queue depth belongs there without a second scaling controller."
+    },
+    {
+      "decision": "new_owner",
+      "name": "tests/autoscale-queue.sh",
+      "rationale": "A focused fixture is needed to prove fresh, stale, mismatched, missing, and maximum-clamped queue behavior."
+    }
+  ],
+  "schema": "limetech.ai-review-marker.v2",
+  "stage": "forecast"
+}

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -697,17 +697,42 @@ heal_poisoned_runners() {
   return "$failed"
 }
 
+# Read a provider-matching queue cache only while it is inside the same 60-second
+# freshness window used by cmd_queued_json. Unknown data must not suppress the
+# normal idle-headroom growth decision.
+autoscale_queue_depth() {
+  local now cache_provider ts count age
+  [ -f "$RUNDIR/queued.cache" ] || { printf '%s\n' -1; return 0; }
+  now="$(date +%s)"
+  read -r cache_provider ts count < "$RUNDIR/queued.cache"
+  case "$cache_provider" in
+    github|gitlab) ;;
+    *) count="$ts"; ts="$cache_provider"; cache_provider=github ;;
+  esac
+  [ "$cache_provider" = "$CI_PROVIDER" ] || { printf '%s\n' -1; return 0; }
+  case "$ts" in ''|*[!0-9]*) printf '%s\n' -1; return 0 ;; esac
+  case "$count" in ''|*[!0-9]*) printf '%s\n' -1; return 0 ;; esac
+  age=$(( now - ts ))
+  [ "$age" -ge 0 ] && [ "$age" -le 60 ] || { printf '%s\n' -1; return 0; }
+  printf '%s\n' "$count"
+}
+
 # one autoscaling evaluation: keep AUTOSCALE_MIN_IDLE warm runners, within [MIN,MAX]
 autoscale_tick() {
   [ "$AUTOSCALE" = "true" ] || return 0
   reap_dead_runners || return 1  # drop dead containers first so idle accounting is real
-  local cur=0 busy=0 idle=0 statef over target
+  local cur=0 busy=0 idle=0 statef over target queue_target qdepth
   # GitHub retains its original cur-busy semantics; GitLab counts only explicit
   # idle managers so disconnected/starting slots are not phantom headroom.
   provider_call autoscale_counts \
     || { err "autoscale: could not enumerate and inspect the managed fleet"; return 1; }
   case "$cur:$busy:$idle" in
     *[!0-9:]*) err "autoscale: provider returned invalid fleet counts"; return 1 ;;
+  esac
+  qdepth="$(autoscale_queue_depth)"
+  case "$qdepth" in
+    -1|[0-9]|[1-9][0-9]*) ;;
+    *) qdepth=-1 ;;
   esac
   statef="${RUNDIR}/autoscale.state"; over=0
   [ -f "$statef" ] && over=$(cat "$statef" 2>/dev/null || echo 0)
@@ -730,7 +755,12 @@ autoscale_tick() {
 
   if [ "$idle" -lt "$AUTOSCALE_MIN_IDLE" ] && [ "$cur" -lt "$AUTOSCALE_MAX" ]; then
     target=$(( cur + AUTOSCALE_STEP )); [ "$target" -gt "$AUTOSCALE_MAX" ] && target=$AUTOSCALE_MAX
-    log "autoscale: idle=$idle/$cur < buffer $AUTOSCALE_MIN_IDLE -> grow to $target"
+    if [ "$qdepth" -gt 0 ]; then
+      queue_target=$(( cur + qdepth ))
+      [ "$queue_target" -gt "$target" ] && target="$queue_target"
+      [ "$target" -gt "$AUTOSCALE_MAX" ] && target=$AUTOSCALE_MAX
+    fi
+    log "autoscale: idle=$idle/$cur queued=$qdepth < buffer $AUTOSCALE_MIN_IDLE -> grow to $target"
     cmd_scale "$target" >/dev/null; echo 0 > "$statef"
   elif [ "$idle" -gt $(( AUTOSCALE_MIN_IDLE + AUTOSCALE_STEP )) ] && [ "$cur" -gt "$floor" ]; then
     over=$(( over + 1 )); echo "$over" > "$statef"

--- a/tests/autoscale-queue.sh
+++ b/tests/autoscale-queue.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Verify that a fresh provider queue cache can increase growth without changing
+# the existing idle-only fallback for stale, mismatched, or missing cache data.
+set -euo pipefail
+# The sourced engine consumes these values through Bash dynamic scope.
+# shellcheck disable=SC2034
+cd "$(dirname "$0")/.."
+
+ENGINE="src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/config" CRF_RUNDIR="$tmp/run"
+mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+# shellcheck source=/dev/null
+source "$ENGINE"
+
+AUTOSCALE=true
+AUTOSCALE_MIN=2
+AUTOSCALE_MAX=16
+AUTOSCALE_MIN_IDLE=2
+AUTOSCALE_STEP=2
+AUTOSCALE_IDLE_GRACE=5
+scale_log="$tmp/scales"
+autoscale_output="$tmp/output"
+
+reap_dead_runners() { :; }
+heal_poisoned_runners() { :; }
+reconcile_stale_runners() { :; }
+provider_call() {
+  [ "${1:-}" = autoscale_counts ] || return 1
+  cur=4
+  busy=4
+  idle=0
+}
+cmd_scale() { printf '%s\n' "$1" >> "$scale_log"; }
+
+assert_target() {
+  local label="$1" provider="$2" timestamp="$3" count="$4" expected="$5"
+  rm -f "$RUNDIR/queued.cache" "$RUNDIR/autoscale.state"
+  : > "$scale_log"
+  if [ "$provider" != none ]; then
+    printf '%s %s %s\n' "$provider" "$timestamp" "$count" > "$RUNDIR/queued.cache"
+  fi
+  autoscale_tick >"$autoscale_output" \
+    || { cat "$autoscale_output" >&2; printf 'autoscale-queue: %s failed\n' "$label" >&2; exit 1; }
+  [ "$(cat "$scale_log")" = "$expected" ] \
+    || { printf 'autoscale-queue: %s expected %s, got %s\n' "$label" "$expected" "$(cat "$scale_log")" >&2; exit 1; }
+}
+
+now="$(date +%s)"
+assert_target "one queued job keeps the step floor" github "$now" 1 6
+grep -q 'queued=1' "$autoscale_output" \
+  || { echo 'autoscale-queue: fresh queue depth was not reported' >&2; exit 1; }
+assert_target "larger queue increases growth" github "$now" 8 12
+assert_target "queue growth stays below the maximum" github "$now" 50 16
+assert_target "stale cache falls back to the step" github "$((now - 61))" 50 6
+assert_target "provider mismatch falls back to the step" gitlab "$now" 50 6
+assert_target "missing cache falls back to the step" none "$now" 0 6
+
+echo "autoscale-queue: PASS"

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -30,6 +30,7 @@ done < <(find "$RUNTIME" -type f \( -name '*.php' -o -name '*.page' \) -print | 
 echo "== Contracts and package =="
 bash tests/config-parity.sh
 bash tests/runner-pools.sh
+bash tests/autoscale-queue.sh
 bash tests/pool-runtime.sh
 bash tests/numeric-config.sh
 bash tests/safe-paths.sh


### PR DESCRIPTION
## Summary
Autoscaling now uses a fresh, provider-matching queue count to grow faster during a backlog while preserving the configured maximum and the existing idle-only fallback.

## Why This Exists
The queue cache was refreshed and shown in the UI, but autoscaling ignored it. A large backlog therefore grew the fleet by the same fixed step as a one-job backlog.

## Resolution
Read the existing queue cache during each autoscale tick. Use the cached count only when its provider matches and its age is at most 60 seconds. Raise the growth target to the larger of the configured step and the cached backlog, then clamp it to `AUTOSCALE_MAX`.

## Reviewer Considerations
- Stale, malformed, missing, and provider-mismatched cache data returns `-1` and keeps the previous step behavior.
- Queue depth affects only the growth branch. Shrink behavior remains unchanged.
- The cache is read locally; the autoscale tick does not add a provider API request.

## Behavior Changes
A fresh queue backlog can add more runners in one autoscale tick. The configured maximum remains the hard ceiling.

## Implementation Summary
- Add provider and age validation for cached queue depth.
- Include the queue count in the autoscale growth calculation and log.
- Add focused tests for queue size, maximum clamping, cache age, provider mismatch, and no cache.

## Verification
- `bash tests/autoscale-queue.sh` passed.
- `bash -n src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh tests/autoscale-queue.sh` passed.
- `git diff --check` passed.

## Risk
Low; unknown queue data follows the existing idle-only behavior, and the scale maximum is unchanged.

Fixes #80