### PR TITLE
fix(image): validate remote Docker image references

### DIFF
--- a/.limetech/ai-review-markers/codex-issue-64-validate-image-ref-366f8cc08ec9.json
+++ b/.limetech/ai-review-markers/codex-issue-64-validate-image-ref-366f8cc08ec9.json
@@ -1,0 +1,25 @@
+{
+  "disposition": "NOT_REQUIRED",
+  "expected_structural_delta": "No new production modules, roots, state owners, protocols, or public operations. Extend the existing engine/provider boundary and add one focused test file.",
+  "minimum_design": "Validate the remote value at the existing effective-image and provider-argument boundary. Return failure before Docker receives invalid input, and prove valid, malformed, command-text, and built-in cases.",
+  "outcome": "When IMAGE_SOURCE is remote, the configured image value passes a Docker-reference shape check before provider Docker arguments or host pulls use it. Built-in image behavior remains unchanged.",
+  "reuse_decisions": [
+    {
+      "decision": "extend",
+      "name": "effective_image and provider Docker argument owners",
+      "rationale": "These existing owners determine and consume the remote image. Validation at this shared boundary protects downstream Docker calls without a second policy path."
+    },
+    {
+      "decision": "not-applicable",
+      "name": "GitLab image-policy validators",
+      "rationale": "The existing GitLab helpers validate manager versions and allowed-image policy, not the provider-neutral Docker reference shape needed by GitHub."
+    },
+    {
+      "decision": "new_owner",
+      "name": "tests/image-validation.sh",
+      "rationale": "A focused fixture is needed to prove the accepted reference shape and the pre-Docker failure boundary."
+    }
+  ],
+  "schema": "limetech.ai-review-marker.v2",
+  "stage": "forecast"
+}

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -265,7 +265,8 @@ github_registry_credentials() {
 
 github_build_args() {
   local idx="$1"
-  local name="${2:-${NAME_PREFIX}-${idx}}" role="${CRF_CONTAINER_ROLE:-runner}" host_service_ip
+  local name="${2:-${NAME_PREFIX}-${idx}}" role="${CRF_CONTAINER_ROLE:-runner}" host_service_ip image
+  image="$(effective_image)" || return 1
   host_service_ip="$(runner_host_service_ipv4)" \
     || { err "could not resolve this farm host's local service address"; return 1; }
   ARGS_TMPDIR=""
@@ -345,7 +346,7 @@ github_build_args() {
     ARGS+=( --env-file "$envf" )
     ARGS_TMPDIR="$envdir"
   fi
-  ARGS+=( "$(effective_image)" )
+  ARGS+=( "$image" )
 }
 
 github_start_one() {
@@ -456,7 +457,7 @@ github_validate() {
   # role without changing the ordinary runner contract.
   local NO_REGISTER=1 CRF_CONTAINER_ROLE=validate
   github_build_args 99 "$name" || return 1
-  local injected=() a eimg; eimg="$(effective_image)"
+  local injected=() a eimg; eimg="$(effective_image)" || return 1
   for a in "${ARGS[@]}"; do
     [ "$a" = "$eimg" ] && injected+=( --entrypoint /bin/sh "$eimg" -c "sleep 30" ) || injected+=( "$a" )
   done

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -1652,8 +1652,19 @@ firewall_apply() {
 
 # Resolve the provider's executable/default-job image: the locally built tag or
 # a remote ref. GitLab's manager image is deliberately separate.
+image_ref_is_safe() {
+  printf '%s' "$1" | grep -qE '^[A-Za-z0-9][A-Za-z0-9_./:@-]*$'
+}
+
 effective_image() {
-  if [ "$IMAGE_SOURCE" = "remote" ] && [ -n "$IMAGE" ]; then echo "$IMAGE"; else builtin_image; fi
+  local image="$IMAGE"
+  if [ "$IMAGE_SOURCE" = "remote" ] && [ -n "$image" ]; then
+    image_ref_is_safe "$image" \
+      || { err "IMAGE is not a safe Docker image reference"; return 1; }
+    printf '%s\n' "$image"
+  else
+    builtin_image
+  fi
 }
 
 # Verify a recycle replacement without pulling a GitLab DinD job image through

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -29,6 +29,7 @@ done < <(find "$RUNTIME" -type f \( -name '*.php' -o -name '*.page' \) -print | 
 
 echo "== Contracts and package =="
 bash tests/config-parity.sh
+bash tests/image-validation.sh
 bash tests/runner-pools.sh
 bash tests/pool-runtime.sh
 bash tests/numeric-config.sh

--- a/tests/image-validation.sh
+++ b/tests/image-validation.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Verify that remote job images have one safe Docker-reference argument shape.
+set -euo pipefail
+# The sourced engine consumes configuration through Bash dynamic scope.
+# shellcheck disable=SC2034
+cd "$(dirname "$0")/.."
+
+ENGINE="src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/config" CRF_RUNDIR="$tmp/run"
+mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR" "$tmp/cache"
+# shellcheck source=/dev/null
+source "$ENGINE"
+
+IMAGE_SOURCE=remote
+CACHE_ROOT="$tmp/cache"
+CACHE_MOUNTS=''
+DIND=false
+SHARE_DOCKER_SOCK=false
+WORK_TMPFS_SIZE=''
+GH_SCOPE=repo
+GH_REPOS='example/project'
+ACCESS_TOKEN=''
+
+valid='ghcr.io/example/runner:latest'
+IMAGE="$valid"
+[ "$(effective_image)" = "$valid" ] \
+  || { echo 'image-validation: valid remote image was rejected' >&2; exit 1; }
+github_build_args 1 ci-runner-1 \
+  || { echo 'image-validation: valid image failed GitHub argument construction' >&2; exit 1; }
+[ "${ARGS[${#ARGS[@]}-1]}" = "$valid" ] \
+  || { echo 'image-validation: validated image did not reach the final Docker argument' >&2; exit 1; }
+
+for invalid in '-q' 'bad image' 'image;touch' '$(touch '"$tmp"'/executed)' '"quoted"'; do
+  IMAGE="$invalid"
+  if effective_image >/dev/null 2>"$tmp/error"; then
+    echo "image-validation: accepted invalid image shape: $invalid" >&2
+    exit 1
+  fi
+  if github_build_args 1 ci-runner-1 >/dev/null 2>&1; then
+    echo "image-validation: GitHub arguments accepted invalid image shape: $invalid" >&2
+    exit 1
+  fi
+done
+[ ! -e "$tmp/executed" ] || { echo 'image-validation: invalid image was executed' >&2; exit 1; }
+
+IMAGE_SOURCE=builtin
+IMAGE='not-used'
+[ "$(effective_image)" = "$(builtin_image)" ] \
+  || { echo 'image-validation: built-in image path changed' >&2; exit 1; }
+
+echo "image-validation: PASS"


### PR DESCRIPTION
## Summary
Remote job image values now pass a shared Docker-reference shape check before provider Docker arguments use them.

## Why This Exists
The web-configured `IMAGE` value could reach GitHub `docker run` and host image-pull paths without validation. Flag-shaped or malformed values produced downstream Docker errors and unclear behavior.

## Resolution
Validate remote image references at `effective_image` with the existing provider-safe alphabet. Make GitHub argument construction capture and propagate validation failure before it creates Docker argv. Built-in images keep their existing path.

## Reviewer Considerations
- The accepted shape matches the reviewed GitLab image validation pattern.
- This checks argument shape, not registry existence or image authorization.
- The check applies only when `IMAGE_SOURCE=remote`; built-in image behavior is unchanged.

## Behavior Changes
Malformed remote image values fail before GitHub runner Docker arguments are built. Valid references and built-in images continue to work.

## Implementation Summary
- Add shared remote image-reference validation.
- Propagate failure through GitHub argument construction.
- Add tests for valid references, invalid shapes, command-text input, and built-in fallback.

## Verification
- `bash tests/image-validation.sh` passed.
- `bash -n` passed for the changed shell files.
- `git diff --check` passed.

## Risk
Low; the check rejects malformed input before Docker and does not change valid image references.

Fixes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for remote Docker image references before they are passed to Docker.
  * Rejects unsafe image values, including options, whitespace, quoting, and command-injection patterns.
  * Preserves existing behavior for built-in images.
  * Prevents invalid image references from being used when validating or building GitHub runner jobs.

* **Tests**
  * Added coverage for valid and invalid image references, including injection safety.
  * Integrated image validation checks into the repository’s standard test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->