### PR TITLE
fix(logging): bound persistent boot log size

### DIFF
--- a/.limetech/ai-review-markers/codex-issue-62-bound-boot-log-61d025307562.json
+++ b/.limetech/ai-review-markers/codex-issue-62-bound-boot-log-61d025307562.json
@@ -1,0 +1,30 @@
+{
+  "disposition": "PATCH",
+  "expected_structural_delta": "Architecture required because the guarantee spans two runtime event hooks and generated install/remove actions. Predicted delta: one production helper module, one shared helper hop, four call sites, one test file, no new durable state owner, protocol, or public operation.",
+  "minimum_design": "Use one shared shell helper at every existing boot.log append point. Rotate an oversized log with a same-directory temporary file and atomic rename, and keep the existing append path fail-open.",
+  "outcome": "When any supported lifecycle path appends to the persistent boot log, the log stays bounded on flash while retaining recent diagnostics. A rotation failure does not block the lifecycle action.",
+  "reuse_decisions": [
+    {
+      "decision": "extend",
+      "name": "existing lifecycle log writers",
+      "rationale": "The runtime event hooks and generated install/remove actions already own every supported boot.log append path. They need one shared call before append."
+    },
+    {
+      "decision": "reuse",
+      "name": "shell temporary-file and rename primitives",
+      "rationale": "The base tree already uses shell tools for local temporary state. A same-directory checked temporary file and mv preserve the existing flash path and atomicity boundary."
+    },
+    {
+      "decision": "new_owner",
+      "name": "new boot-log helper",
+      "rationale": "The bounded-log invariant spans runtime hooks and generated package actions, so one helper gives the invariant one owner and avoids duplicated rotation logic."
+    },
+    {
+      "decision": "extend",
+      "name": "tests/package-contents.sh",
+      "rationale": "The existing package test already checks generated install/remove content and can prove helper inclusion and call placement."
+    }
+  ],
+  "schema": "limetech.ai-review-marker.v2",
+  "stage": "forecast"
+}

--- a/build-plg.sh
+++ b/build-plg.sh
@@ -459,6 +459,10 @@ fi
 # Bring the fleet + autoscaler up. Runs on manual install AND on every boot
 # (rc.local reinstalls plugins), detached so it waits for dockerd+array without
 # blocking. No-op until the selected provider's runner token is configured.
+if [ -r "\$PLGDIR/include/boot-log.sh" ]; then
+  . "\$PLGDIR/include/boot-log.sh" || true
+  crf_bound_boot_log "\$CFGDIR/boot.log" || true
+fi
 ( nohup "\$PLGDIR/include/runner-farm.sh" boot-autostart >>"\$CFGDIR/boot.log" 2>&1 & ) || true
 echo ""
 echo "+=============================================================+"
@@ -476,6 +480,10 @@ set -euo pipefail
 PLGDIR="/usr/local/emhttp/plugins/${NAME}"
 CFGDIR="/boot/config/plugins/${NAME}"
 ENGINE="\$PLGDIR/include/runner-farm.sh"
+if [ -r "\$PLGDIR/include/boot-log.sh" ]; then
+  . "\$PLGDIR/include/boot-log.sh" || true
+  crf_bound_boot_log "\$CFGDIR/boot.log" || true
+fi
 if [ -x "\$ENGINE" ]; then
   if ! "\$PLGDIR/include/runner-farm.sh" stop >>"\$CFGDIR/boot.log" 2>&1; then
     echo "ci-runner-farm NOT removed: one or more runners, jobs, or privileged sidecars could not be stopped safely." >&2

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/event/docker_started
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/event/docker_started
@@ -17,4 +17,9 @@
 # Detached so we never block Unraid's start sequence.
 PLGDIR="/usr/local/emhttp/plugins/ci-runner-farm"
 CFGDIR="/boot/config/plugins/ci-runner-farm"
