### PR TITLE
fix(autoscale): recycle GitHub runners reported offline

### DIFF
--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -107,8 +107,12 @@ github_runner_liveness_status() {
   awk -F'|' -v want="$wanted" '$1 == want { print $2; exit }' "$GITHUB_LIVENESS_CACHE" 2>/dev/null
 }
 
+github_runner_liveness_cache_timestamp() {
+  awk 'NR == 1 { print $1; exit }' "$GITHUB_LIVENESS_CACHE" 2>/dev/null
+}
+
 github_offline_runner_confirmed() {
-  local c="$1" status marker count=0
+  local c="$1" status marker count=0 marker_at="" cache_at
   status="$(github_runner_liveness_status "$c")"
   marker="$RUNDIR/github-offline.${c}"
   case "$status" in
@@ -121,10 +125,14 @@ github_offline_runner_confirmed() {
         rm -f "$marker"
         return 1
       fi
-      [ -f "$marker" ] && read -r count < "$marker"
+      cache_at="$(github_runner_liveness_cache_timestamp)"
+      [ -n "$cache_at" ] || return 1
+      [ -f "$marker" ] && read -r count marker_at < "$marker"
       case "$count" in ''|*[!0-9]*) count=0 ;; esac
-      count=$((count + 1))
-      printf '%s\n' "$count" > "$marker"
+      if [ "$marker_at" != "$cache_at" ]; then
+        count=$((count + 1))
+        printf '%s %s\n' "$count" "$cache_at" > "$marker"
+      fi
       if [ "$count" -ge "$GITHUB_OFFLINE_CONFIRMATIONS" ]; then
         return 0
       fi

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -38,6 +38,103 @@ github_runner_state() {
   esac
 }
 
+# Docker can report a healthy listener after its GitHub control-plane session
+# becomes stale. Keep a short host-side inventory cache so autoscale can detect
+# that mismatch without placing the long-lived PAT in the runner container.
+GITHUB_LIVENESS_CACHE="${RUNDIR}/github-runners.cache"
+GITHUB_OFFLINE_CONFIRMATIONS=2
+
+github_parse_runner_statuses() {
+  tr ',' '\n' | awk '
+    /"name"[[:space:]]*:/ {
+      s=$0
+      sub(/^[^:]*:[[:space:]]*"/, "", s)
+      sub(/".*/, "", s)
+      runner_name=s
+    }
+    /"status"[[:space:]]*:/ {
+      s=$0
+      sub(/^[^:]*:[[:space:]]*"/, "", s)
+      sub(/".*/, "", s)
+      if (runner_name != "") {
+        print runner_name "|" s
+        runner_name=""
+      }
+    }'
+}
+
+github_runner_liveness_refresh() {
+  local now expected_key cached_at cached_key age tmp body valid=0 repo url
+  now="$(date +%s)"
+  expected_key="$(printf '%s\0' "$GH_SCOPE" "$GH_OWNER" "$GH_REPOS" | sha256sum | cut -c1-12)"
+  if [ -f "$GITHUB_LIVENESS_CACHE" ]; then
+    read -r cached_at cached_key < "$GITHUB_LIVENESS_CACHE"
+    case "$cached_at" in ''|*[!0-9]*) ;; *)
+      age=$((now - cached_at))
+      [ "$age" -ge 0 ] && [ "$age" -le 60 ] && [ "$cached_key" = "$expected_key" ] && return 0
+      ;;
+    esac
+  fi
+  tmp="$(mktemp "$RUNDIR/github-liveness.XXXXXX" 2>/dev/null)" || return 1
+  if [ "$GH_SCOPE" = org ]; then
+    url="/orgs/${GH_OWNER}/actions/runners?per_page=100"
+    body="$(gh_api GET "$url")" || { rm -f "$tmp"; return 1; }
+    case "$body" in *'"runners"'*) valid=1 ;; esac
+    printf '%s' "$body" | github_parse_runner_statuses >> "$tmp"
+  else
+    for repo in $GH_REPOS; do
+      [ -n "$repo" ] || continue
+      url="/repos/${repo}/actions/runners?per_page=100"
+      body="$(gh_api GET "$url")" || { rm -f "$tmp"; return 1; }
+      case "$body" in *'"runners"'*) valid=1 ;; esac
+      printf '%s' "$body" | github_parse_runner_statuses >> "$tmp"
+    done
+  fi
+  [ "$valid" = 1 ] || { rm -f "$tmp"; return 1; }
+  {
+    printf '%s %s\n' "$now" "$expected_key"
+    cat "$tmp"
+  } > "${tmp}.cache" || { rm -f "$tmp" "${tmp}.cache"; return 1; }
+  mv "${tmp}.cache" "$GITHUB_LIVENESS_CACHE" || { rm -f "$tmp" "${tmp}.cache"; return 1; }
+  rm -f "$tmp"
+}
+
+github_runner_liveness_status() {
+  local c="$1" wanted
+  wanted="$(host)-${c}"
+  awk -F'|' -v want="$wanted" '$1 == want { print $2; exit }' "$GITHUB_LIVENESS_CACHE" 2>/dev/null
+}
+
+github_offline_runner_confirmed() {
+  local c="$1" status marker count=0
+  status="$(github_runner_liveness_status "$c")"
+  marker="$RUNDIR/github-offline.${c}"
+  case "$status" in
+    online)
+      rm -f "$marker"
+      return 1
+      ;;
+    offline)
+      if runner_busy "$c"; then
+        rm -f "$marker"
+        return 1
+      fi
+      [ -f "$marker" ] && read -r count < "$marker"
+      case "$count" in ''|*[!0-9]*) count=0 ;; esac
+      count=$((count + 1))
+      printf '%s\n' "$count" > "$marker"
+      if [ "$count" -ge "$GITHUB_OFFLINE_CONFIRMATIONS" ]; then
+        return 0
+      fi
+      log "autoscale: GitHub reports $c offline (confirmation $count/$GITHUB_OFFLINE_CONFIRMATIONS); retaining it"
+      ;;
+    *)
+      rm -f "$marker"
+      ;;
+  esac
+  return 1
+}
+
 github_scale_down_eligible() { ! runner_busy "$1"; }
 github_autoscale_counts() {
   cur="$(current_count)" || return 1

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/providers/github.sh
@@ -42,6 +42,7 @@ github_runner_state() {
 # becomes stale. Keep a short host-side inventory cache so autoscale can detect
 # that mismatch without placing the long-lived PAT in the runner container.
 GITHUB_LIVENESS_CACHE="${RUNDIR}/github-runners.cache"
+GITHUB_LIVENESS_TTL=300 # seconds between GitHub liveness refreshes
 GITHUB_OFFLINE_CONFIRMATIONS=2
 
 github_parse_runner_statuses() {
@@ -71,7 +72,8 @@ github_runner_liveness_refresh() {
     read -r cached_at cached_key < "$GITHUB_LIVENESS_CACHE"
     case "$cached_at" in ''|*[!0-9]*) ;; *)
       age=$((now - cached_at))
-      [ "$age" -ge 0 ] && [ "$age" -le 60 ] && [ "$cached_key" = "$expected_key" ] && return 0
+      [ "$age" -ge 0 ] && [ "$age" -le "$GITHUB_LIVENESS_TTL" ] \
+        && [ "$cached_key" = "$expected_key" ] && return 0
       ;;
     esac
   fi

--- a/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
+++ b/src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh
@@ -553,9 +553,13 @@ scale_down_idle() {
 # empty => treated as fine, so this is a safe no-op until the new image ships).
 # Caches/DinD roots persist as bind mounts across the recycle.
 reap_dead_runners() {
-  local c st health provider sock side phase job_container failf failcount
+  local c st health provider sock side phase job_container failf failcount github_liveness_ready=true
   local names sidecars snapshot id role index gen failed=0
   names="$(managed_names)" || return 1
+  if [ "$CI_PROVIDER" = github ] && [ -n "$names" ]; then
+    github_runner_liveness_refresh \
+      || { log "autoscale: GitHub runner liveness is unavailable; retaining running runners"; github_liveness_ready=false; }
+  fi
   for c in $names; do
     [ -n "$c" ] || continue
     snapshot="$(managed_runner_snapshot "$c")" || { failed=1; continue; }
@@ -605,6 +609,11 @@ reap_dead_runners() {
         fi
       fi
     fi
+    if [ "$provider" = "github" ] && [ "$st" = "running" ] && [ "$github_liveness_ready" = true ] \
+       && github_offline_runner_confirmed "$c"; then
+      log "autoscale: reaping $c because GitHub reports its runner offline"
+      st=dead
+    fi
     case "$st" in
       exited|dead)
         log "autoscale: reaping dead runner $c (state=$st)" ;;
@@ -614,6 +623,7 @@ reap_dead_runners() {
       *) continue ;;
     esac
     if remove_runner "$c" true "$id" "$provider"; then
+      rm -f "$RUNDIR/github-offline.$c" 2>/dev/null || true
       rm -f "$RUNDIR/gitlab-sidecar-fail.$c" 2>/dev/null || true
     else
       log "autoscale: failed to remove dead runner $c; will retry"

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -34,6 +34,7 @@ bash tests/boot-log.sh
 bash tests/editorconfig.sh
 bash tests/runner-pools.sh
 bash tests/autoscale-queue.sh
+bash tests/github-liveness.sh
 bash tests/pool-runtime.sh
 bash tests/numeric-config.sh
 bash tests/safe-paths.sh

--- a/tests/github-liveness.sh
+++ b/tests/github-liveness.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Verify that a locally healthy GitHub runner is recycled after GitHub reports
+# it offline, while API failures and busy runners remain non-destructive.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ENGINE="src/usr/local/emhttp/plugins/ci-runner-farm/include/runner-farm.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+export CRF_SOURCE_ONLY=1 CRF_CFGDIR="$tmp/config" CRF_RUNDIR="$tmp/run"
+mkdir -p "$CRF_CFGDIR" "$CRF_RUNDIR"
+# shellcheck source=/dev/null
+source "$ENGINE"
+
+ACCESS_TOKEN='github-test-token'
+CI_PROVIDER=github
+GH_SCOPE=org
+GH_OWNER=example-owner
+host() { printf 'mockhost\n'; }
+runner_busy() { return 1; }
+
+api_log="$tmp/api.log"
+: > "$api_log"
+gh_api() {
+  printf '%s %s\n' "$1" "$2" >> "$api_log"
+  case "$1 $2" in
+    'GET /orgs/example-owner/actions/runners?per_page=100')
+      printf '%s\n' '{"total_count":2,"runners":[{"id":1,"name":"mockhost-ci-runner-1","os":"Linux","status":"offline","busy":false},{"id":2,"name":"mockhost-ci-runner-2","os":"Linux","status":"online","busy":false}]}'
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+github_runner_liveness_refresh || { echo 'github-liveness: refresh failed' >&2; exit 1; }
+[ "$(wc -l < "$api_log" | tr -d ' ')" = 1 ] || { echo 'github-liveness: expected one inventory request' >&2; exit 1; }
+[ "$(github_runner_liveness_status ci-runner-1)" = offline ] || { echo 'github-liveness: offline status was not read' >&2; exit 1; }
+[ "$(github_runner_liveness_status ci-runner-2)" = online ] || { echo 'github-liveness: online status was not read' >&2; exit 1; }
+[ "$(wc -l < "$api_log" | tr -d ' ')" = 1 ] || { echo 'github-liveness: fresh cache was not reused' >&2; exit 1; }
+
+if github_offline_runner_confirmed ci-runner-1; then
+  echo 'github-liveness: recycled an offline runner after one reading' >&2
+  exit 1
+fi
+github_offline_runner_confirmed ci-runner-1 || { echo 'github-liveness: did not confirm two offline readings' >&2; exit 1; }
+
+runner_busy() { return 0; }
+rm -f "$RUNDIR/github-offline.ci-runner-1"
+if github_offline_runner_confirmed ci-runner-1; then
+  echo 'github-liveness: recycled a busy offline runner' >&2
+  exit 1
+fi
+
+runner_busy() { return 1; }
+rm -f "$GITHUB_LIVENESS_CACHE" "$RUNDIR/github-offline.ci-runner-1"
+managed_names() { printf 'ci-runner-1\n'; }
+managed_runner_snapshot() { printf '%064d|github|runner|1|test-generation\n' 1; }
+docker() {
+  case "$1" in
+    inspect)
+      case "$*" in
+        *State.Status*) printf 'running\n' ;;
+        *State.Health*) printf 'healthy\n' ;;
+      esac
+      ;;
+  esac
+}
+removed=0
+remove_runner() { removed=$((removed + 1)); }
+reap_dead_runners || { echo 'github-liveness: reaper failed' >&2; exit 1; }
+[ "$removed" = 0 ] || { echo 'github-liveness: reaper acted after one offline reading' >&2; exit 1; }
+reap_dead_runners || { echo 'github-liveness: reaper failed on confirmation' >&2; exit 1; }
+[ "$removed" = 1 ] || { echo 'github-liveness: reaper did not replace confirmed offline runner' >&2; exit 1; }
+
+rm -f "$GITHUB_LIVENESS_CACHE"
+gh_api() { return 1; }
+if github_runner_liveness_refresh; then
+  echo 'github-liveness: treated an API failure as a valid inventory' >&2
+  exit 1
+fi
+
+echo 'github-liveness: PASS'

--- a/tests/github-liveness.sh
+++ b/tests/github-liveness.sh
@@ -36,6 +36,7 @@ github_runner_liveness_refresh || { echo 'github-liveness: refresh failed' >&2; 
 [ "$(wc -l < "$api_log" | tr -d ' ')" = 1 ] || { echo 'github-liveness: expected one inventory request' >&2; exit 1; }
 [ "$(github_runner_liveness_status ci-runner-1)" = offline ] || { echo 'github-liveness: offline status was not read' >&2; exit 1; }
 [ "$(github_runner_liveness_status ci-runner-2)" = online ] || { echo 'github-liveness: online status was not read' >&2; exit 1; }
+github_runner_liveness_refresh || { echo 'github-liveness: cached refresh failed' >&2; exit 1; }
 [ "$(wc -l < "$api_log" | tr -d ' ')" = 1 ] || { echo 'github-liveness: fresh cache was not reused' >&2; exit 1; }
 
 cache_key="$(printf '%s\0' "$GH_SCOPE" "$GH_OWNER" "$GH_REPOS" | sha256sum | cut -c1-12)"
@@ -51,7 +52,15 @@ if github_offline_runner_confirmed ci-runner-1; then
   echo 'github-liveness: recycled an offline runner after one reading' >&2
   exit 1
 fi
-github_offline_runner_confirmed ci-runner-1 || { echo 'github-liveness: did not confirm two offline readings' >&2; exit 1; }
+if github_offline_runner_confirmed ci-runner-1; then
+  echo 'github-liveness: counted the same inventory generation twice' >&2
+  exit 1
+fi
+sleep 1
+now="$(date +%s)"
+printf '%s %s\n' "$((now - GITHUB_LIVENESS_TTL - 1))" "$cache_key" > "$GITHUB_LIVENESS_CACHE"
+github_runner_liveness_refresh || { echo 'github-liveness: second inventory refresh failed' >&2; exit 1; }
+github_offline_runner_confirmed ci-runner-1 || { echo 'github-liveness: did not confirm two fresh offline readings' >&2; exit 1; }
 
 runner_busy() { return 0; }
 rm -f "$RUNDIR/github-offline.ci-runner-1"
@@ -78,6 +87,9 @@ removed=0
 remove_runner() { removed=$((removed + 1)); }
 reap_dead_runners || { echo 'github-liveness: reaper failed' >&2; exit 1; }
 [ "$removed" = 0 ] || { echo 'github-liveness: reaper acted after one offline reading' >&2; exit 1; }
+sleep 1
+now="$(date +%s)"
+printf '%s %s\n' "$((now - GITHUB_LIVENESS_TTL - 1))" "$cache_key" > "$GITHUB_LIVENESS_CACHE"
 reap_dead_runners || { echo 'github-liveness: reaper failed on confirmation' >&2; exit 1; }
 [ "$removed" = 1 ] || { echo 'github-liveness: reaper did not replace confirmed offline runner' >&2; exit 1; }
 

--- a/tests/github-liveness.sh
+++ b/tests/github-liveness.sh
@@ -38,6 +38,15 @@ github_runner_liveness_refresh || { echo 'github-liveness: refresh failed' >&2; 
 [ "$(github_runner_liveness_status ci-runner-2)" = online ] || { echo 'github-liveness: online status was not read' >&2; exit 1; }
 [ "$(wc -l < "$api_log" | tr -d ' ')" = 1 ] || { echo 'github-liveness: fresh cache was not reused' >&2; exit 1; }
 
+cache_key="$(printf '%s\0' "$GH_SCOPE" "$GH_OWNER" "$GH_REPOS" | sha256sum | cut -c1-12)"
+now="$(date +%s)"
+printf '%s %s\n' "$((now - GITHUB_LIVENESS_TTL + 1))" "$cache_key" > "$GITHUB_LIVENESS_CACHE"
+github_runner_liveness_refresh || { echo 'github-liveness: cache expired too early' >&2; exit 1; }
+[ "$(wc -l < "$api_log" | tr -d ' ')" = 1 ] || { echo 'github-liveness: cache did not remain valid for five minutes' >&2; exit 1; }
+printf '%s %s\n' "$((now - GITHUB_LIVENESS_TTL - 1))" "$cache_key" > "$GITHUB_LIVENESS_CACHE"
+github_runner_liveness_refresh || { echo 'github-liveness: expired cache was not refreshed' >&2; exit 1; }
+[ "$(wc -l < "$api_log" | tr -d ' ')" = 2 ] || { echo 'github-liveness: expired cache refresh was not requested' >&2; exit 1; }
+
 if github_offline_runner_confirmed ci-runner-1; then
   echo 'github-liveness: recycled an offline runner after one reading' >&2
   exit 1


### PR DESCRIPTION
## Summary

Recover GitHub Actions runners whose local containers remain healthy after their GitHub control-plane sessions go offline.

## Why This Exists

The build fleet recently showed every selected runner as offline while Docker containers and listener processes remained healthy. The current autoscaler trusts local process state, so it treated those runners as idle capacity and did not replace them.

A manual fleet restart restored service and the runners immediately accepted queued jobs.

## Resolution

The autoscale reaper now reads the GitHub runner inventory through a host-side cache. It recycles an idle managed runner after two consecutive offline readings from distinct inventory refreshes.

Successful liveness responses remain cached for five minutes. This reduces API traffic while keeping recovery within roughly five to ten minutes after two offline confirmations.

The reaper keeps busy runners and does not recycle runners when the GitHub API response is unavailable or incomplete.

## Reviewer Considerations

- The cache lasts 300 seconds and is keyed to the configured GitHub scope, owner, and repositories.
- Confirmation state records the inventory timestamp, so repeated autoscale passes cannot count one cached response twice.
- Two fresh readings reduce false replacement during a short GitHub control-plane interruption.
- The check runs under the existing fleet lock before autoscale capacity calculation.
- The runner container never receives the long-lived GitHub token.
- The existing Docker health check remains in place as a local-process safeguard.

## Behavior Changes

A locally running, Docker-healthy GitHub runner that GitHub reports offline is replaced automatically when it remains idle across two fresh liveness checks.

## Implementation Summary

- Add host-side GitHub runner inventory refresh and status parsing.
- Cache successful inventory responses for five minutes.
- Tie offline confirmations to distinct cache timestamps.
- Integrate confirmed offline detection into the existing dead-runner reaper.
- Clear confirmation state after successful replacement.
- Add regression coverage for cache reuse, the five-minute expiry boundary, duplicate confirmation prevention, API failure, busy runners, and reaper behavior.

## Verification

- bash tests/github-liveness.sh
- bash tests/run-linux-checks.sh
- The Linux repository check suite passed.
- The recovered live build fleet reported all active runners online and accepting jobs after the restart.

## Risk

Low. The change is limited to autoscale recovery. API failures preserve existing runners instead of causing destructive action.
