### PR TITLE
fix(editors): exclude LICENSE from formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,12 @@ insert_final_newline = true
 # Markdown uses trailing double-space for hard line breaks.
 [*.md]
 trim_trailing_whitespace = false
+
+# LICENSE is a verbatim legal document. Do not let an editor normalize it.
+[LICENSE]
+indent_style = unset
+indent_size = unset
+end_of_line = unset
+charset = unset
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.limetech/ai-review-markers/codex-issue-72-exclude-license-formatting-4a97e5efb6bc.json
+++ b/.limetech/ai-review-markers/codex-issue-72-exclude-license-formatting-4a97e5efb6bc.json
@@ -1,0 +1,20 @@
+{
+  "disposition": "NOT_REQUIRED",
+  "expected_structural_delta": "No production modules, runtime roots, state owners, protocols, or public operations. Extend two existing editor configuration files and add one focused configuration test.",
+  "minimum_design": "Add path-specific exceptions to the existing EditorConfig and VS Code settings, then prove that both configuration layers target LICENSE without changing the file.",
+  "outcome": "When a supported editor saves LICENSE, the file keeps its verbatim whitespace and final-newline state.",
+  "reuse_decisions": [
+    {
+      "decision": "reuse",
+      "name": "global editor defaults",
+      "rationale": "The existing repository defaults remain the policy source. A LICENSE-specific override is the smallest boundary for the legal-file exception."
+    },
+    {
+      "decision": "extend",
+      "name": "tests/check.sh",
+      "rationale": "The repository contract suite already owns static configuration checks and can run the focused exception test."
+    }
+  ],
+  "schema": "limetech.ai-review-marker.v2",
+  "stage": "forecast"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,15 @@
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "files.trimFinalNewlines": true,
+  "files.associations": {
+    "LICENSE": "plaintext"
+  },
   "[markdown]": {
     "files.trimTrailingWhitespace": false
+  },
+  "[plaintext]": {
+    "files.insertFinalNewline": false,
+    "files.trimTrailingWhitespace": false,
+    "files.trimFinalNewlines": false
   }
 }

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -29,6 +29,7 @@ done < <(find "$RUNTIME" -type f \( -name '*.php' -o -name '*.page' \) -print | 
 
 echo "== Contracts and package =="
 bash tests/config-parity.sh
+bash tests/editorconfig.sh
 bash tests/runner-pools.sh
 bash tests/pool-runtime.sh
 bash tests/numeric-config.sh

--- a/tests/editorconfig.sh
+++ b/tests/editorconfig.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Verify that the verbatim LICENSE file is excluded from editor formatting.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+python3 - <<'PY'
+import configparser
+import json
+
+editorconfig = configparser.ConfigParser(interpolation=None)
+editorconfig.optionxform = str
+with open('.editorconfig', encoding='utf-8') as handle:
+    editorconfig.read_string('[__root__]\n' + handle.read())
+
+license_rules = editorconfig['LICENSE']
+assert license_rules['indent_style'] == 'unset'
+assert license_rules['indent_size'] == 'unset'
+assert license_rules['end_of_line'] == 'unset'
+assert license_rules['charset'] == 'unset'
+assert license_rules['trim_trailing_whitespace'] == 'false'
+assert license_rules['insert_final_newline'] == 'false'
+
+with open('.vscode/settings.json', encoding='utf-8') as handle:
+    settings = json.load(handle)
+assert settings['files.associations']['LICENSE'] == 'plaintext'
+plaintext_rules = settings['[plaintext]']
+assert plaintext_rules['files.insertFinalNewline'] is False
+assert plaintext_rules['files.trimTrailingWhitespace'] is False
+assert plaintext_rules['files.trimFinalNewlines'] is False
+
+print('editorconfig: PASS')
+PY


### PR DESCRIPTION
## Summary
The verbatim LICENSE file now opts out of whitespace and final-newline normalization in EditorConfig and VS Code.

## Why This Exists
Global editor rules applied to LICENSE, which can silently change legal text when a contributor saves the file.

## Resolution
Add a dedicated `[LICENSE]` EditorConfig section and map LICENSE to a VS Code plaintext profile with save normalization disabled. Add a configuration test so both layers keep the exception.

## Reviewer Considerations
- The VS Code exception uses the plaintext language profile because VS Code has no path-only save-settings block.
- Other plaintext files inherit the same disabled save normalization when they use that profile.
- The change does not modify LICENSE contents.

## Behavior Changes
Editors configured with these repository settings no longer trim whitespace or change final-newline state for LICENSE.

## Implementation Summary
- Add LICENSE-specific EditorConfig overrides.
- Associate LICENSE with the VS Code plaintext profile and disable save normalization.
- Add `tests/editorconfig.sh` and run it from the repository check suite.

## Verification
- `python3 -m json.tool .vscode/settings.json` passed.
- `bash tests/editorconfig.sh` passed.
- `git diff --check` passed.

## Risk
Low; the change is configuration-only and the legal file remains unchanged.

Fixes #72