+if [ -r "$PLGDIR/include/boot-log.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$PLGDIR/include/boot-log.sh" || true
+  crf_bound_boot_log "$CFGDIR/boot.log" || true
+fi
 ( nohup "$PLGDIR/include/runner-farm.sh" boot-autostart >>"$CFGDIR/boot.log" 2>&1 & ) || true

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/event/stopping_docker
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/event/stopping_docker
@@ -13,4 +13,9 @@
 # itself as part of the normal shutdown.
 PLGDIR="/usr/local/emhttp/plugins/ci-runner-farm"
 CFGDIR="/boot/config/plugins/ci-runner-farm"
+if [ -r "$PLGDIR/include/boot-log.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$PLGDIR/include/boot-log.sh" || true
+  crf_bound_boot_log "$CFGDIR/boot.log" || true
+fi
 "$PLGDIR/include/runner-farm.sh" docker-stopping >>"$CFGDIR/boot.log" 2>&1 || true

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/boot-log.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/boot-log.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Keep the persistent boot log useful after repeated Docker lifecycle events
+# without allowing it to consume unbounded space on the flash device.
+crf_bound_boot_log() {
+  local log="${1:-}" size tmp
+  [ -n "$log" ] && [ -f "$log" ] || return 0
+  size="$(wc -c < "$log" 2>/dev/null | tr -d '[:space:]')" || return 0
+  case "$size" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$size" -gt 65536 ] || return 0
+
+  tmp="$(mktemp "${log}.XXXXXX" 2>/dev/null)" || return 0
+  if tail -n 200 "$log" > "$tmp" && mv -f -- "$tmp" "$log"; then
+    return 0
+  fi
+  rm -f -- "$tmp"
+  return 0
+}

--- a/tests/boot-log.sh
+++ b/tests/boot-log.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Verify that the persistent boot log stays bounded and retains recent entries.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail() { printf 'boot-log: FAIL: %s\n' "$*" >&2; exit 1; }
+LOG_HELPER="src/usr/local/emhttp/plugins/ci-runner-farm/include/boot-log.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# shellcheck source=/dev/null
+source "$LOG_HELPER"
+
+log="$tmp/boot.log"
+for i in $(seq 1 600); do
+  printf 'line-%04d %0120d\n' "$i" "$i" >> "$log"
+done
+[ "$(wc -c < "$log" | tr -d '[:space:]')" -gt 65536 ] || fail "fixture is not larger than the rotation threshold"
+crf_bound_boot_log "$log" || fail "rotation returned failure"
+[ "$(wc -l < "$log" | tr -d '[:space:]')" = 200 ] || fail "rotation did not retain exactly 200 lines"
+[ "$(wc -c < "$log" | tr -d '[:space:]')" -le 65536 ] || fail "rotated log is still above the size limit"
+grep -q '^line-0600 ' "$log" || fail "rotation discarded the newest log entry"
+if grep -q '^line-0001 ' "$log"; then fail "rotation retained the oldest log entry"; fi
+
+small="$tmp/small.log"
+printf 'small log\n' > "$small"
+before="$(sha256sum "$small" | cut -d' ' -f1)"
+crf_bound_boot_log "$small" || fail "small log check returned failure"
+after="$(sha256sum "$small" | cut -d' ' -f1)"
+[ "$before" = "$after" ] || fail "small log changed below the rotation threshold"
+
+for event in src/usr/local/emhttp/plugins/ci-runner-farm/event/docker_started \
+             src/usr/local/emhttp/plugins/ci-runner-farm/event/stopping_docker; do
+  grep -qF '. "$PLGDIR/include/boot-log.sh"' "$event" \
+    || fail "$event does not load the boot-log helper"
+done
+grep -qF 'crf_bound_boot_log "\$CFGDIR/boot.log"' build-plg.sh \
+  || fail "generated install/remove actions do not bound boot.log"
+
+echo "boot-log: PASS"

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -29,6 +29,7 @@ done < <(find "$RUNTIME" -type f \( -name '*.php' -o -name '*.page' \) -print | 
 
 echo "== Contracts and package =="
 bash tests/config-parity.sh
+bash tests/boot-log.sh
 bash tests/runner-pools.sh
 bash tests/pool-runtime.sh
 bash tests/numeric-config.sh

--- a/tests/package-contents.sh
+++ b/tests/package-contents.sh
@@ -50,6 +50,7 @@ remove_block="$(awk '
 for required_remove_line in \
   'set -euo pipefail' \
   'if ! "$PLGDIR/include/runner-farm.sh" stop' \
+  'crf_bound_boot_log "$CFGDIR/boot.log"' \
   'cleanup engine is missing and Docker is unavailable' \
   'cleanup engine is missing and Docker ownership enumeration failed' \
   'cleanup engine is missing and GitLab executor ownership enumeration failed' \
@@ -73,7 +74,7 @@ for required in \
   RunnerFarm.page RunnerFarmDashboard.page RunnerFarmFleet.page RunnerFarmImage.page RunnerFarmSettings.page \
   default.cfg default.Dockerfile default.github.Dockerfile default.gitlab.Dockerfile \
   event/docker_started event/stopping_docker include/runner-farm.sh include/exec.php include/crf-core.php \
-  include/providers/github.sh include/providers/gitlab.sh \
+  include/boot-log.sh include/providers/github.sh include/providers/gitlab.sh \
   nchan/ci_runner_farm README.md
 do
   [ -f "$tmp/extracted/$required" ] || {


### PR DESCRIPTION
## Summary
The persistent boot log now stays bounded on flash while retaining the latest boot diagnostics.

## Why This Exists
Docker lifecycle hooks appended to `/boot/config/plugins/ci-runner-farm/boot.log` without a size limit. Repeated array starts, stops, or Docker restarts could consume unbounded flash space.

## Resolution
Add a shared boot-log helper that trims an oversized log atomically to its newest 200 lines before the next hook append. Keep the log on flash so it survives reboot, and make rotation failures non-blocking for lifecycle events.

## Reviewer Considerations
- The threshold is 64 KiB and the retained history is 200 lines.
- The helper uses a same-directory temporary file and an atomic rename.
- Both runtime event hooks and generated install/remove actions use the helper.
- A rotation failure leaves the existing log in place and does not block Docker startup or shutdown.

## Behavior Changes
`boot.log` no longer grows without a bound during normal lifecycle events.

## Implementation Summary
- Add `include/boot-log.sh` with bounded rotation.
- Invoke it from Docker start and stop hooks.
- Include it in generated plugin install and remove actions.
- Test size, line retention, below-threshold stability, package inclusion, and generated actions.

## Verification
- `bash tests/boot-log.sh` passed.
- `bash tests/package-contents.sh` passed.
- `bash -n` passed for the helper, hooks, and test.
- `git diff --check` passed.

## Risk
Low; the log remains persistent, and rotation is fail-open if the temporary file or rename cannot be created.

Fixes #62